### PR TITLE
Fix incorrect times being displayed on web app 

### DIFF
--- a/QueueProcessors/QueueProcessor/queue_processor.py
+++ b/QueueProcessors/QueueProcessor/queue_processor.py
@@ -148,8 +148,8 @@ class Listener(object):
                                      hidden_in_failviewer=0,
                                      admin_log='',
                                      reduction_log='',
-                                     created=datetime.datetime.now(),
-                                     last_updated=datetime.datetime.now(),
+                                     created=datetime.datetime.utcnow(),
+                                     last_updated=datetime.datetime.utcnow(),
                                      experiment_id=experiment.id,
                                      instrument_id=instrument.id,
                                      status_id=status.id,
@@ -202,7 +202,7 @@ class Listener(object):
             if str(reduction_run.status.value) == "Error" or str(
                     reduction_run.status.value) == "Queued":
                 reduction_run.status = StatusUtils().get_processing()
-                reduction_run.started = datetime.datetime.now()
+                reduction_run.started = datetime.datetime.utcnow()
                 session.add(reduction_run)
                 session.commit()
             else:
@@ -235,7 +235,7 @@ class Listener(object):
             if reduction_run:
                 if reduction_run.status.value == "Processing":
                     reduction_run.status = StatusUtils().get_completed()
-                    reduction_run.finished = datetime.datetime.now()
+                    reduction_run.finished = datetime.datetime.utcnow()
                     for name in ['message', 'reduction_log', 'admin_log']:
                         setattr(reduction_run, name, self._data_dict.get(name, ""))
                     if 'reduction_data' in self._data_dict:
@@ -305,7 +305,7 @@ class Listener(object):
             return
 
         reduction_run.status = StatusUtils().get_error()
-        reduction_run.finished = datetime.datetime.now()
+        reduction_run.finished = datetime.datetime.utcnow()
         for name in ['message', 'reduction_log', 'admin_log']:
             setattr(reduction_run, name, self._data_dict.get(name, ""))
         session.add(reduction_run)

--- a/QueueProcessors/QueueProcessor/utils/reduction_run_utils.py
+++ b/QueueProcessors/QueueProcessor/utils/reduction_run_utils.py
@@ -37,7 +37,7 @@ class ReductionRunUtils(object):
             """ Set a run as canceled """
             run.message = "Run cancelled by user"
             run.status = StatusUtils().get_error()
-            run.finished = datetime.datetime.now()
+            run.finished = datetime.datetime.utcnow()
             run.retry_when = None
             run.save()
 
@@ -95,8 +95,8 @@ class ReductionRunUtils(object):
                                instrument=reduction_run.instrument,
                                script=script_text,
                                status=StatusUtils().get_queued(),
-                               created=datetime.datetime.now(),
-                               last_updated=datetime.datetime.now(),
+                               created=datetime.datetime.utcnow(),
+                               last_updated=datetime.datetime.utcnow(),
                                message="",
                                started_by=username,
                                cancel=0,
@@ -110,7 +110,7 @@ class ReductionRunUtils(object):
 
             reduction_run.retry_run = new_job
             reduction_run.retry_when = \
-                datetime.datetime.now() + datetime.timedelta(seconds=delay if delay else 0)
+                datetime.datetime.utcnow() + datetime.timedelta(seconds=delay if delay else 0)
             session.add(new_job)
             session.commit()
 


### PR DESCRIPTION
<!--If you are submitting this pull request, please fill out this section-->
**Description of changes**
<!--Summaries the changes you made as part of this pull request-->
- Django stores datetime information in UTC in the database for reasons listed [here](https://docs.djangoproject.com/en/1.11/topics/i18n/timezones/), however the queue processor was simply using `datetime.now()` causing jobs **not** submitted through the web app to be an hour out.
- This PR just changes `datetime.now()` to `datetime.utcnow()` in the queue processor.

**How to test**
<!--Any specific parts of the system that need to be tested to validate this change-->
- Restart the queue processors 
- Submit a job using the manual submission script 
    - Check the times displayed on the web app are correct for that job
- Re-submit a job on the web app
    - Check the times displayed on the web app are correct for that job


Fixes #22 

---

<!--Complete this section if you are the tester-->
**To test**
* Log into the devolpement nodes
* `git checkout this-pull-request-branch`
* restart services on each node (information on how to do this can be found in the development documentation)
* Submit some runs with the manualsubmission.py script

Once you are happy, merge this pull request into develop, and update the development nodes to the devlop branch
```
> git checkout origin/devlop
> git fetch -p
> git pull origin/develop
```
