### PR TITLE
Improve QueueProcessor restart.sh

### DIFF
--- a/QueueProcessors/restart.sh
+++ b/QueueProcessors/restart.sh
@@ -9,7 +9,7 @@
 ROOT_DIR="$(dirname "$0")"
 
 ## Autoreduction Processor
-pkill -9 -f "python AutoreductionProcessor/autoreduction_processor_daemon.py start" &&
+pkill -9 -f "python .*AutoreductionProcessor/autoreduction_processor_daemon.py start" &&
 echo "Stopped autoreduction_processor_daemon.py";
 if [ -e /tmp/AutoreduceQueueProcessorDaemon.pid ]
 then
@@ -25,7 +25,7 @@ echo ""; # New line
 
 
 ## QueueProcessor
-pkill -9 -f "python QueueProcessor/queue_processor_daemon.py start" &&
+pkill -9 -f "python .*QueueProcessor/queue_processor_daemon.py start" &&
 echo "Stopped queue_processor_daemon";
 if [ -e /tmp/QueueProcessorDaemon.pid ]
 then

--- a/QueueProcessors/restart.sh
+++ b/QueueProcessors/restart.sh
@@ -6,18 +6,33 @@
 #### WARNING: If there's currently reduction runs "processing" this may 
 #### cause them to get stuck in the "processing" state.
 
+ROOT_DIR="$(dirname "$0")"
+
+## Autoreduction Processor
 pkill -9 -f "python AutoreductionProcessor/autoreduction_processor_daemon.py start" &&
 echo "Stopped autoreduction_processor_daemon.py";
-rm /tmp/AutoreduceQueueProcessorDaemon.pid && # Removes the tmp pid file
-echo "Removed /tmp/AutoreduceQueueProcessorDaemon.pid"
-python AutoreductionProcessor/autoreduction_processor_daemon.py start &&
+if [ -e /tmp/AutoreduceQueueProcessorDaemon.pid ]
+then
+    rm /tmp/AutoreduceQueueProcessorDaemon.pid && # Removes the tmp pid file
+    echo "Removed /tmp/AutoreduceQueueProcessorDaemon.pid"
+else
+    echo ".pid file not found - starting process"
+fi
+python $ROOT_DIR/AutoreductionProcessor/autoreduction_processor_daemon.py start &&
 echo "Started autoreduction_processor_daemon";
 
 echo ""; # New line
 
+
+## QueueProcessor
 pkill -9 -f "python QueueProcessor/queue_processor_daemon.py start" &&
 echo "Stopped queue_processor_daemon";
-rm /tmp/QueueProcessorDaemon.pid && # Removes the tmp pid file
-echo "Removed /tmp/QueueProcessorDaemon.pid"
-python QueueProcessor/queue_processor_daemon.py start &&
+if [ -e /tmp/QueueProcessorDaemon.pid ]
+then
+    rm /tmp/QueueProcessorDaemon.pid && # Removes the tmp pid file
+    echo "Removed /tmp/QueueProcessorDaemon.pid"
+else
+    echo ".pid file not found - starting process"
+fi
+python $ROOT_DIR/QueueProcessor/queue_processor_daemon.py start &&
 echo "Started queue_processor_daemon.py";


### PR DESCRIPTION
**Description of changes**
* The restart.sh script should now be callable from any location
* If the queues are not running (can't find `.pid`) restart will start them

**How to test**
* Stop daemons and try to use restart to start them - this should work
* Try to restart the queues while it's running - this should work
* Try to use the script from any location (don't `cd` into `QueueProcessors` folder) 
