### PR TITLE
ICAT Checker for EoRM

### DIFF
--- a/monitors/end_of_run_monitor.py
+++ b/monitors/end_of_run_monitor.py
@@ -14,7 +14,9 @@ from monitors.settings import (INST_FOLDER, DATA_LOC, SUMMARY_LOC,
                                LAST_RUN_LOC, EORM_LOG_FILE, INSTRUMENTS)
 from utils.clients.queue_client import QueueClient
 
-logging.basicConfig(filename=EORM_LOG_FILE, level=logging.INFO, format='%(asctime)s %(message)s')
+logging.basicConfig(filename=EORM_LOG_FILE,
+                    level=logging.INFO,
+                    format='%(asctime)s %(levelname)s [%(filename)s:%(lineno)d] %(message)s')
 observer = Observer()  # pylint: disable=invalid-name
 
 

--- a/monitors/end_of_run_monitor.py
+++ b/monitors/end_of_run_monitor.py
@@ -11,10 +11,10 @@ from watchdog.events import FileSystemEventHandler
 from watchdog.observers import Observer
 
 from monitors.settings import (INST_FOLDER, DATA_LOC, SUMMARY_LOC,
-                               LAST_RUN_LOC, LOG_FILE, INSTRUMENTS)
+                               LAST_RUN_LOC, EORM_LOG_FILE, INSTRUMENTS)
 from utils.clients.queue_client import QueueClient
 
-logging.basicConfig(filename=LOG_FILE, level=logging.INFO, format='%(asctime)s %(message)s')
+logging.basicConfig(filename=EORM_LOG_FILE, level=logging.INFO, format='%(asctime)s %(message)s')
 observer = Observer()  # pylint: disable=invalid-name
 
 

--- a/monitors/icat_monitor.py
+++ b/monitors/icat_monitor.py
@@ -25,6 +25,8 @@ def get_run_number(file_name, instrument_prefix):
 def get_cycle_dates(icat_client):
     """
     What cycles could the last run have been in?
+    If the search space isn't constrained in some way then it takes far too long
+    to sort the list of data files. Narrowing down the dates is part of this.
     """
     date = datetime.datetime.today().strftime("%Y-%m-%d")
     logging.info("Getting nearest cycles to current date (%s)" % date)
@@ -44,7 +46,10 @@ def get_cycle_dates(icat_client):
 
 def get_instrument_run(icat_client, inst_name, cycle_dates):
     """
-    Returns the last run on the named instrument in ICAT
+    Returns the last run on the named instrument in ICAT.
+    Gets the list of investigations on the provided instrument within the
+    previously established cycle dates. The query then descends the investigation
+    tree until it reaches the files.
     """
     logging.info("Grabbing recent data files for instrument: %s" % inst_name)
     datafiles = icat_client.execute_query("SELECT df FROM InvestigationInstrument ii"
@@ -68,7 +73,7 @@ def get_instrument_run(icat_client, inst_name, cycle_dates):
 
 def get_last_runs():
     """
-    Retrieves the last run from ICAT on an instrument.
+    Retrieves the last run from ICAT for each instrument.
     """
     logging.info("Connecting to ICAT")
     icat_client = ICATClient()
@@ -77,7 +82,7 @@ def get_last_runs():
     # First, constrain the search space by getting recent cycle dates
     cycle_dates = get_cycle_dates(icat_client)
 
-    # Loop through the instruments, finding the latest run number for each
+    # Loop through the instruments, finding the last run number for each
     for instrument in INSTRUMENTS:
         run_number = get_instrument_run(icat_client, instrument['name'], cycle_dates)
         last_runs[instrument['name']] = run_number

--- a/monitors/icat_monitor.py
+++ b/monitors/icat_monitor.py
@@ -1,6 +1,5 @@
 """
-Monitor ICAT for the latest run on an instrument. If end of run monitor is out of sync
-then restart it.
+Monitor ICAT for the latest run on an instrument.
 """
 
 import datetime
@@ -19,6 +18,9 @@ logging.basicConfig(filename=ICAT_MON_LOG_FILE,
 def get_run_number(file_name, instrument_prefix):
     """
     Extract the run number from a RAW or Nexus file
+    :param file_name: The RAW or Nexus file name
+    :param instrument_prefix: Prefix on file names for this instrument
+    :return: The run number of the input file as a string
     """
     # Check that the file name conforms to the expected pattern
     match = re.match("%s[0-9]*(.nxs|.raw)" % instrument_prefix, file_name, re.IGNORECASE)
@@ -37,6 +39,8 @@ def get_cycle_dates(icat_client):
     What cycles could the last run have been in?
     If the search space isn't constrained in some way then it takes far too long
     to sort the list of data files. Narrowing down the dates is part of this.
+    :param icat_client: ICAT Client
+    :return: Pair of dates as strings
     """
     date = datetime.datetime.today().strftime("%Y-%m-%d")
     logging.info("Getting nearest cycles to current date (%s)", date)
@@ -64,6 +68,10 @@ def get_last_run_in_dates(icat_client, instrument, cycle_dates):
     Gets the list of investigations on the provided instrument within the
     previously established cycle dates. The query then descends the investigation
     tree until it reaches the files.
+    :param icat_client: ICAT Client
+    :param instrument: Instrument list entry
+    :param cycle_dates: Pair of dates to look between for investigations
+    :return: The latest run number as a string
     """
     inst_name = instrument['name']
     inst_prefix = instrument['file_prefix']
@@ -93,6 +101,8 @@ def get_last_run_in_dates(icat_client, instrument, cycle_dates):
 def get_last_run(instrument):
     """
     Retrieves the last run from ICAT for an instrument
+    :param instrument: Instrument dictionary taken from the list
+    :return: The latest run number as a string
     """
     logging.info("Connecting to ICAT")
     icat_client = ICATClient()

--- a/monitors/icat_monitor.py
+++ b/monitors/icat_monitor.py
@@ -7,6 +7,14 @@ import datetime
 
 from utils.clients.icat_client import ICATClient
 
+def get_run_number(file_name, instrument_prefix):
+    """
+    Extract the run number from a RAW or nexus file
+    """
+    file_name = file_name.replace(instrument_prefix, '')
+    run_number = ''.join([s for s in file_name if s.isdigit()])
+    return run_number
+
 class ICATMonitor:
     """
     Monitors ICAT to ensure the end of run monitor is
@@ -40,19 +48,19 @@ class ICATMonitor:
         # Grab investigations from the current cycle on the relevant instrument
         # Then sort the data files to find the last one written.
         cycle_dates = self.get_cycle_dates()
-        print(cycle_dates)
+
         datafile = self.icat_client.execute_query("SELECT df FROM InvestigationInstrument ii"
                                                   " JOIN ii.investigation.datasets AS ds"
                                                   " JOIN ds.datafiles AS df"
                                                   " WHERE ii.instrument.name = 'SANS2D'"
                                                   " AND ii.investigation.startDate BETWEEN '%s' AND '%s'"
-                                                  " AND df.name LIKE '%%.nxs'"
+                                                  " AND (df.name LIKE '%%.nxs' OR df.name LIKE '%%.RAW')"
                                                   " ORDER BY df.datafileCreateTime DESC"
-                                                  " LIMIT 0,1" % cycle_dates)
-        print(datafile)
+                                                  " LIMIT 0,1" % cycle_dates)[0]
 
         # return the latest run number for each instrument
-
+        run_number = get_run_number(datafile.name, 'SANS2D')
+        print(run_number)
 
 mon = ICATMonitor()
 mon.get_last_runs()

--- a/monitors/icat_monitor.py
+++ b/monitors/icat_monitor.py
@@ -1,11 +1,17 @@
 """
-Monitor the ICAT for the latest run. If end of run monitor is out of sync
+Monitor ICAT for the latest run on each instrument. If end of run monitor is out of sync
 then restart it.
 """
 
 import datetime
+import logging
 
+from settings import INSTRUMENTS, ICAT_MON_LOG_FILE
 from utils.clients.icat_client import ICATClient
+
+
+logging.basicConfig(filename=ICAT_MON_LOG_FILE, level=logging.INFO, format='%(asctime)s %(message)s')
+
 
 def get_run_number(file_name, instrument_prefix):
     """
@@ -15,52 +21,69 @@ def get_run_number(file_name, instrument_prefix):
     run_number = ''.join([s for s in file_name if s.isdigit()])
     return run_number
 
-class ICATMonitor:
+
+def get_cycle_dates(icat_client):
     """
-    Monitors ICAT to ensure the end of run monitor is
-    keeping up with the latest runs.
+    What cycles could the last run have been in?
     """
-    def __init__(self):
-        self.last_runs = {}
-        self.icat_client = ICATClient()
+    date = datetime.datetime.today().strftime("%Y-%m-%d")
+    logging.info("Getting nearest cycles to current date (%s)" % date)
+    cycles = (icat_client.execute_query("SELECT c.startDate FROM FacilityCycle c"
+                                        " WHERE '%s' > c.endDate"
+                                        " ORDER BY c.startDate DESC"
+                                        " LIMIT 0,1" % date)[0],
+              icat_client.execute_query("SELECT c.endDate FROM FacilityCycle c"
+                                        " WHERE '%s' < c.startDate"
+                                        " ORDER BY c.endDate ASC"
+                                        " LIMIT 0,1" % date)[0])
+    # Convert them to strings
+    cycles_str = (cycles[0].strftime('%Y-%m-%d'), cycles[1].strftime('%Y-%m-%d'))
+    logging.info("Found nearest cycle dates: %s and %s" % cycles_str)
+    return cycles_str
 
-    def get_cycle_dates(self):
-        """
-        What cycles could the last run have been in?
-        """
-        date = datetime.datetime.today().strftime("%Y-%m-%d")
-        cycles = (self.icat_client.execute_query("SELECT c.startDate FROM FacilityCycle c"
-                                                 " WHERE '%s' > c.endDate"
-                                                 " ORDER BY c.startDate DESC"
-                                                 " LIMIT 0,1" % date)[0],
-                  self.icat_client.execute_query("SELECT c.endDate FROM FacilityCycle c"
-                                                 " WHERE '%s' < c.startDate"
-                                                 " ORDER BY c.endDate ASC"
-                                                 " LIMIT 0,1" % date)[0])
-        # Convert them to strings
-        cycles_str = (cycles[0].strftime('%Y-%m-%d'), cycles[1].strftime('%Y-%m-%d'))
-        return cycles_str
 
-    def get_last_runs(self):
-        """
-        Retrieves the last run from ICAT on an instrument.
-        """
-        # Grab investigations from the current cycle on the relevant instrument
-        # Then sort the data files to find the last one written.
-        cycle_dates = self.get_cycle_dates()
+def get_instrument_run(icat_client, inst_name, cycle_dates):
+    """
+    Returns the last run on the named instrument in ICAT
+    """
+    logging.info("Grabbing recent data files for instrument: %s" % inst_name)
+    datafiles = icat_client.execute_query("SELECT df FROM InvestigationInstrument ii"
+                                          " JOIN ii.investigation.datasets AS ds"
+                                          " JOIN ds.datafiles AS df"
+                                          " WHERE ii.instrument.fullName = '%s'"
+                                          " AND ii.investigation.startDate BETWEEN '%s' AND '%s'"
+                                          " AND (df.name LIKE '%%.nxs' OR df.name LIKE '%%.RAW')"
+                                          " ORDER BY df.datafileCreateTime DESC"
+                                          " LIMIT 0,1"
+                                          % (inst_name, cycle_dates[0], cycle_dates[1]))
+    run_number = u'0'
+    if len(datafiles) == 0:
+        logging.error("No files returned for instrument: %s" % inst_name)
+    else:
+        # Return the run number
+        run_number = get_run_number(datafiles[0].name, inst_name)
+        logging.info("Found last run for instrument: %s" % run_number)
+    return run_number
 
-        datafile = self.icat_client.execute_query("SELECT df FROM InvestigationInstrument ii"
-                                                  " JOIN ii.investigation.datasets AS ds"
-                                                  " JOIN ds.datafiles AS df"
-                                                  " WHERE ii.instrument.name = 'SANS2D'"
-                                                  " AND ii.investigation.startDate BETWEEN '%s' AND '%s'"
-                                                  " AND (df.name LIKE '%%.nxs' OR df.name LIKE '%%.RAW')"
-                                                  " ORDER BY df.datafileCreateTime DESC"
-                                                  " LIMIT 0,1" % cycle_dates)[0]
 
-        # return the latest run number for each instrument
-        run_number = get_run_number(datafile.name, 'SANS2D')
-        print(run_number)
+def get_last_runs():
+    """
+    Retrieves the last run from ICAT on an instrument.
+    """
+    logging.info("Connecting to ICAT")
+    icat_client = ICATClient()
+    last_runs = {}
 
-mon = ICATMonitor()
-mon.get_last_runs()
+    # First, constrain the search space by getting recent cycle dates
+    cycle_dates = get_cycle_dates(icat_client)
+
+    # Loop through the instruments, finding the latest run number for each
+    for instrument in INSTRUMENTS:
+        run_number = get_instrument_run(icat_client, instrument['name'], cycle_dates)
+        last_runs[instrument['name']] = run_number
+
+    logging.info("Last run dictionary: %s" % last_runs)
+    return last_runs
+
+
+get_last_runs()

--- a/monitors/icat_monitor.py
+++ b/monitors/icat_monitor.py
@@ -1,0 +1,58 @@
+"""
+Monitor the ICAT for the latest run. If end of run monitor is out of sync
+then restart it.
+"""
+
+import datetime
+
+from utils.clients.icat_client import ICATClient
+
+class ICATMonitor:
+    """
+    Monitors ICAT to ensure the end of run monitor is
+    keeping up with the latest runs.
+    """
+    def __init__(self):
+        self.last_runs = {}
+        self.icat_client = ICATClient()
+
+    def get_cycle_dates(self):
+        """
+        What cycles could the last run have been in?
+        """
+        date = datetime.datetime.today().strftime("%Y-%m-%d")
+        cycles = (self.icat_client.execute_query("SELECT c.startDate FROM FacilityCycle c"
+                                                 " WHERE '%s' > c.endDate"
+                                                 " ORDER BY c.startDate DESC"
+                                                 " LIMIT 0,1" % date)[0],
+                  self.icat_client.execute_query("SELECT c.endDate FROM FacilityCycle c"
+                                                 " WHERE '%s' < c.startDate"
+                                                 " ORDER BY c.endDate ASC"
+                                                 " LIMIT 0,1" % date)[0])
+        # Convert them to strings
+        cycles_str = (cycles[0].strftime('%Y-%m-%d'), cycles[1].strftime('%Y-%m-%d'))
+        return cycles_str
+
+    def get_last_runs(self):
+        """
+        Retrieves the last run from ICAT on an instrument.
+        """
+        # Grab investigations from the current cycle on the relevant instrument
+        # Then sort the data files to find the last one written.
+        cycle_dates = self.get_cycle_dates()
+        print(cycle_dates)
+        datafile = self.icat_client.execute_query("SELECT df FROM InvestigationInstrument ii"
+                                                  " JOIN ii.investigation.datasets AS ds"
+                                                  " JOIN ds.datafiles AS df"
+                                                  " WHERE ii.instrument.name = 'SANS2D'"
+                                                  " AND ii.investigation.startDate BETWEEN '%s' AND '%s'"
+                                                  " AND df.name LIKE '%%.nxs'"
+                                                  " ORDER BY df.datafileCreateTime DESC"
+                                                  " LIMIT 0,1" % cycle_dates)
+        print(datafile)
+
+        # return the latest run number for each instrument
+
+
+mon = ICATMonitor()
+mon.get_last_runs()

--- a/monitors/icat_monitor.py
+++ b/monitors/icat_monitor.py
@@ -7,7 +7,7 @@ import datetime
 import logging
 import re
 
-from monitors.settings import INSTRUMENTS, ICAT_MON_LOG_FILE
+from monitors.settings import ICAT_MON_LOG_FILE
 from utils.clients.icat_client import ICATClient
 
 
@@ -105,8 +105,3 @@ def get_last_run(instrument):
     # Find the last run number for the instrument
     last_run = get_last_run_in_dates(icat_client, instrument, cycle_dates)
     return last_run
-
-
-for inst in INSTRUMENTS:
-    print inst['name']
-    print get_last_run(inst)

--- a/monitors/test_settings.py
+++ b/monitors/test_settings.py
@@ -13,9 +13,9 @@ SUMMARY_LOC = os.path.join('logs', 'journal', 'summary.txt')
 LAST_RUN_LOC = os.path.join('logs', 'lastrun.txt')
 EORM_LOG_FILE = os.path.join(get_project_root(), 'logs', 'end_of_run_monitor.log')
 ICAT_MON_LOG_FILE = os.path.join(get_project_root(), 'logs', 'icat_monitor.log')
-INSTRUMENTS = [{'name': 'WISH', 'use_nexus': True},
-               {'name': 'GEM', 'use_nexus': True},
-               {'name': 'OSIRIS', 'use_nexus': True},
-               {'name': 'POLARIS', 'use_nexus': True},
-               {'name': 'MUSR', 'use_nexus': True},
-               {'name': 'POLREF', 'use_nexus': True}]
+INSTRUMENTS = [{'name': 'WISH', 'file_prefix': 'WISH', 'use_nexus': True},
+               {'name': 'GEM', 'file_prefix': 'GEM', 'use_nexus': True},
+               {'name': 'OSIRIS', 'file_prefix': 'OSIRIS', 'use_nexus': True},
+               {'name': 'POLARIS', 'file_prefix': 'POLARIS', 'use_nexus': True},
+               {'name': 'MUSR', 'file_prefix': 'MUSR', 'use_nexus': True},
+               {'name': 'POLREF', 'file_prefix': 'POLREF', 'use_nexus': True}]

--- a/monitors/test_settings.py
+++ b/monitors/test_settings.py
@@ -11,7 +11,8 @@ INST_FOLDER = os.path.join(get_project_root(), 'data-archive', 'NDX%s', 'Instrum
 DATA_LOC = os.path.join('data', 'cycle_%s')
 SUMMARY_LOC = os.path.join('logs', 'journal', 'summary.txt')
 LAST_RUN_LOC = os.path.join('logs', 'lastrun.txt')
-LOG_FILE = os.path.join(get_project_root(), 'logs', 'monitor.log')
+EORM_LOG_FILE = os.path.join(get_project_root(), 'logs', 'end_of_run_monitor.log')
+ICAT_MON_LOG_FILE = os.path.join(get_project_root(), 'logs', 'icat_monitor.log')
 INSTRUMENTS = [{'name': 'WISH', 'use_nexus': True},
                {'name': 'GEM', 'use_nexus': True},
                {'name': 'OSIRIS', 'use_nexus': True},

--- a/monitors/tests/test_icat_monitor.py
+++ b/monitors/tests/test_icat_monitor.py
@@ -30,6 +30,7 @@ class TestICATMonitor(unittest.TestCase):
         run_num = icat_monitor.get_run_number('WISH00042587.nxs', 'WISH')
         self.assertEqual(run_num, '00042587')
 
+    # pylint:disable=invalid-name
     def test_get_run_number_invalid_file(self):
         """
         Test handling of invalid file

--- a/monitors/tests/test_icat_monitor.py
+++ b/monitors/tests/test_icat_monitor.py
@@ -1,0 +1,35 @@
+
+import unittest
+import datetime
+from mock import Mock
+
+import monitors.icat_monitor as icat_monitor
+import monitors.settings
+
+
+# pylint:disable=too-few-public-methods
+class DataFile(object):
+    """
+    Basic data file representation for testing
+    """
+    def __init__(self, df_name):
+        self.name = df_name
+
+
+class TestICATMonitor(unittest.TestCase):
+    def test_get_run_number(self):
+        run_num = icat_monitor.get_run_number('WISH00042587.nxs', 'WISH')
+        self.assertEqual(run_num, '00042587')
+
+    def test_get_cycle_dates(self):
+        icat_client = Mock()
+        icat_client.execute_query = Mock(return_value=[datetime.datetime(2018, 10, 18)])
+        dates = icat_monitor.get_cycle_dates(icat_client)
+        self.assertEqual(dates[0], '2018-10-18')
+        self.assertEqual(dates[1], '2018-10-18')
+
+    def test_get_instrument_run(self):
+        icat_client = Mock()
+        icat_client.execute_query = Mock(return_value=[DataFile("GEM3223.nxs")])
+        run = icat_monitor.get_instrument_run(icat_client, 'GEM', ('2018-10-18', '2018-10-19'))
+        self.assertEqual(run, '3223')

--- a/monitors/tests/test_icat_monitor.py
+++ b/monitors/tests/test_icat_monitor.py
@@ -1,10 +1,13 @@
+"""
+Unit tests for the ICAT monitor
+"""
 
 import unittest
 import datetime
 from mock import Mock
 
 import monitors.icat_monitor as icat_monitor
-import monitors.settings
+from monitors.settings import INSTRUMENTS
 
 
 # pylint:disable=too-few-public-methods
@@ -17,19 +20,55 @@ class DataFile(object):
 
 
 class TestICATMonitor(unittest.TestCase):
+    """
+    Test cases for the ICAT monitor
+    """
     def test_get_run_number(self):
+        """
+        Test getting the run number from a file
+        """
         run_num = icat_monitor.get_run_number('WISH00042587.nxs', 'WISH')
         self.assertEqual(run_num, '00042587')
 
     def test_get_cycle_dates(self):
+        """
+        Test handling of cycle dates from ICAT
+        """
         icat_client = Mock()
         icat_client.execute_query = Mock(return_value=[datetime.datetime(2018, 10, 18)])
         dates = icat_monitor.get_cycle_dates(icat_client)
         self.assertEqual(dates[0], '2018-10-18')
         self.assertEqual(dates[1], '2018-10-18')
 
-    def test_get_instrument_run(self):
+    def test_get_cycle_dates_no_cycles(self):
+        """
+        Test handling of cycles when none are returned
+        """
         icat_client = Mock()
-        icat_client.execute_query = Mock(return_value=[DataFile("GEM3223.nxs")])
-        run = icat_monitor.get_instrument_run(icat_client, 'GEM', ('2018-10-18', '2018-10-19'))
+        icat_client.execute_query = Mock(return_value=[])
+        dates = icat_monitor.get_cycle_dates(icat_client)
+        self.assertEqual(dates, None)
+
+    def test_get_last_run_in_dates(self):
+        """
+        Test handling of run retrieval from ICAT
+        """
+        icat_client = Mock()
+        file_name = INSTRUMENTS[0]['file_prefix'] + '3223.nxs'
+        icat_client.execute_query = Mock(return_value=[DataFile(file_name)])
+        run = icat_monitor.get_last_run_in_dates(icat_client,
+                                                 INSTRUMENTS[0],
+                                                 ('2018-10-18', '2018-10-19'))
         self.assertEqual(run, '3223')
+
+    # pylint:disable=invalid-name
+    def test_get_last_run_in_dates_no_files(self):
+        """
+        Test handling of runs when no files are returned
+        """
+        icat_client = Mock()
+        icat_client.execute_query = Mock(return_value=[])
+        run = icat_monitor.get_last_run_in_dates(icat_client,
+                                                 INSTRUMENTS[0],
+                                                 ('2018-10-18', '2018-10-19'))
+        self.assertEqual(run, None)

--- a/monitors/tests/test_icat_monitor.py
+++ b/monitors/tests/test_icat_monitor.py
@@ -30,6 +30,10 @@ class TestICATMonitor(unittest.TestCase):
         run_num = icat_monitor.get_run_number('WISH00042587.nxs', 'WISH')
         self.assertEqual(run_num, '00042587')
 
+    def test_get_run_number_invalid_file(self):
+        run_num = icat_monitor.get_run_number('WISH_HELLO.RAW', 'WISH')
+        self.assertEqual(run_num, None)
+
     def test_get_cycle_dates(self):
         """
         Test handling of cycle dates from ICAT

--- a/monitors/tests/test_icat_monitor.py
+++ b/monitors/tests/test_icat_monitor.py
@@ -31,6 +31,9 @@ class TestICATMonitor(unittest.TestCase):
         self.assertEqual(run_num, '00042587')
 
     def test_get_run_number_invalid_file(self):
+        """
+        Test handling of invalid file
+        """
         run_num = icat_monitor.get_run_number('WISH_HELLO.RAW', 'WISH')
         self.assertEqual(run_num, None)
 


### PR DESCRIPTION
ICAT checker that accepts as input an element from the INSTRUMENTS list and returns the latest run number from that instrument according to ICAT. The list of instruments can be found in the test_settings.py of the monitors directory.

I also expanded logging so it includes the log level, file name and line number in both EoRM and the ICAT checker. I think this will make it easier to track down bugs.

A 'file_prefix' attribute has been added to the instrument dictionary because not all instruments prefix their files with the full name of the instrument. e.g. 'MERLIN' and 'MER'

## To Test

* Run the unit tests. No special configuration is required to do this.
* Run icat_monitor.py against a real ICAT. It should print out the latest run number for each instrument in the INSTRUMENTS list. This can be verified by looking at the last_run.txt of each instrument.

Fixes #203 