### PR TITLE
Add validators to model and perform clean before saving

### DIFF
--- a/WebApp/autoreduce_webapp/reduction_viewer/models.py
+++ b/WebApp/autoreduce_webapp/reduction_viewer/models.py
@@ -37,8 +37,8 @@ class ReductionRun(models.Model):
     graph = models.TextField(null=True, blank=True)
     message = models.TextField(blank=True)
     reduction_log = models.TextField(blank=True)
-    # Scripts should be 10,000 chars or less. The DB supports up to 4GB strings here
-    script = models.TextField(blank=False, validators=[MaxLengthValidator(10000)])
+    # Scripts should be 100,000 chars or less. The DB supports up to 4GB strings here
+    script = models.TextField(blank=False, validators=[MaxLengthValidator(100000)])
 
     # Date time fields
     created = models.DateTimeField(auto_now_add=True, blank=False)

--- a/WebApp/autoreduce_webapp/reduction_viewer/models.py
+++ b/WebApp/autoreduce_webapp/reduction_viewer/models.py
@@ -1,4 +1,5 @@
 from django.db import models
+from django.core.validators import MinValueValidator, MaxLengthValidator
 import autoreduce_webapp.icat_communication
 
 class Instrument(models.Model):
@@ -20,34 +21,42 @@ class Status(models.Model):
 
     def __unicode__(self):
         return u'%s' % self.value        
-        
+
+
 class ReductionRun(models.Model):
-    run_number = models.IntegerField(blank=False)
-    run_version = models.IntegerField(blank=False)
-    run_name = models.CharField(max_length=200, blank=True)
-    experiment = models.ForeignKey(Experiment, blank=False, related_name='reduction_runs')
-    instrument = models.ForeignKey(Instrument, related_name='reduction_runs', null=True)
-    
-    script = models.TextField(blank=False)
-    
-    status = models.ForeignKey(Status, blank=False, related_name='+')
-    created = models.DateTimeField(auto_now_add=True, blank=False)
-    last_updated = models.DateTimeField(auto_now=True, blank=False)
-    started = models.DateTimeField(null=True, blank=True)
-    finished = models.DateTimeField(null=True, blank=True)
+    # Integer fields
+    run_number = models.IntegerField(blank=False, validators=[MinValueValidator(0)])
+    run_version = models.IntegerField(blank=False, validators=[MinValueValidator(0)])
     started_by = models.IntegerField(null=True, blank=True)
+
+    # Char fields
+    run_name = models.CharField(max_length=200, blank=True)
+
+    # Text fields
+    admin_log = models.TextField(blank=True)
     graph = models.TextField(null=True, blank=True)
-    
     message = models.TextField(blank=True)
     reduction_log = models.TextField(blank=True)
-    admin_log = models.TextField(blank=True)
-    
-    retry_run = models.ForeignKey('self', on_delete=models.SET_NULL, null=True, blank=True)
+    # Scripts should be 10,000 chars or less. The DB supports up to 4GB strings here
+    script = models.TextField(blank=False, validators=[MaxLengthValidator(10000)])
+
+    # Date time fields
+    created = models.DateTimeField(auto_now_add=True, blank=False)
+    finished = models.DateTimeField(null=True, blank=True)
+    last_updated = models.DateTimeField(auto_now=True, blank=False)
     retry_when = models.DateTimeField(null=True, blank=True)
+    started = models.DateTimeField(null=True, blank=True)
+
+    # Bool field
     cancel = models.BooleanField(default=False)
     hidden_in_failviewer = models.BooleanField(default=False)
     overwrite = models.NullBooleanField(default=True)
-    
+
+    # Foreign Keys
+    experiment = models.ForeignKey(Experiment, blank=False, related_name='reduction_runs')
+    instrument = models.ForeignKey(Instrument, related_name='reduction_runs', null=True)
+    retry_run = models.ForeignKey('self', on_delete=models.SET_NULL, null=True, blank=True)
+    status = models.ForeignKey(Status, blank=False, related_name='+')
 
     def __unicode__(self):
         if self.run_name:

--- a/WebApp/autoreduce_webapp/reduction_viewer/utils.py
+++ b/WebApp/autoreduce_webapp/reduction_viewer/utils.py
@@ -1,10 +1,14 @@
-import logging, os, sys, time, datetime
-sys.path.append(os.path.join("../", os.path.dirname(os.path.dirname(__file__))))
-os.environ["DJANGO_SETTINGS_MODULE"] = "autoreduce_webapp.settings"
-logger = logging.getLogger('app')
+import logging, os, sys, time, datetime, traceback
+
+import django.core.exceptions
 from django.utils import timezone
 from reduction_viewer.models import Instrument, Status, ReductionRun, DataLocation
 from reduction_variables.models import RunVariable
+
+sys.path.append(os.path.join("../", os.path.dirname(os.path.dirname(__file__))))
+os.environ["DJANGO_SETTINGS_MODULE"] = "autoreduce_webapp.settings"
+logger = logging.getLogger('app')
+
 
 class StatusUtils(object):
     def _get_status(self, status_value):
@@ -89,8 +93,6 @@ class ReductionRunUtils(object):
         If variables (RunVariable) are provided, copy them and associate them with the new one, otherwise use the previous run's.
         If a script (as a string) is supplied then use it, otherwise use the previous run's.
         """
-        from reduction_variables.utils import InstrumentVariablesUtils, VariableUtils
-        
         run_last_updated = reductionRun.last_updated
         
         if username == 'super':
@@ -98,55 +100,57 @@ class ReductionRunUtils(object):
 
         # find the previous run version, so we don't create a duplicate
         last_version = -1
-        for run in ReductionRun.objects.filter(experiment=reductionRun.experiment, run_number=reductionRun.run_number):
-            last_version = max(last_version, run.run_version)
-        
-        try:
-            # get the script to use:
-            script_text = script if script is not None else reductionRun.script
-        
-            # create the run object and save it
-            new_job = ReductionRun( instrument = reductionRun.instrument
-                                  , run_number = reductionRun.run_number
-                                  , run_name = description
-                                  , run_version = last_version+1
-                                  , experiment = reductionRun.experiment
-                                  , started_by = username
-                                  , status = StatusUtils().get_queued()
-                                  , script = script_text
-                                  , overwrite = overwrite
-                                  )
-            new_job.save()
-            
-            reductionRun.retry_run = new_job
-            reductionRun.retry_when = timezone.now().replace(microsecond=0) + datetime.timedelta(seconds=delay if delay else 0)
-            reductionRun.save()
-            
-            ReductionRun.objects.filter(id = reductionRun.id).update(last_updated = run_last_updated)
-            
-            # copy the previous data locations
-            for data_location in reductionRun.data_location.all():
-                new_data_location = DataLocation(file_path=data_location.file_path, reduction_run=new_job)
-                new_data_location.save()
-                new_job.data_location.add(new_data_location)
-                
-            if variables is not None:
-                # associate the variables with the new run
-                for var in variables:
-                    var.reduction_run = new_job
-                    var.save()
-            else:
-                # provide variables if they aren't already
-                InstrumentVariablesUtils().create_variables_for_run(new_job)
+        previous_run = ReductionRun.objects.filter(experiment=reductionRun.experiment, run_number=reductionRun.run_number)\
+                .order_by("-run_version").first()
 
-            return new_job
-            
-        except Exception as e:
-            import traceback
+        last_version = previous_run.run_version
+
+        # get the script to use:
+        script_text = script if script is not None else reductionRun.script
+
+        # create the run object and save it
+        new_job = ReductionRun(instrument=reductionRun.instrument,
+                               run_number=reductionRun.run_number,
+                               run_name=description,
+                               run_version=last_version + 1,
+                               experiment=reductionRun.experiment,
+                               started_by=username,
+                               status=StatusUtils().get_queued(),
+                               script=script_text,
+                               overwrite=overwrite)
+
+        # Check record is safe to save
+        try:
+            new_job.full_clean()
+        except django.core.exceptions as e:
             logger.error(traceback.format_exc())
             logger.error(e)
-            new_job.delete()
             raise
+
+        new_job.save()
+
+        reductionRun.retry_run = new_job
+        reductionRun.retry_when = timezone.now().replace(microsecond=0) + datetime.timedelta(seconds=delay if delay else 0)
+        reductionRun.save()
+
+        ReductionRun.objects.filter(id = reductionRun.id).update(last_updated = run_last_updated)
+
+        # copy the previous data locations
+        for data_location in reductionRun.data_location.all():
+            new_data_location = DataLocation(file_path=data_location.file_path, reduction_run=new_job)
+            new_data_location.save()
+            new_job.data_location.add(new_data_location)
+
+        if variables is not None:
+            # associate the variables with the new run
+            for var in variables:
+                var.reduction_run = new_job
+                var.save()
+        else:
+            # provide variables if they aren't already
+            InstrumentVariablesUtils().create_variables_for_run(new_job)
+
+        return new_job
             
             
     def get_script_and_arguments(self, reductionRun):

--- a/WebApp/autoreduce_webapp/reduction_viewer/utils.py
+++ b/WebApp/autoreduce_webapp/reduction_viewer/utils.py
@@ -127,7 +127,14 @@ class ReductionRunUtils(object):
             logger.error(e)
             raise
 
-        new_job.save()
+        # Attempt to save
+        try:
+            new_job.save()
+        except ValueError as e:
+            # This usually indicates a F.K. constraint wasn't matched. Maybe we didn't get a record in?
+            logger.error(traceback.format_exc())
+            logger.error(e)
+            raise
 
         reductionRun.retry_run = new_job
         reductionRun.retry_when = timezone.now().replace(microsecond=0) + datetime.timedelta(seconds=delay if delay else 0)


### PR DESCRIPTION
**Description of changes**
- Adds validators to the model for better error reporting in the stack traces
- Reworks control flow so we don't attempt to save a record before a clean. 
- This could still fail a FK constraint on the DB side. So instead of attempting to delete the record (which will lose our trace) that wasn't saved, we let Django fail the entry.
- We let the database sort by version, instead of parsing each record and using max to achieve the same effect.
- We now catch specific exceptions, rather than the kitchen sink approach.

**How to test**
- Go to reduction_viewer\utils.py:112
- Change the line that reads: `run_version=last_version + 1` to `run_version='a'`.
- Check a sane stack trace and error message are printed
- Examine the stack trace, it should have failed on `full_clean()` instead of save

Fixes #91 

---

<!--Complete this section if you are the tester-->
**To test**
* Log into the devolpement nodes
* `git checkout this-pull-request-branch`
* restart services on each node (information on how to do this can be found in the development documentation)
* Submit some runs with the manualsubmission.py script

Once you are happy, merge this pull request into develop, and update the development nodes to the devlop branch
```
> git checkout origin/devlop
> git fetch -p
> git pull origin/develop
```
