### PR TITLE
Move project requirements to setup.py

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ before_install:
   - mysql < Scripts/Build/database/travis-db-setup.sql
 
 install:
+  - python setup.py install
   - pip install -r requirements.txt
   - ./Scripts/Build/install/icat.sh
   - ./Scripts/Build/install/activemq.sh

--- a/QueueProcessors/AutoreductionProcessor/autoreduction_processor.py
+++ b/QueueProcessors/AutoreductionProcessor/autoreduction_processor.py
@@ -4,8 +4,10 @@ Module that reads from the reduction pending queue and calls the python script o
 import json
 import os
 import subprocess
-import stomp
+
 from twisted.internet import reactor
+import stomp
+
 
 from QueueProcessors.AutoreductionProcessor.autoreduction_logging_setup import logger
 # pylint:disable=no-name-in-module,import-error

--- a/Scripts/ManualSubmissionScript/manual_submission.py
+++ b/Scripts/ManualSubmissionScript/manual_submission.py
@@ -7,9 +7,9 @@ import json
 import sys
 import argparse
 
+import icat
 import stomp
 
-import icat
 # The below is only a template on the repo
 # pylint: disable=import-error, no-name-in-module
 from Scripts.ManualSubmissionScript.settings import ACTIVE_MQ

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,13 +1,2 @@
-Django==1.11.12
-django_extensions==2.0.7
-django-user-agents==0.3.2
-MySQL-python==1.2.5
 nose==1.3.7
 pylint==1.8.4
-python-daemon==2.1.2
-requests==2.18.4
-SQLAlchemy==1.2.7
-stomp.py==4.1.20
-suds==0.4
-Twisted==14.0.2
-watchdog==0.8.3

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,21 @@
-from distutils.core import setup
+from setuptools import setup
 
 setup(name='AutoReduction',
       version='1.0',
       description='ISIS AutoReduction service',
       author='ISIS Autoreduction Team',
-      url='https://github.com/ISISScientificComputing/autoreduce/')
+      url='https://github.com/ISISScientificComputing/autoreduce/',
+      install_requires=[
+          'Django==1.11.12',
+          'django_extensions==2.0.7',
+          'django-user-agents==0.3.2',
+          'MySQL-python==1.2.5',
+          'python-daemon==2.1.2',
+          'requests==2.18.4',
+          'SQLAlchemy==1.2.7',
+          'stomp.py==4.1.20',
+          'suds==0.4',
+          'Twisted==14.0.2',
+          'watchdog==0.8.3'
+      ]
+      )


### PR DESCRIPTION
**Description of changes**
* Move project requirements to install requires

**How to test**
* Run `pip install -e autoreduction` (from parent directory of the project) and ensure that the  pip requirements are checked/ installed.
  * This should also work with `python setup.py install`
* Ensure that the build still passes on travis (with new build instructions)
