### PR TITLE
Remove saving to archive feature

### DIFF
--- a/QueueProcessors/AutoreductionProcessor/post_process_admin.py
+++ b/QueueProcessors/AutoreductionProcessor/post_process_admin.py
@@ -218,11 +218,6 @@ class PostProcessAdmin(object):
 
             # Specify directories where autoreduction output will go
             reduce_result_dir = MISC["temp_root_directory"] + instrument_output_dir
-            if self.instrument not in MISC["excitation_instruments"]:
-                run_output_dir = os.path.join(MISC["temp_root_directory"],
-                                              instrument_output_dir[:instrument_output_dir.rfind('/') + 1])
-            else:
-                run_output_dir = reduce_result_dir
 
             if 'run_description' in self.data:
                 logger.info("DESCRIPTION: %s", self.data["run_description"])
@@ -304,7 +299,6 @@ class PostProcessAdmin(object):
             logger.info("----------------")
             logger.info("Reduction script: %s ...", self.reduction_script[:50])
             logger.info("Result dir: %s", reduce_result_dir)
-            logger.info("Run Output dir: %s", run_output_dir)
             logger.info("Log dir: %s", log_dir)
             logger.info("Out log: %s", script_out)
             logger.info("Datafile: %s", self.data_file)

--- a/QueueProcessors/AutoreductionProcessor/post_process_admin.py
+++ b/QueueProcessors/AutoreductionProcessor/post_process_admin.py
@@ -14,7 +14,6 @@ import imp
 import json
 import logging
 import os
-import re
 import shutil
 import socket
 import sys
@@ -210,12 +209,12 @@ class PostProcessAdmin(object):
 
             # Specify instrument directory
             instrument_output_dir = MISC["ceph_directory"] % (self.instrument,
-                                                           self.proposal,
-                                                           self.run_number)
+                                                              self.proposal,
+                                                              self.run_number)
 
             if self.instrument in MISC["excitation_instruments"]:
-                    # Excitations would like to remove the run number folder at the end
-                    instrument_output_dir = instrument_output_dir[:instrument_output_dir.rfind('/') + 1]
+                # Excitations would like to remove the run number folder at the end
+                instrument_output_dir = instrument_output_dir[:instrument_output_dir.rfind('/') + 1]
 
             # Specify directories where autoreduction output will go
             reduce_result_dir = MISC["temp_root_directory"] + instrument_output_dir

--- a/QueueProcessors/AutoreductionProcessor/post_process_admin.py
+++ b/QueueProcessors/AutoreductionProcessor/post_process_admin.py
@@ -210,20 +210,13 @@ class PostProcessAdmin(object):
 
             # Specify instrument directory
             cycle = re.match(r'.*cycle_(\d\d_\d).*', self.data_file.lower()).group(1)
-            if self.instrument in MISC["ceph_instruments"] + MISC["excitation_instruments"]:
-
-                instrument_dir = MISC["ceph_directory"] % (self.instrument,
+            instrument_dir = MISC["ceph_directory"] % (self.instrument,
                                                            self.proposal,
                                                            self.run_number)
 
-                if self.instrument in MISC["excitation_instruments"]:
+            if self.instrument in MISC["excitation_instruments"]:
                     # Excitations would like to remove the run number folder at the end
                     instrument_dir = instrument_dir[:instrument_dir.rfind('/') + 1]
-            else:
-                instrument_dir = MISC["archive_directory"] % (self.instrument,
-                                                              cycle,
-                                                              self.proposal,
-                                                              self.run_number)
 
             # Specify directories where autoreduction output will go
             reduce_result_dir = MISC["temp_root_directory"] + instrument_dir

--- a/QueueProcessors/AutoreductionProcessor/post_process_admin.py
+++ b/QueueProcessors/AutoreductionProcessor/post_process_admin.py
@@ -209,20 +209,19 @@ class PostProcessAdmin(object):
             self.client.send(ACTIVEMQ['reduction_started'], json.dumps(self.data))
 
             # Specify instrument directory
-            cycle = re.match(r'.*cycle_(\d\d_\d).*', self.data_file.lower()).group(1)
-            instrument_dir = MISC["ceph_directory"] % (self.instrument,
+            instrument_output_dir = MISC["ceph_directory"] % (self.instrument,
                                                            self.proposal,
                                                            self.run_number)
 
             if self.instrument in MISC["excitation_instruments"]:
                     # Excitations would like to remove the run number folder at the end
-                    instrument_dir = instrument_dir[:instrument_dir.rfind('/') + 1]
+                    instrument_output_dir = instrument_output_dir[:instrument_output_dir.rfind('/') + 1]
 
             # Specify directories where autoreduction output will go
-            reduce_result_dir = MISC["temp_root_directory"] + instrument_dir
+            reduce_result_dir = MISC["temp_root_directory"] + instrument_output_dir
             if self.instrument not in MISC["excitation_instruments"]:
                 run_output_dir = os.path.join(MISC["temp_root_directory"],
-                                              instrument_dir[:instrument_dir.rfind('/') + 1])
+                                              instrument_output_dir[:instrument_output_dir.rfind('/') + 1])
             else:
                 run_output_dir = reduce_result_dir
 

--- a/QueueProcessors/AutoreductionProcessor/settings.py.template
+++ b/QueueProcessors/AutoreductionProcessor/settings.py.template
@@ -21,9 +21,7 @@ MISC = {
     "mantid_path": "/opt/Mantid/bin",
     "scripts_directory": "/isis/NDX%s/user/scripts/autoreduction",
     "post_process_directory": os.path.join(os.path.dirname(os.path.realpath(__file__)), "post_process_admin.py"),
-    "archive_directory": "/isis/NDX%s/Instrument/data/cycle_%s/autoreduced/%s/%s",
     "ceph_directory": "/instrument/%s/RBNumber/RB%s/autoreduced/%s",
     "temp_root_directory": "/autoreducetmp",
-    "ceph_instruments": [],
     "excitation_instruments": ["LET", "MARI", "MAPS", "MERLIN", "WISH", "GEM"]
 }


### PR DESCRIPTION
<!--If you are submitting this pull request, please fill out this section-->
**Description of changes**
<!--Summaries the changes you made as part of this pull-->
- Reduced data can no longer be saved on the ISIS archive, it all goes to CEPH
- This also means new instruments will not need adding to `ceph_instruments` in the queue processor settings files. The `excitation_instruments` setting still remains as their data is saved in a different format (No run number folders)


**How to test**
<!--Any specific parts of the system that need to be tested to validate this change-->
- Submit a non-excitation (defined in `QueueProcessors/AutoreductionProcessor/settings.py`)  instrument reduction job 
- Check it the reduced data gets saved with the correct directory strucure
    - Reduced data should be contained in a run number directory. e.g. `/instrument/GEM/RBNumber/RB1720007/autoreduced/84854/`
- Submit an excitation instrument reduction job
- Check the reduced data gets saved with the correct folder structure (No run number folders)
- Ensure `archive_directory` and `ceph_instruments` are removed from `QueueProcessors/AutoreductionProcessor/settings.py` and check the queue processor still works


Fixes #5 