### PR TITLE
Fixes to queue processor

### DIFF
--- a/QueueProcessors/AutoreductionProcessor/autoreduction_processor.py
+++ b/QueueProcessors/AutoreductionProcessor/autoreduction_processor.py
@@ -5,15 +5,14 @@ import json
 import os
 import subprocess
 
-import stomp
-
 from twisted.internet import reactor
+
+import stomp
 
 from QueueProcessors.AutoreductionProcessor.autoreduction_logging_setup import logger
 # pylint:disable=no-name-in-module,import-error
 from QueueProcessors.AutoreductionProcessor.settings import MISC
 from utils.settings import ACTIVEMQ
-from utils.clients.queue_client import QueueClient
 
 
 class Listener(object):


### PR DESCRIPTION
revert some changes made in QueueProcessor to use Client as they are not quite working. It's safer at this point during release cycle to revert instead. This should be fixed properly in 18.3

*No associated issue*