### PR TITLE
Remove unused test files for syntax error

### DIFF
--- a/WebApp/autoreduce_webapp/test_files/syntax_error/reduce.py
+++ b/WebApp/autoreduce_webapp/test_files/syntax_error/reduce.py
@@ -1,2 +1,0 @@
-# pylint:skip-file
-pass

--- a/WebApp/autoreduce_webapp/test_files/syntax_error/reduce_vars.py
+++ b/WebApp/autoreduce_webapp/test_files/syntax_error/reduce_vars.py
@@ -1,7 +1,0 @@
-# pylint:skip-file
-standard_vars = {
-    'test' = 'test'
-    syntaxerr
-}
-advanced_vars = {
-}

--- a/build/tests/test_pylint.sh
+++ b/build/tests/test_pylint.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-errorThreshold=82
+errorThreshold=80
 
 sourceRoot=$(git rev-parse --show-toplevel)
 currentDir=$(pwd)


### PR DESCRIPTION
Remove two unused test files to reduce the pylint score. Despite the skip-file flag being in the offending file, these still raise an error in pylint as they have syntax errors in them

