### PR TITLE
Set testing builds to debug mode by default

### DIFF
--- a/WebApp/autoreduce_webapp/autoreduce_webapp/test_settings.py
+++ b/WebApp/autoreduce_webapp/autoreduce_webapp/test_settings.py
@@ -10,7 +10,11 @@ BASE_DIR = os.path.dirname(os.path.dirname(__file__))
 SECRET_KEY = 'YOUR-SECRET-KEY'
 
 # SECURITY WARNING: don't run with these turned on in production!
-DEBUG = False
+
+# Enable debug by default, this allows us to serve static content without
+# having to run `manage.py collectstatic` each time. On production
+# we use Apache to serve static content instead.
+DEBUG = True
 DEBUG_PROPAGATE_EXCEPTIONS = False
 
 ALLOWED_HOSTS = ['127.0.0.1', 'localhost', 'reducedev2.isis.cclrc.ac.uk']


### PR DESCRIPTION
**Description of changes**
Sets the testing settings to enable debug mode by default, so Django can serve content in lieu of Apache (which is used on production)



**How to test**
- With a fresh cloned repository follow the local setup instructions
- Attempt to open the page, the static content should not load in
- Checkout these changes
- Run `migrate_test_settings.sh`
- The static content should now load

Fixes #82 

---

<!--Complete this section if you are the tester-->
**To test**
* Log into the devolpement nodes
* `git checkout this-pull-request-branch`
* restart services on each node (information on how to do this can be found in the development documentation)
* Submit some runs with the manualsubmission.py script

Once you are happy, merge this pull request into develop, and update the development nodes to the devlop branch
```
> git checkout origin/devlop
> git fetch -p
> git pull origin/develop
```
