### PR TITLE
Allow overwrite to be null

### DIFF
--- a/WebApp/autoreduce_webapp/reduction_viewer/models.py
+++ b/WebApp/autoreduce_webapp/reduction_viewer/models.py
@@ -46,7 +46,7 @@ class ReductionRun(models.Model):
     retry_when = models.DateTimeField(null=True, blank=True)
     cancel = models.BooleanField(default=False)
     hidden_in_failviewer = models.BooleanField(default=False)
-    overwrite = models.BooleanField(default=True)
+    overwrite = models.NullBooleanField(default=True)
     
 
     def __unicode__(self):


### PR DESCRIPTION
<!--If you are submitting this pull request, please fill out this section-->
**Description of changes**
<!--Summaries the changes you made as part of this pull request-->
- Allow the `overwrite` attribute of a reduction run to be null.
   - Fixes issue with a newly migrated database not working with queue_processor. An exception was being thrown when queue processor tried to insert a reduction run with the overwrite attribute null.