### PR TITLE
Allow negative RB numbers in WebApp

### DIFF
--- a/WebApp/autoreduce_webapp/autoreduce_webapp/urls.py
+++ b/WebApp/autoreduce_webapp/autoreduce_webapp/urls.py
@@ -24,7 +24,7 @@ urlpatterns = [
     url(r'^runs/$', reduction_viewer_views.run_list, name='run_list'),
     url(r'^runs/queue/$', reduction_viewer_views.run_queue, name='run_queue'),
     url(r'^runs/failed/$', reduction_viewer_views.fail_queue, name='fail_queue'),
-    url(r'^runs/list/(?P<reference_number>[0-9]+)/$',
+    url(r'^runs/list/(?P<reference_number>-?[0-9]+)/$',
         reduction_viewer_views.load_runs, name='load_runs'),
     url(r'^runs/list/(?P<instrument_name>\w+)/$',
         reduction_viewer_views.load_runs, name='load_runs'),
@@ -58,7 +58,7 @@ urlpatterns = [
         reduction_variables_views.current_default_variables, name='current_default_variables'),
 
     # ===========================EXPERIMENT========================== #
-    url(r'^experiment/(?P<reference_number>[0-9]+)/$',
+    url(r'^experiment/(?P<reference_number>-?[0-9]+)/$',
         reduction_viewer_views.experiment_summary, name='experiment_summary'),
 
     # ===========================SCRIPTS============================= #


### PR DESCRIPTION
<!--If you are submitting this pull request, please fill out this section-->
**Description of changes**
<!--Summaries the changes you made as part of this pull request-->
- A simple change to allow negative RB numbers in the URL. Negative RB's are often used for calibration runs. 

**How to test**
<!--Any specific parts of the system that need to be tested to validate this change-->
- Check that you can access an experiment with a negative RB number, for example GEM RB-1000
- Check that you can still access an experiment with a positive RB number.


Fixes #107 

---

<!--Complete this section if you are the tester-->
**To test**
* Log into the devolpement nodes
* `git checkout this-pull-request-branch`
* restart services on each node (information on how to do this can be found in the development documentation)
* Submit some runs with the manualsubmission.py script

Once you are happy, merge this pull request into develop, and update the development nodes to the devlop branch
```
> git checkout origin/devlop
> git fetch -p
> git pull origin/develop
```
