### PR TITLE
add setup py file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ settings.py
 */target/**
 
 venv/
+migrations/

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,7 @@
+from distutils.core import setup
+
+setup(name='AutoReduction',
+      version='1.0',
+      description='ISIS AutoReduction service',
+      author='ISIS Autoreduction Team',
+      url='https://github.com/ISISScientificComputing/autoreduce/')


### PR DESCRIPTION
**Description of changes**
* Add a basic setup.py file that can be used with pip install -e to initialise the python path for the project and allow for absolute imports.
* small tidy up to ignore migration files in project (these are generated when creating the test database)



**How to test**
* Test on local machine
* Run `pip install -e autoreduce` from the parent directory of the autoreduce project.
* Ensure the command executes as expected
* Ensure that you can perform absolute imports in the project


Fixes #34 
