### PR TITLE
Remove pylint checks for migrations files

### DIFF
--- a/build/tests/test_pylint.sh
+++ b/build/tests/test_pylint.sh
@@ -15,7 +15,7 @@ errScore=0 # Pylint score
 logFileName="pylint.log"
 rm -f "$logFileName" || true
 
-for i in $(find . -name migrations -prune -o -name '*.py');
+for i in $(find . -not -path "*migrations*" -name '*.py');
 do
     fileCount=$((fileCount+1))
 

--- a/build/tests/test_pylint.sh
+++ b/build/tests/test_pylint.sh
@@ -15,7 +15,7 @@ errScore=0 # Pylint score
 logFileName="pylint.log"
 rm -f "$logFileName" || true
 
-for i in $(find . -name '*.py');
+for i in $(find . -name migrations -prune -o -name '*.py');
 do
     fileCount=$((fileCount+1))
 

--- a/build/tests/test_pylint.sh
+++ b/build/tests/test_pylint.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-errorThreshold=264
+errorThreshold=232
 
 sourceRoot=$(git rev-parse --show-toplevel)
 currentDir=$(pwd)


### PR DESCRIPTION
The migrations files are auto generated and hence should be ignored by pylint