### PR TITLE
Webapp: Ensure that reduction variables naming convention

### DIFF
--- a/WebApp/autoreduce_webapp/templates/snippets/run_variables.html
+++ b/WebApp/autoreduce_webapp/templates/snippets/run_variables.html
@@ -6,8 +6,8 @@
         <form id="run_variables" method="POST" action="{% url 'run_confirmation' instrument=instrument.name %}" class="form-horizontal">
             {% csrf_token %}
             <input type="hidden" name="use_current_script" id="use_current_script" value="false">
-            <input type="hidden" name="run_number" value="{{ run_number }} ">
-            <input type="hidden" name="run_version" value="{{ run_version }} ">
+            <input type="hidden" name="run_range" value="{{ run_number }}">
+            <input type="hidden" name="run_version" value="{{ run_version }}">
             <div class="row">
                 <div class="col-md-9">
                     {% include "snippets/form_warnings.html" %}


### PR DESCRIPTION
Original issue found during smoke testing

### Description of work

This issue ensures that the reduction variables that get passed to the server side validation are named correctly. Previous a name mis-match caused the variable to not be found in the POST content. 

### To test

* Run the webapp
* Click on a run (note: if this run is already queued in another job this will not pass validation)
* Expand the `Re-run reduction job` tab
* Add a sensible name in the `Re-run description` field (e.g. `validate #174 is resolved`)
* Click the `Re-run with new variables`
* Ensure that this validates (receive message about run submitted successfully)
* Ensure that the run appears in the `All jobs` page and reduces successfully

Fixes #174