### PR TITLE
Add generation script for apache_django_wsgi.conf

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ settings.py
 venv/
 migrations/
 AutoReduction.egg-info/
+# This is generated from a template so should be ignored to force regeneration
+apache_django_wsgi.conf

--- a/Scripts/Build/generate_apache_wsgi.py
+++ b/Scripts/Build/generate_apache_wsgi.py
@@ -1,0 +1,40 @@
+"""
+Generate the apache_django_wsgi.py file to serve django content from an apache server
+
+Usage:
+python generate_apache_wsgi.py path/to/autoreduction/git/dir
+e.g.
+python generate_apache_wsgi.pt C:\Users\...\git\aautoreduction
+"""
+
+import os
+import sys
+
+
+def _generate_conf_file():
+    """
+    Generates the configuration file using a command line argument
+    """
+    try:
+        root_dir = sys.argv[1]
+    except IndexError:
+        raise RuntimeError("Root directory argument not given.")
+    root_dir = root_dir.strip('/')
+    if os.path.isdir(root_dir):
+        root_dir = root_dir.replace('\\', '/')
+        _write_file(root_dir)
+    else:
+        raise RuntimeError("Unable to generate apache_django_wsgi.conf."
+                           "Root directory: %s -  was invalid" % root_dir)
+
+
+def _write_file(root_dir):
+    apache_dir = os.path.join(root_dir, 'WebApp', 'autoreduce_webapp', 'apache')
+    with open(os.path.join(apache_dir, 'apache_django_wsgi.conf.template'), 'r') as template_file:
+        with open(os.path.join(apache_dir, 'apache_django_wsgi.conf'), 'w') as output_file:
+            for line in template_file:
+                output_file.write(line.format(root_dir))
+
+
+if __name__ == '__main__':
+    _generate_conf_file()

--- a/WebApp/autoreduce_webapp/apache/apache_django_wsgi.conf.template
+++ b/WebApp/autoreduce_webapp/apache/apache_django_wsgi.conf.template
@@ -1,31 +1,31 @@
 # Location of the wsgi file and the WebApp base folder
-WSGIScriptAlias / C:/WebApp/autoreduce_webapp/autoreduce_webapp/wsgi.py
-WSGIPythonPath C:/WebApp/autoreduce_webapp
+WSGIScriptAlias / {0}/WebApp/autoreduce_webapp/autoreduce_webapp/wsgi.py
+WSGIPythonPath {0}/WebApp/autoreduce_webapp
 
 # Allow Apache to access the main WebApp folder
-<Directory C:/WebApp/autoreduce_webapp/autoreduce_webapp>
+<Directory {0}/WebApp/autoreduce_webapp/autoreduce_webapp>
 Order allow,deny
 Allow from all
 </Directory>
 
 # Allow Apache to access the base WebApp folder
-<Directory C:/WebApp/autoreduce_webapp>
+<Directory {0}/WebApp/autoreduce_webapp>
 Allow from all
 </Directory>
 
 ####################################################
 # Add the static and template locations so Apache can sucessfully serve them up
-Alias /static/ C:/WebApp/autoreduce_webapp/static/
-Alias /htmls/ C:/WebApp/autoreduce_webapp/templates/
+Alias /static/ {0}/WebApp/autoreduce_webapp/static/
+Alias /htmls/ {0}/WebApp/autoreduce_webapp/templates/
 
 # Allow Apache to access the static folder (containing CSS and JS files)
-<Directory C:/WebApp/autoreduce_webapp/static>
+<Directory {0}/WebApp/autoreduce_webapp/static>
 Order deny,allow
 Allow from all
 </Directory>
 
 # Allow Apache to access the templates folder (containing HTML files)
-<Directory C:/WebApp/autoreduce_webapp/templates>
+<Directory {0}/WebApp/autoreduce_webapp/templates>
 Order deny,allow
 Allow from all
 </Directory>


### PR DESCRIPTION
**Description of changes**

* Changed file wsgi file to template on git
* Created script to generate wsgi file from command line input
*This should form part of the general build script once it's implemented*



**How to test**
* Checkout the code on webapp dev node.
* Copy the `Webapp/autoreduce_webapp/apache/apache_django_wsgi.conf` to a different location outside the project.
* Delete the apache_django_wsgi.conf *(this will have to be done manually this time as it is now in the git ignore)*
* Generate the new apache_django_wsgi.conf using the script (usage instructions are in the docstring).
* Stop the webapp service and ensure you can no longer access it
* Start the webapp service (this should now be using the conf file) 
* Check you can access the webapp
* Delete the copy of `apache_django_wsgi.conf` made in previous steps


Fixes #64

