### PR TITLE
Move serialisation to queue client

### DIFF
--- a/monitors/end_of_run_monitor.py
+++ b/monitors/end_of_run_monitor.py
@@ -76,13 +76,10 @@ class InstrumentMonitor(FileSystemEventHandler):
         filename += get_file_extension(self.use_nexus)
         run_data_loc = os.path.join(self._get_instrument_data_folder_loc(),
                                     filename)
-        return {
-            "rb_number": self._get_rb_num(),
-            "instrument": self.instrument_name,
-            "data": run_data_loc,
-            "run_number": last_run_data[1],
-            "facility": "ISIS"
-        }
+        return self.client.serialise_data(rb_number=self._get_rb_num(),
+                                          instrument=self.instrument_name,
+                                          location=run_data_loc,
+                                          run_number=last_run_data[1])
 
     def _get_rb_num(self):
         """ Reads last line of summary.txt file and returns the RB number. """

--- a/scripts/manual_submission_script/manual_submission.py
+++ b/scripts/manual_submission_script/manual_submission.py
@@ -22,11 +22,10 @@ def submit_run(active_mq_client, rb_number, instrument, data_file_location, run_
     :param data_file_location: location of the data file
     :param run_number: run number fo the experiment
     """
-    data_dict = {"rb_number": rb_number,
-                 "instrument": instrument,
-                 "data": data_file_location,
-                 "run_number": run_number,
-                 "facility": "ISIS"}
+    data_dict = active_mq_client.serialise_data(rb_number=rb_number,
+                                                instrument=instrument,
+                                                location=data_file_location,
+                                                run_number=run_number)
 
     active_mq_client.send('/queue/DataReady', json.dumps(data_dict), priority=1)
     print("Submitted run: \r\n" + json.dumps(data_dict, indent=1))

--- a/utils/clients/queue_client.py
+++ b/utils/clients/queue_client.py
@@ -110,6 +110,17 @@ class QueueClient(AbstractClient):
         # pylint:disable=no-value-for-parameter
         self._connection.ack(frame)
 
+    @staticmethod
+    def serialise_data(rb_number, instrument, location, run_number):
+        """
+        Packs the specified data into a dictionary ready to send to a processor queue
+        """
+        return {'rb_number': rb_number,
+                'instrument': instrument,
+                'data': location,
+                'run_number': run_number,
+                'facility': 'ISIS'}
+
     # pylint:disable=too-many-arguments
     def send(self, destination, message, persistent='true', priority='4', delay=None):
         """

--- a/utils/clients/tests/test_queue_client.py
+++ b/utils/clients/tests/test_queue_client.py
@@ -56,6 +56,16 @@ class TestQueueClient(unittest.TestCase):
         client.disconnect()
         self.assertIsNone(client._connection)
 
+    def test_serialise_message(self):
+        """ Test data is correctly serialised """
+        client = QueueClient()
+        data = client.serialise_data('123', 'WISH', 'file/path', '001')
+        self.assertEqual(data['rb_number'], '123')
+        self.assertEqual(data['instrument'], 'WISH')
+        self.assertEqual(data['data'], 'file/path')
+        self.assertEqual(data['run_number'], '001')
+        self.assertEqual(data['facility'], 'ISIS')
+
     # pylint:disable=no-self-use
     def test_send_data(self):
         """ Test data can be sent without error """


### PR DESCRIPTION
Move the data serialisation to the queue client. The unit tests should be enough to validate that this change is successful

Fixes #140