### PR TITLE
Prevent queued jobs from being re-queued

### DIFF
--- a/WebApp/autoreduce_webapp/reduction_variables/views.py
+++ b/WebApp/autoreduce_webapp/reduction_variables/views.py
@@ -347,19 +347,26 @@ def run_confirmation(request, instrument=None):
         context_dictionary['error'] = 'Runs span multiple experiment numbers (' + ','.join(str(i) for i in rb_number) + ') please select a different range.'
 
     for run_number in run_numbers:
-        old_reduction_run = ReductionRun.objects.filter(run_number=run_number).order_by('-run_version').first()
+        matching_previous_runs_queryset = ReductionRun.objects.filter(run_number=run_number).order_by('-run_version')
+
+        most_recent_previous_run = matching_previous_runs_queryset.first()
 
         # Check old run exists
-        if old_reduction_run is None:
+        if most_recent_previous_run is None:
             context_dictionary['error'] = "Run number " + str(run_number) + " doesn't exist."
+
+        # Check it is not currently queued
+        if matching_previous_runs_queryset.filter(status=queued_status).first() is not None:
+            context_dictionary['error'] = "The specified run number is already queued to run"
+            return context_dictionary
 
         use_current_script = request.POST.get('use_current_script', u"true").lower() == u"true"
         if use_current_script:
             script_text = InstrumentVariablesUtils().get_current_script_text(instrument.name)[0]
             default_variables = InstrumentVariablesUtils().get_default_variables(instrument.name)
         else:
-            script_text = old_reduction_run.script
-            default_variables = old_reduction_run.run_variables.all()
+            script_text = most_recent_previous_run.script
+            default_variables = most_recent_previous_run.run_variables.all()
         
         new_variables = []
 
@@ -401,7 +408,9 @@ def run_confirmation(request, instrument=None):
         
         run_description = request.POST.get('run_description')
                 
-        new_job = ReductionRunUtils().createRetryRun(old_reduction_run, script=script_text, overwrite=overwrite_previous_data, variables=new_variables, username=request.user.username, description=run_description)
+        new_job = ReductionRunUtils().createRetryRun(most_recent_previous_run, script=script_text,
+                                                     overwrite=overwrite_previous_data, variables=new_variables,
+                                                     username=request.user.username, description=run_description)
 
         try:
             MessagingUtils().send_pending(new_job)

--- a/WebApp/autoreduce_webapp/reduction_variables/views.py
+++ b/WebApp/autoreduce_webapp/reduction_variables/views.py
@@ -356,8 +356,9 @@ def run_confirmation(request, instrument=None):
             context_dictionary['error'] = "Run number " + str(run_number) + " doesn't exist."
 
         # Check it is not currently queued
-        if matching_previous_runs_queryset.filter(status=queued_status).first() is not None:
-            context_dictionary['error'] = "The specified run number is already queued to run"
+        queued_runs = matching_previous_runs_queryset.filter(status=queued_status).first()
+        if queued_runs is not None:
+            context_dictionary['error'] = "Run number {0} is already queued to run".format(queued_runs.run_number)
             return context_dictionary
 
         use_current_script = request.POST.get('use_current_script', u"true").lower() == u"true"

--- a/WebApp/autoreduce_webapp/reduction_viewer/utils.py
+++ b/WebApp/autoreduce_webapp/reduction_viewer/utils.py
@@ -145,7 +145,7 @@ class ReductionRunUtils(object):
             import traceback
             logger.error(traceback.format_exc())
             logger.error(e)
-            new_job.delete()
+            #new_job.delete()
             raise
             
             


### PR DESCRIPTION
**Description of changes**
Prevents jobs from being re-queued if another run with the same number is queued for that instrument.

**How to test**
- Queue a job up for an instrument
- Attempt to queue for the same instrument again, this should fail
- Attempt to queue the same run number for a different instrument, this should work

Fixes #49

---

<!--Complete this section if you are the tester-->
**To test**
* Log into the devolpement nodes
* `git checkout this-pull-request-branch`
* restart services on each node (information on how to do this can be found in the development documentation)
* Submit some runs with the manualsubmission.py script

Once you are happy, merge this pull request into develop, and update the development nodes to the devlop branch
```
> git checkout origin/devlop
> git fetch -p
> git pull origin/develop
```
