### PR TITLE
Simplify imports

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,7 @@ install:
 
   # ================== Test setup ==================== #
   - python setup.py test_settings
+  - cat utils/settings.py
   # Externals must be after test_settings
   - python setup.py externals -s activemq,icat
   - python setup.py database

--- a/QueueProcessors/QueueProcessor/queue_processor.py
+++ b/QueueProcessors/QueueProcessor/queue_processor.py
@@ -18,18 +18,16 @@ from QueueProcessors.QueueProcessor.base import session
 from QueueProcessors.QueueProcessor.orm_mapping import (ReductionRun, Instrument,
                                                         Status, Experiment,
                                                         DataLocation, ReductionLocation)
-# pylint: disable=cyclic-import
-from QueueProcessors.QueueProcessor.queueproc_utils.messaging_utils import MessagingUtils
-from QueueProcessors.QueueProcessor.queueproc_utils.instrument_variable_utils \
-    import InstrumentVariablesUtils
-from QueueProcessors.QueueProcessor.queueproc_utils.status_utils import StatusUtils
-from QueueProcessors.QueueProcessor.queueproc_utils.reduction_run_utils import ReductionRunUtils
+from QueueProcessors.QueueProcessor.queueproc_utils import (MessagingUtils,
+                                                            InstrumentVariablesUtils,
+                                                            StatusUtils, ReductionRunUtils)
+
 # pylint: disable=import-error, no-name-in-module
 from QueueProcessors.QueueProcessor.settings import (LOGGING, EMAIL_HOST,
                                                      EMAIL_PORT, EMAIL_ERROR_RECIPIENTS,
                                                      EMAIL_ERROR_SENDER, BASE_URL)
 
-from utils.clients.queue_client import QueueClient
+from utils.clients import QueueClient
 
 # Set up logging and attach the logging to the right part of the config.
 logging.config.dictConfig(LOGGING)

--- a/QueueProcessors/QueueProcessor/queueproc_utils/__init__.py
+++ b/QueueProcessors/QueueProcessor/queueproc_utils/__init__.py
@@ -1,0 +1,9 @@
+"""
+Import sub packages for ease of use and shorter import lines
+"""
+from .instrument_utils import InstrumentUtils
+from .instrument_variable_utils import InstrumentVariablesUtils
+from .messaging_utils import MessagingUtils
+from .reduction_run_utils import ReductionRunUtils
+from .status_utils import StatusUtils
+from .variable_utils import VariableUtils

--- a/QueueProcessors/QueueProcessor/queueproc_utils/instrument_variable_utils.py
+++ b/QueueProcessors/QueueProcessor/queueproc_utils/instrument_variable_utils.py
@@ -16,8 +16,7 @@ from QueueProcessors.QueueProcessor.orm_mapping import (InstrumentJoin, Notifica
                                                         Variable)
 # pylint:disable=no-name-in-module,import-error
 from QueueProcessors.QueueProcessor.settings import REDUCTION_DIRECTORY, LOGGING
-from QueueProcessors.QueueProcessor.queueproc_utils.instrument_utils import InstrumentUtils
-from QueueProcessors.QueueProcessor.queueproc_utils.variable_utils import VariableUtils
+from QueueProcessors.QueueProcessor.queueproc_utils import (InstrumentUtils, VariableUtils)
 
 
 # Set up logging and attach the logging to the right part of the config.

--- a/QueueProcessors/QueueProcessor/queueproc_utils/messaging_utils.py
+++ b/QueueProcessors/QueueProcessor/queueproc_utils/messaging_utils.py
@@ -7,7 +7,7 @@ from QueueProcessors.QueueProcessor.base import session
 from QueueProcessors.QueueProcessor.orm_mapping import DataLocation
 # pylint:disable=no-name-in-module,import-error
 from QueueProcessors.QueueProcessor.settings import LOGGING, FACILITY
-from utils.clients.queue_client import QueueClient
+from utils.clients import QueueClient
 
 # Set up logging and attach the logging to the right part of the config.
 logging.config.dictConfig(LOGGING)
@@ -31,7 +31,7 @@ class MessagingUtils(object):
     def _make_pending_msg(reduction_run):
         """ Creates a dict message from the given run, ready to be sent to ReductionPending. """
         # Deferred import to avoid circular dependencies
-        from ..utils.reduction_run_utils import ReductionRunUtils
+        from QueueProcessors.QueueProcessor.queueproc_utils import ReductionRunUtils
 
         script, arguments = ReductionRunUtils().get_script_and_arguments(reduction_run)
 

--- a/QueueProcessors/QueueProcessor/queueproc_utils/reduction_run_utils.py
+++ b/QueueProcessors/QueueProcessor/queueproc_utils/reduction_run_utils.py
@@ -9,11 +9,9 @@ from QueueProcessors.QueueProcessor.base import session
 from QueueProcessors.QueueProcessor.settings import LOGGING
 from QueueProcessors.QueueProcessor.orm_mapping import DataLocation, ReductionRun, RunJoin
 
-from QueueProcessors.QueueProcessor.queueproc_utils.instrument_variable_utils \
-    import InstrumentVariablesUtils
-from QueueProcessors.QueueProcessor.queueproc_utils.messaging_utils import MessagingUtils
-from QueueProcessors.QueueProcessor.queueproc_utils.status_utils import StatusUtils
-from QueueProcessors.QueueProcessor.queueproc_utils.variable_utils import VariableUtils
+from QueueProcessors.QueueProcessor.queueproc_utils import (InstrumentVariablesUtils,
+                                                            MessagingUtils, StatusUtils,
+                                                            VariableUtils)
 
 # Set up logging and attach the logging to the right part of the config.
 logging.config.dictConfig(LOGGING)

--- a/build/commands/__init__.py
+++ b/build/commands/__init__.py
@@ -1,0 +1,8 @@
+"""
+Import sub packages for ease of use and shorter import lines
+"""
+from .database import InitialiseTestDatabase
+from .help import Help
+from .installs import InstallExternals
+from .migrate_settings import MigrateTestSettings
+from .start import Start

--- a/monitors/end_of_run_monitor.py
+++ b/monitors/end_of_run_monitor.py
@@ -12,7 +12,7 @@ from watchdog.observers import Observer
 
 from monitors.settings import (INST_FOLDER, DATA_LOC, SUMMARY_LOC,
                                LAST_RUN_LOC, EORM_LOG_FILE, INSTRUMENTS)
-from utils.clients.queue_client import QueueClient
+from utils.clients import QueueClient
 
 logging.basicConfig(filename=EORM_LOG_FILE,
                     level=logging.INFO,

--- a/monitors/health_check.py
+++ b/monitors/health_check.py
@@ -11,7 +11,8 @@ import json
 from monitors import end_of_run_monitor
 from monitors import icat_monitor
 from monitors.settings import INSTRUMENTS
-from utils.clients import (DatabaseClient, QueueClient)
+from utils.clients.database_client import DatabaseClient
+from utils.clients import QueueClient
 from utils.clients.connection_exception import ConnectionException
 from utils.settings import ACTIVEMQ_SETTINGS
 from utils.project.structure import get_project_root

--- a/monitors/health_check.py
+++ b/monitors/health_check.py
@@ -11,8 +11,7 @@ import json
 from monitors import end_of_run_monitor
 from monitors import icat_monitor
 from monitors.settings import INSTRUMENTS
-from utils.clients.database_client import DatabaseClient
-from utils.clients.queue_client import QueueClient
+from utils.clients import (DatabaseClient, QueueClient)
 from utils.clients.connection_exception import ConnectionException
 from utils.settings import ACTIVEMQ_SETTINGS
 from utils.project.structure import get_project_root

--- a/monitors/icat_monitor.py
+++ b/monitors/icat_monitor.py
@@ -6,7 +6,7 @@ import datetime
 import logging
 import re
 
-from utils.clients.icat_client import ICATClient
+from utils.clients import ICATClient
 
 
 def get_run_number(file_name, instrument_prefix):

--- a/monitors/tests/test_end_of_run_monitors.py
+++ b/monitors/tests/test_end_of_run_monitors.py
@@ -13,9 +13,8 @@ from monitors.end_of_run_monitor import (InstrumentMonitor, get_file_extension,
                                          get_data_and_check, stop, main)
 from monitors.settings import INSTRUMENTS
 from monitors.tests.helpers import TestListener, create_connection
-from utils.clients.queue_client import QueueClient
-from utils.data_archive.data_archive_creator import DataArchiveCreator
-from utils.data_archive.archive_explorer import ArchiveExplorer
+from utils.clients import QueueClient
+from utils.data_archive import (DataArchiveCreator, ArchiveExplorer)
 from utils.project.structure import get_project_root
 
 

--- a/scripts/manual_submission_script/manual_submission.py
+++ b/scripts/manual_submission_script/manual_submission.py
@@ -7,10 +7,7 @@ import json
 import sys
 import argparse
 
-# The below is only a template on the repo
-# pylint: disable=import-error, no-name-in-module
-from utils.clients.icat_client import ICATClient
-from utils.clients.queue_client import QueueClient
+from utils.clients import (ICATClient, QueueClient)
 
 
 def submit_run(active_mq_client, rb_number, instrument, data_file_location, run_number):

--- a/scripts/manual_submission_script/tests/test_manual_submission.py
+++ b/scripts/manual_submission_script/tests/test_manual_submission.py
@@ -5,7 +5,7 @@ import unittest
 import json
 from mock import Mock, patch
 import scripts.manual_submission_script.manual_submission as ms
-from utils.clients.queue_client import QueueClient
+from utils.clients import QueueClient
 
 
 # pylint:disable=too-few-public-methods

--- a/setup.py
+++ b/setup.py
@@ -9,11 +9,9 @@ from setuptools import setup
 
 import platform
 
-from build.commands.database import InitialiseTestDatabase
-from build.commands.help import Help
-from build.commands.installs import InstallExternals
-from build.commands.migrate_settings import MigrateTestSettings
-from build.commands.start import Start
+from build.commands import (InitialiseTestDatabase, Help,
+                            InstallExternals, MigrateTestSettings,
+                            Start)
 
 setup_requires = ['Django',
                   'django_extensions',

--- a/utils/clients/__init__.py
+++ b/utils/clients/__init__.py
@@ -1,0 +1,6 @@
+"""
+Import sub packages for ease of use and shorter import lines
+"""
+from .database_client import DatabaseClient
+from .icat_client import ICATClient
+from .queue_client import QueueClient

--- a/utils/clients/__init__.py
+++ b/utils/clients/__init__.py
@@ -1,6 +1,5 @@
 """
 Import sub packages for ease of use and shorter import lines
 """
-from .database_client import DatabaseClient
 from .icat_client import ICATClient
 from .queue_client import QueueClient

--- a/utils/clients/tests/test_database_client.py
+++ b/utils/clients/tests/test_database_client.py
@@ -8,7 +8,7 @@ from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm.session import Session
 
 from utils.clients.connection_exception import ConnectionException
-from utils.clients.database_client import DatabaseClient
+from utils.clients import DatabaseClient
 from utils.clients.settings.client_settings_factory import ClientSettingsFactory
 
 

--- a/utils/clients/tests/test_database_client.py
+++ b/utils/clients/tests/test_database_client.py
@@ -8,7 +8,7 @@ from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm.session import Session
 
 from utils.clients.connection_exception import ConnectionException
-from utils.clients import DatabaseClient
+from utils.clients.database_client import DatabaseClient
 from utils.clients.settings.client_settings_factory import ClientSettingsFactory
 
 

--- a/utils/clients/tests/test_icat_client.py
+++ b/utils/clients/tests/test_icat_client.py
@@ -9,7 +9,7 @@ from mock import patch
 
 import icat
 
-from utils.clients.icat_client import ICATClient
+from utils.clients import ICATClient
 from utils.clients.settings.client_settings_factory import ClientSettingsFactory
 from utils.clients.connection_exception import ConnectionException
 

--- a/utils/clients/tests/test_queue_client.py
+++ b/utils/clients/tests/test_queue_client.py
@@ -6,7 +6,7 @@ import unittest
 from mock import patch, call
 
 from utils.clients.connection_exception import ConnectionException
-from utils.clients.queue_client import QueueClient
+from utils.clients import QueueClient
 from utils.clients.settings.client_settings_factory import ClientSettingsFactory
 
 

--- a/utils/data_archive/README.md
+++ b/utils/data_archive/README.md
@@ -35,7 +35,7 @@ specific files or directories in the data archive:
 ```python
 import datetime
 import time
-from utils.data_archive.archive_explorer import ArchiveExplorer
+from utils.data_archive import ArchiveExplorer
 
 archive_explorer = ArchiveExplorer('path/to/base-directory')
 
@@ -58,7 +58,7 @@ On initialisation, the ``DataArchiveCreator`` will need a base directory as inpu
 This will be where the ``data-archive`` directory is created. Once initialised, the object
 can be used to create the archive and files within it. The example below shows this:
 ```python
-from utils.data_archive.data_archive_creator import DataArchiveCreator
+from utils.data_archive import DataArchiveCreator
 
 data_archive_creator = DataArchiveCreator('base-directory')
 

--- a/utils/data_archive/__init__.py
+++ b/utils/data_archive/__init__.py
@@ -1,0 +1,5 @@
+"""
+Import sub packages for ease of use and shorter import lines
+"""
+from .archive_explorer import ArchiveExplorer
+from .data_archive_creator import DataArchiveCreator

--- a/utils/data_archive/tests/test_archive_explorer.py
+++ b/utils/data_archive/tests/test_archive_explorer.py
@@ -7,8 +7,7 @@ import shutil
 import tempfile
 import unittest
 
-from utils.data_archive.data_archive_creator import DataArchiveCreator
-from utils.data_archive.archive_explorer import ArchiveExplorer
+from utils.data_archive import (DataArchiveCreator, ArchiveExplorer)
 
 
 # pylint:disable=invalid-name

--- a/utils/data_archive/tests/test_data_archive_creator.py
+++ b/utils/data_archive/tests/test_data_archive_creator.py
@@ -5,7 +5,7 @@ import os
 import unittest
 import tempfile
 
-from utils.data_archive.data_archive_creator import DataArchiveCreator
+from utils.data_archive import DataArchiveCreator
 
 
 # pylint:disable=missing-docstring, protected-access, invalid-name, too-many-public-methods


### PR DESCRIPTION
### Changes
Simply the way we import some of our more commonly used classes by importing sub classes in some selected inits. These include:
* queue_proc_utils
* clients
* data_archive

### Test
* Perform a manual submission to validate that the queue is still working.
* Run the tests to ensure the imports are still working for the utils package