### PR TITLE
Remove get_or_create in models

### DIFF
--- a/Documentation/Technical Documentation.md
+++ b/Documentation/Technical Documentation.md
@@ -227,7 +227,7 @@ Models are the instances of database records. Each model matches against a table
 
 This contains utilities related to the models found within reduction_viewer.
 
-* **StatusUtils** - A helper function to get status models back for either Queue, Processing, Completed or Error. This utility wraps all calls in a `get_or_create` call to remove the need of pre-populating the database with these values.
+* **StatusUtils** - A helper function to get status models back for either Queue, Processing, Completed or Error.
 * **InstrumentUtils** - A helper function to get Instrument models back for the provided name. If an instrument matching the name isn't found, one is created prior to return.
 * **ReductionRunUtils** - Contains helper functions for `ReductionRun`s. `cancelRun()` provides cancellation functionality for runs that are being or will be retried. `createRetryRun()` 'copies' the provided run, suitable for retrying (e.g., it ensures that the `run_version` field is incremented as necessary).
 

--- a/WebApp/autoreduce_webapp/reduction_viewer/utils.py
+++ b/WebApp/autoreduce_webapp/reduction_viewer/utils.py
@@ -1,4 +1,7 @@
 import logging, os, sys, time, datetime
+
+import django.core.exceptions, django.http
+
 sys.path.append(os.path.join("../", os.path.dirname(os.path.dirname(__file__))))
 os.environ["DJANGO_SETTINGS_MODULE"] = "autoreduce_webapp.settings"
 logger = logging.getLogger('app')
@@ -28,15 +31,22 @@ class StatusUtils(object):
 
     def get_skipped(self):
         return self._get_status("Skipped")
-            
+
+
 class InstrumentUtils(object):
+
     def get_instrument(self, instrument_name):
         """
         Helper method that will try to get an instrument matching the given name or create one if it doesn't yet exist
         """
-        instrument = Instrument.objects.get(name__iexact=instrument_name)
+        try:
+            instrument = Instrument.objects.get(name__iexact=instrument_name)
+        except django.core.exceptions.ObjectDoesNotExist:
+            raise django.http.Http404()
+
         return instrument
-        
+
+
 class ReductionRunUtils(object):
 
     def cancelRun(self, reductionRun):

--- a/WebApp/autoreduce_webapp/reduction_viewer/utils.py
+++ b/WebApp/autoreduce_webapp/reduction_viewer/utils.py
@@ -11,9 +11,7 @@ class StatusUtils(object):
         """
         Helper method that will try to get a status matching the given name or create one if it doesn't yet exist
         """
-        status, created = Status.objects.get_or_create(value=status_value)
-        if created:
-            logger.warn("%s status was not found, created it." % status_value)
+        status = Status.objects.get(value=status_value)
         return status
 
     def get_error(self):
@@ -36,11 +34,7 @@ class InstrumentUtils(object):
         """
         Helper method that will try to get an instrument matching the given name or create one if it doesn't yet exist
         """
-        instrument, created = Instrument.objects.get_or_create(name__iexact=instrument_name)
-        if created:
-            instrument.name = instrument_name
-            instrument.save()
-            logger.warn("%s instrument was not found, created it." % instrument_name)
+        instrument = Instrument.objects.get(name__iexact=instrument_name)
         return instrument
         
 class ReductionRunUtils(object):


### PR DESCRIPTION
**Description of changes**
Changes the current helper methods in `utils` from `get_or_create` to `get`. This should prevent accidental creation of new records in the database

**How to test**
- Navigate to `/instrument/MUSR/variables/` - if this loads correctly the changes work (as it relies on `get_instrument` and `get_status` to work

- Navigate to `/instrument/foo/variables/` - the old code would create an entry in the DB. This should throw a does not exist record

Fixes #94 

---

<!--Complete this section if you are the tester-->
**To test**
* Log into the devolpement nodes
* `git checkout this-pull-request-branch`
* restart services on each node (information on how to do this can be found in the development documentation)
* Submit some runs with the manualsubmission.py script

Once you are happy, merge this pull request into develop, and update the development nodes to the devlop branch
```
> git checkout origin/devlop
> git fetch -p
> git pull origin/develop
```
