### PR TITLE
ICAT checker and EoRM link

### DIFF
--- a/monitors/end_of_run_monitor.py
+++ b/monitors/end_of_run_monitor.py
@@ -21,6 +21,7 @@ logging.basicConfig(filename=EORM_LOG_FILE,
                     format='%(asctime)s %(levelname)s [%(filename)s:%(lineno)d] %(message)s')
 observer = Observer()  # pylint: disable=invalid-name
 
+
 def write_last_run(file_name, instrument, last_run):
     """
     Write the last run for an instrument to the last runs CSV file
@@ -52,6 +53,7 @@ def write_last_run(file_name, instrument, last_run):
     for row in last_run_rows:
         last_run_writer.writerow(row)
     last_run_file.close()
+
 
 def get_file_extension(use_nxs):
     """ Choose the data extension based on the boolean. """

--- a/monitors/end_of_run_monitor.py
+++ b/monitors/end_of_run_monitor.py
@@ -6,11 +6,11 @@ import json
 import logging
 import os
 import threading
-import csv
 
 from watchdog.events import FileSystemEventHandler
 from watchdog.observers import Observer
 
+import monitors.health_check
 from monitors.settings import (INST_FOLDER, DATA_LOC, SUMMARY_LOC,
                                LAST_RUN_LOC, EORM_LOG_FILE, INSTRUMENTS,
                                EORM_LAST_RUN_FILE)
@@ -35,39 +35,6 @@ def get_data_and_check(last_run_file):
     if len(data) != 3:
         raise Exception("Unexpected last run file format")
     return data
-
-
-def write_last_run(instrument, last_run):
-    """
-    Write the last run for an instrument to the last runs CSV file
-    """
-    try:
-        # Attempt to open and read the CSV file
-        with open(EORM_LAST_RUN_FILE, 'rb') as last_run_file:
-            last_run_rows = []
-            last_run_reader = csv.reader(last_run_file)
-            found_inst = False
-            # Attempt to find the instrument in the CSV file
-            for row in last_run_reader:
-                if row[0] == instrument:
-                    row[1] = last_run
-                    found_inst = True
-                last_run_rows.append(row)
-
-            # If the instrument isn't found, then we need to add it
-            if not found_inst:
-                row = [instrument, last_run]
-                last_run_rows.append(row)
-    except IOError:
-        # File hasn't been created yet
-        last_run_rows = [[instrument, last_run]]
-
-    # Write each row of the CSV back to the file
-    last_run_file = open(EORM_LAST_RUN_FILE, 'wb+')
-    last_run_writer = csv.writer(last_run_file)
-    for row in last_run_rows:
-        last_run_writer.writerow(row)
-    last_run_file.close()
 
 
 class InstrumentMonitor(FileSystemEventHandler):
@@ -153,7 +120,9 @@ class InstrumentMonitor(FileSystemEventHandler):
                     logging.debug("self.last_run updated to be %s", str(data[1]))
                     self.send_message(data)
                     # Write to the last runs file for the health checker
-                    write_last_run(self.instrument_name, self.last_run)
+                    monitors.health_check.write_last_run(EORM_LAST_RUN_FILE,
+                                                         self.instrument_name,
+                                                         self.last_run)
         except Exception as exp:  # pylint: disable=broad-except
             # if this code can't be executed it will raise a logging error towards the user.
             logging.exception("Error on loading file: %s", exp.message, exc_info=True)

--- a/monitors/end_of_run_monitor.py
+++ b/monitors/end_of_run_monitor.py
@@ -43,7 +43,7 @@ def write_last_run(instrument, last_run):
     """
     try:
         # Attempt to open and read the CSV file
-        with open(EORM_LAST_RUN_FILE, 'r') as last_run_file:
+        with open(EORM_LAST_RUN_FILE, 'rb') as last_run_file:
             last_run_rows = []
             last_run_reader = csv.reader(last_run_file)
             found_inst = False

--- a/monitors/health_check.py
+++ b/monitors/health_check.py
@@ -35,13 +35,11 @@ class HealthCheckThread(threading.Thread):
         logging.info('Main Health check thread loop stopped')
 
     @staticmethod
-    def health_check():
+    def icat_check():
         """
-        Check to see if the service is still running as expected
-        :return: True: Service is okay, False: Service requires restart
+        Check the last run to be inserted into ICAT for each instrument
+        :return: True if the latest run in ICAT is the same or older than the one known by EoRM
         """
-        logging.info('Performing Health Check at %s', datetime.now())
-
         # Loop through the instrument list, getting the last run on each
         with open(EORM_LAST_RUN_FILE, 'rb') as last_run_file:
             last_run_reader = csv.reader(last_run_file)
@@ -52,6 +50,15 @@ class HealthCheckThread(threading.Thread):
                     if int(icat_last_run) > int(row[1]):
                         return False
         return True
+
+    @staticmethod
+    def health_check():
+        """
+        Check to see if the service is still running as expected
+        :return: True: Service is okay, False: Service requires restart
+        """
+        logging.info('Performing Health Check at %s', datetime.now())
+        return HealthCheckThread.icat_check()
 
     @staticmethod
     def restart_service():

--- a/monitors/health_check.py
+++ b/monitors/health_check.py
@@ -10,6 +10,7 @@ import os
 
 from monitors import icat_monitor
 from monitors import end_of_run_monitor
+from monitors.end_of_run_monitor import write_last_run
 from monitors.settings import (EORM_LAST_RUN_FILE, INSTRUMENTS, INST_FOLDER,
                                LAST_RUN_LOC)
 

--- a/monitors/health_check.py
+++ b/monitors/health_check.py
@@ -55,14 +55,17 @@ class HealthCheckThread(threading.Thread):
         """
         logging.info('Performing Health Check at %s', datetime.now())
         # Loop through the instrument list, getting the last run on each
-        with open(EORM_LAST_RUN_FILE, 'rb') as last_run_file:
-            last_run_reader = csv.reader(last_run_file)
-            for row in last_run_reader:
-                # Query the ICAT
-                icat_last_run = icat_monitor.get_last_run(row[0])
-                if icat_last_run:
-                    if int(icat_last_run) > int(row[1]):
-                        return False
+        try:
+            with open(EORM_LAST_RUN_FILE, 'rb') as last_run_file:
+                last_run_reader = csv.reader(last_run_file)
+                for row in last_run_reader:
+                    # Query the ICAT
+                    icat_last_run = icat_monitor.get_last_run(row[0])
+                    if icat_last_run:
+                        if int(icat_last_run) > int(row[1]):
+                            return False
+        except IOError:
+            logging.Error("Unable to open last runs file: ", EORM_LAST_RUN_FILE)
         return True
 
     @staticmethod

--- a/monitors/health_check.py
+++ b/monitors/health_check.py
@@ -65,7 +65,7 @@ class HealthCheckThread(threading.Thread):
                         if int(icat_last_run) > int(row[1]):
                             return False
         except IOError:
-            logging.error("Unable to open last runs file: ", EORM_LAST_RUN_FILE)
+            logging.error("Unable to open last runs file: %s", EORM_LAST_RUN_FILE)
         return True
 
     @staticmethod

--- a/monitors/health_check.py
+++ b/monitors/health_check.py
@@ -8,43 +8,10 @@ import threading
 import csv
 import os
 
-from monitors import end_of_run_monitor
 from monitors import icat_monitor
+from monitors import end_of_run_monitor
 from monitors.settings import (EORM_LAST_RUN_FILE, INSTRUMENTS, INST_FOLDER,
                                LAST_RUN_LOC)
-
-
-def write_last_run(file_name, instrument, last_run):
-    """
-    Write the last run for an instrument to the last runs CSV file
-    """
-    try:
-        # Attempt to open and read the CSV file
-        with open(file_name, 'rb') as last_run_file:
-            last_run_rows = []
-            last_run_reader = csv.reader(last_run_file)
-            found_inst = False
-            # Attempt to find the instrument in the CSV file
-            for row in last_run_reader:
-                if row[0] == instrument:
-                    row[1] = last_run
-                    found_inst = True
-                last_run_rows.append(row)
-
-            # If the instrument isn't found, then we need to add it
-            if not found_inst:
-                row = [instrument, last_run]
-                last_run_rows.append(row)
-    except IOError:
-        # File hasn't been created yet
-        last_run_rows = [[instrument, last_run]]
-
-    # Write each row of the CSV back to the file
-    last_run_file = open(file_name, 'wb+')
-    last_run_writer = csv.writer(last_run_file)
-    for row in last_run_rows:
-        last_run_writer.writerow(row)
-    last_run_file.close()
 
 
 # pylint:disable=missing-docstring

--- a/monitors/health_check.py
+++ b/monitors/health_check.py
@@ -65,7 +65,7 @@ class HealthCheckThread(threading.Thread):
                         if int(icat_last_run) > int(row[1]):
                             return False
         except IOError:
-            logging.Error("Unable to open last runs file: ", EORM_LAST_RUN_FILE)
+            logging.error("Unable to open last runs file: ", EORM_LAST_RUN_FILE)
         return True
 
     @staticmethod

--- a/monitors/health_check.py
+++ b/monitors/health_check.py
@@ -6,10 +6,45 @@ import logging
 import time
 import threading
 import csv
+import os
 
 from monitors import end_of_run_monitor
 from monitors import icat_monitor
-from monitors.settings import EORM_LAST_RUN_FILE
+from monitors.settings import (EORM_LAST_RUN_FILE, INSTRUMENTS, INST_FOLDER,
+                               LAST_RUN_LOC)
+
+
+def write_last_run(file_name, instrument, last_run):
+    """
+    Write the last run for an instrument to the last runs CSV file
+    """
+    try:
+        # Attempt to open and read the CSV file
+        with open(file_name, 'rb') as last_run_file:
+            last_run_rows = []
+            last_run_reader = csv.reader(last_run_file)
+            found_inst = False
+            # Attempt to find the instrument in the CSV file
+            for row in last_run_reader:
+                if row[0] == instrument:
+                    row[1] = last_run
+                    found_inst = True
+                last_run_rows.append(row)
+
+            # If the instrument isn't found, then we need to add it
+            if not found_inst:
+                row = [instrument, last_run]
+                last_run_rows.append(row)
+    except IOError:
+        # File hasn't been created yet
+        last_run_rows = [[instrument, last_run]]
+
+    # Write each row of the CSV back to the file
+    last_run_file = open(file_name, 'wb+')
+    last_run_writer = csv.writer(last_run_file)
+    for row in last_run_rows:
+        last_run_writer.writerow(row)
+    last_run_file.close()
 
 
 # pylint:disable=missing-docstring
@@ -24,6 +59,9 @@ class HealthCheckThread(threading.Thread):
         """
         Perform a service health check every time_interval
         """
+        # Create initial last runs CSV
+        HealthCheckThread.create_last_runs_csv()
+
         while self.exit is False:
             service_okay = self.health_check()
             if service_okay:
@@ -35,11 +73,27 @@ class HealthCheckThread(threading.Thread):
         logging.info('Main Health check thread loop stopped')
 
     @staticmethod
-    def icat_check():
+    def create_last_runs_csv():
         """
-        Check the last run to be inserted into ICAT for each instrument
-        :return: True if the latest run in ICAT is the same or older than the one known by EoRM
+        Populate the last runs CSV with initial data
         """
+        for inst in INSTRUMENTS:
+            last_run_file = os.path.join((INST_FOLDER % inst['name']), LAST_RUN_LOC)
+            try:
+                with open(last_run_file, 'r') as last_run_file:
+                    line = last_run_file.readline()
+                    parts = line.split(' ')
+                    write_last_run(EORM_LAST_RUN_FILE, inst['name'], parts[1])
+            except IOError:
+                logging.error("Couldn't find last_run.txt for instrument: %s", inst['name'])
+
+    @staticmethod
+    def health_check():
+        """
+        Check to see if the service is still running as expected
+        :return: True: Service is okay, False: Service requires restart
+        """
+        logging.info('Performing Health Check at %s', datetime.now())
         # Loop through the instrument list, getting the last run on each
         with open(EORM_LAST_RUN_FILE, 'rb') as last_run_file:
             last_run_reader = csv.reader(last_run_file)
@@ -50,15 +104,6 @@ class HealthCheckThread(threading.Thread):
                     if int(icat_last_run) > int(row[1]):
                         return False
         return True
-
-    @staticmethod
-    def health_check():
-        """
-        Check to see if the service is still running as expected
-        :return: True: Service is okay, False: Service requires restart
-        """
-        logging.info('Performing Health Check at %s', datetime.now())
-        return HealthCheckThread.icat_check()
 
     @staticmethod
     def restart_service():

--- a/monitors/health_check.py
+++ b/monitors/health_check.py
@@ -7,6 +7,8 @@ import time
 import threading
 
 from monitors import end_of_run_monitor
+from monitors import icat_monitor
+from settings import INSTRUMENTS
 
 
 # pylint:disable=missing-docstring
@@ -38,6 +40,11 @@ class HealthCheckThread(threading.Thread):
         :return: True: Service is okay, False: Service requires restart
         """
         logging.info('Performing Health Check at %s', datetime.now())
+
+        # Loop through the instrument list, getting the last run on each
+        for inst in INSTRUMENTS:
+            icat_last_run = icat_monitor.get_last_run(inst)
+           # eorm_last_run =
         return True
 
     @staticmethod

--- a/monitors/health_check.py
+++ b/monitors/health_check.py
@@ -9,7 +9,7 @@ import csv
 
 from monitors import end_of_run_monitor
 from monitors import icat_monitor
-from settings import (INSTRUMENTS, EORM_LAST_RUN_FILE)
+from monitors.settings import EORM_LAST_RUN_FILE
 
 
 # pylint:disable=missing-docstring

--- a/monitors/health_check.py
+++ b/monitors/health_check.py
@@ -6,13 +6,11 @@ import logging
 import time
 import threading
 import csv
-import os
 
 from monitors import icat_monitor
 from monitors import end_of_run_monitor
 from monitors.end_of_run_monitor import write_last_run
-from monitors.settings import (EORM_LAST_RUN_FILE, INSTRUMENTS, INST_FOLDER,
-                               LAST_RUN_LOC)
+from monitors.settings import (EORM_LAST_RUN_FILE, INSTRUMENTS)
 
 
 # pylint:disable=missing-docstring
@@ -46,14 +44,8 @@ class HealthCheckThread(threading.Thread):
         Populate the last runs CSV with initial data
         """
         for inst in INSTRUMENTS:
-            last_run_file = os.path.join((INST_FOLDER % inst['name']), LAST_RUN_LOC)
-            try:
-                with open(last_run_file, 'r') as last_run_file:
-                    line = last_run_file.readline()
-                    parts = line.split(' ')
-                    write_last_run(EORM_LAST_RUN_FILE, inst['name'], parts[1])
-            except IOError:
-                logging.error("Couldn't find last_run.txt for instrument: %s", inst['name'])
+            last_run = icat_monitor.get_last_run(inst['name'])
+            write_last_run(EORM_LAST_RUN_FILE, inst['name'], last_run)
 
     @staticmethod
     def health_check():

--- a/monitors/icat_monitor.py
+++ b/monitors/icat_monitor.py
@@ -6,13 +6,7 @@ import datetime
 import logging
 import re
 
-from monitors.settings import ICAT_MON_LOG_FILE
 from utils.clients.icat_client import ICATClient
-
-
-logging.basicConfig(filename=ICAT_MON_LOG_FILE,
-                    level=logging.INFO,
-                    format='%(asctime)s %(levelname)s [%(filename)s:%(lineno)d] %(message)s')
 
 
 def get_run_number(file_name, instrument_prefix):

--- a/monitors/icat_monitor.py
+++ b/monitors/icat_monitor.py
@@ -73,10 +73,7 @@ def get_last_run_in_dates(icat_client, instrument, cycle_dates):
     :param cycle_dates: Pair of dates to look between for investigations
     :return: The latest run number as a string
     """
-    inst_name = instrument['name']
-    inst_prefix = instrument['file_prefix']
-
-    logging.info("Grabbing recent data files for instrument: %s", inst_name)
+    logging.info("Grabbing recent data files for instrument: %s", instrument)
     datafiles = icat_client.execute_query("SELECT df FROM InvestigationInstrument ii"
                                           " JOIN ii.investigation.datasets AS ds"
                                           " JOIN ds.datafiles AS df"
@@ -85,14 +82,14 @@ def get_last_run_in_dates(icat_client, instrument, cycle_dates):
                                           " AND (df.name LIKE '%%.nxs' OR df.name LIKE '%%.RAW')"
                                           " ORDER BY df.datafileCreateTime DESC"
                                           " LIMIT 0,1"
-                                          % (inst_name, cycle_dates[0], cycle_dates[1]))
+                                          % (instrument, cycle_dates[0], cycle_dates[1]))
 
     if not datafiles:
-        logging.error("No files returned for instrument: %s", inst_name)
+        logging.error("No files returned for instrument: %s", instrument)
         return None
 
     # Return the run number
-    run_number = get_run_number(datafiles[0].name, inst_prefix)
+    run_number = get_run_number(datafiles[0].name, instrument)
     if run_number:
         logging.info("Found last run for instrument: %s", run_number)
     return run_number

--- a/monitors/test_settings.py
+++ b/monitors/test_settings.py
@@ -13,9 +13,9 @@ SUMMARY_LOC = os.path.join('logs', 'journal', 'summary.txt')
 LAST_RUN_LOC = os.path.join('logs', 'lastrun.txt')
 EORM_LOG_FILE = os.path.join(get_project_root(), 'logs', 'end_of_run_monitor.log')
 EORM_LAST_RUN_FILE = os.path.join(get_project_root(), 'logs', 'eorm_last_runs.csv')
-INSTRUMENTS = [{'name': 'WISH', 'file_prefix': 'WISH', 'use_nexus': True},
-               {'name': 'GEM', 'file_prefix': 'GEM', 'use_nexus': True},
-               {'name': 'OSIRIS', 'file_prefix': 'OSIRIS', 'use_nexus': True},
-               {'name': 'POLARIS', 'file_prefix': 'POLARIS', 'use_nexus': True},
-               {'name': 'MUSR', 'file_prefix': 'MUSR', 'use_nexus': True},
-               {'name': 'POLREF', 'file_prefix': 'POLREF', 'use_nexus': True}]
+INSTRUMENTS = [{'name': 'WISH', 'use_nexus': True},
+               {'name': 'GEM', 'use_nexus': True},
+               {'name': 'OSIRIS', 'use_nexus': True},
+               {'name': 'POLARIS', 'use_nexus': True},
+               {'name': 'MUSR', 'use_nexus': True},
+               {'name': 'POLREF', 'use_nexus': True}]

--- a/monitors/test_settings.py
+++ b/monitors/test_settings.py
@@ -12,6 +12,7 @@ DATA_LOC = os.path.join('data', 'cycle_%s')
 SUMMARY_LOC = os.path.join('logs', 'journal', 'summary.txt')
 LAST_RUN_LOC = os.path.join('logs', 'lastrun.txt')
 EORM_LOG_FILE = os.path.join(get_project_root(), 'logs', 'end_of_run_monitor.log')
+EORM_LAST_RUN_FILE = os.path.join(get_project_root(), 'logs', 'eorm_last_runs.csv')
 INSTRUMENTS = [{'name': 'WISH', 'file_prefix': 'WISH', 'use_nexus': True},
                {'name': 'GEM', 'file_prefix': 'GEM', 'use_nexus': True},
                {'name': 'OSIRIS', 'file_prefix': 'OSIRIS', 'use_nexus': True},

--- a/monitors/test_settings.py
+++ b/monitors/test_settings.py
@@ -12,7 +12,6 @@ DATA_LOC = os.path.join('data', 'cycle_%s')
 SUMMARY_LOC = os.path.join('logs', 'journal', 'summary.txt')
 LAST_RUN_LOC = os.path.join('logs', 'lastrun.txt')
 EORM_LOG_FILE = os.path.join(get_project_root(), 'logs', 'end_of_run_monitor.log')
-ICAT_MON_LOG_FILE = os.path.join(get_project_root(), 'logs', 'icat_monitor.log')
 INSTRUMENTS = [{'name': 'WISH', 'file_prefix': 'WISH', 'use_nexus': True},
                {'name': 'GEM', 'file_prefix': 'GEM', 'use_nexus': True},
                {'name': 'OSIRIS', 'file_prefix': 'OSIRIS', 'use_nexus': True},

--- a/monitors/tests/test_end_of_run_monitors.py
+++ b/monitors/tests/test_end_of_run_monitors.py
@@ -5,14 +5,11 @@ import os
 import unittest
 import threading
 import time
-import csv
 
 from watchdog.events import FileSystemEvent
 
-from monitors.end_of_run_monitor import (InstrumentMonitor, get_file_extension, get_data_and_check,
-                                         write_last_run)
+from monitors.end_of_run_monitor import InstrumentMonitor, get_file_extension, get_data_and_check
 from monitors.tests.helpers import TestListener, create_connection
-from monitors.settings import EORM_LAST_RUN_FILE
 from utils.clients.queue_client import QueueClient
 from utils.data_archive.data_archive_creator import DataArchiveCreator
 from utils.data_archive.archive_explorer import ArchiveExplorer
@@ -117,23 +114,6 @@ class TestEndOfRunMonitor(unittest.TestCase):
                                     'WISH12346.nxs')
         updated_dict["data"] = new_data_loc
         self.assertEqual(message, updated_dict)
-
-    def test_write_last_run(self):
-        """
-        Test write of the last runs CSV file
-        """
-        write_last_run('GEM', '1234')
-        write_last_run('WISH', '1234')
-        write_last_run('POLARIS', '1234')
-
-        row_array = [['GEM', '1234'], ['WISH', '1234'], ['POLARIS', '1234']]
-
-        # Now read back using the CSV reader
-        with open(EORM_LAST_RUN_FILE, 'r') as last_run_file:
-            last_run_reader = csv.reader(last_run_file)
-            for (i, row) in enumerate(last_run_reader):
-                self.assertEqual(row_array[i][0], row[0])
-                self.assertEqual(row_array[i][1], row[1])
 
     def _get_message_from_queues(self):
         """

--- a/monitors/tests/test_end_of_run_monitors.py
+++ b/monitors/tests/test_end_of_run_monitors.py
@@ -5,10 +5,12 @@ import os
 import unittest
 import threading
 import time
+import csv
 
 from watchdog.events import FileSystemEvent
 
-from monitors.end_of_run_monitor import InstrumentMonitor, get_file_extension, get_data_and_check
+from monitors.end_of_run_monitor import (InstrumentMonitor, get_file_extension, get_data_and_check,
+                                         write_last_run)
 from monitors.tests.helpers import TestListener, create_connection
 from utils.clients.queue_client import QueueClient
 from utils.data_archive.data_archive_creator import DataArchiveCreator
@@ -85,6 +87,26 @@ class TestEndOfRunMonitor(unittest.TestCase):
     def test_get_rb_number(self):
         rb_number = self.monitor._get_rb_num()
         self.assertEqual(rb_number, '111')
+
+    def test_write_last_run(self):
+        """
+        Test write of the last runs CSV file
+        """
+        test_file = "last_runs_test.csv"
+        write_last_run(test_file, 'GEM', '1234')
+        write_last_run(test_file, 'WISH', '1234')
+        write_last_run(test_file, 'POLARIS', '1234')
+
+        row_array = [['GEM', '1234'], ['WISH', '1234'], ['POLARIS', '1234']]
+
+        # Now read back using the CSV reader
+        with open(test_file, 'r') as last_run_file:
+            last_run_reader = csv.reader(last_run_file)
+            for (i, row) in enumerate(last_run_reader):
+                self.assertEqual(row_array[i][0], row[0])
+                self.assertEqual(row_array[i][1], row[1])
+
+        os.remove(test_file)
 
     def test_build_dict(self):
         # input is return value of get_data_and_check

--- a/monitors/tests/test_end_of_run_monitors.py
+++ b/monitors/tests/test_end_of_run_monitors.py
@@ -12,11 +12,11 @@ from watchdog.events import FileSystemEvent
 from monitors.end_of_run_monitor import (InstrumentMonitor, get_file_extension, get_data_and_check,
                                          write_last_run)
 from monitors.tests.helpers import TestListener, create_connection
+from monitors.settings import EORM_LAST_RUN_FILE
 from utils.clients.queue_client import QueueClient
 from utils.data_archive.data_archive_creator import DataArchiveCreator
 from utils.data_archive.archive_explorer import ArchiveExplorer
 from utils.project.structure import get_project_root
-from monitors.settings import EORM_LAST_RUN_FILE
 
 
 # pylint:disable=missing-docstring,protected-access

--- a/monitors/tests/test_end_of_run_monitors.py
+++ b/monitors/tests/test_end_of_run_monitors.py
@@ -5,15 +5,18 @@ import os
 import unittest
 import threading
 import time
+import csv
 
 from watchdog.events import FileSystemEvent
 
-from monitors.end_of_run_monitor import InstrumentMonitor, get_file_extension, get_data_and_check
+from monitors.end_of_run_monitor import (InstrumentMonitor, get_file_extension, get_data_and_check,
+                                         write_last_run)
 from monitors.tests.helpers import TestListener, create_connection
 from utils.clients.queue_client import QueueClient
 from utils.data_archive.data_archive_creator import DataArchiveCreator
 from utils.data_archive.archive_explorer import ArchiveExplorer
 from utils.project.structure import get_project_root
+from monitors.settings import EORM_LAST_RUN_FILE
 
 
 # pylint:disable=missing-docstring,protected-access
@@ -114,6 +117,23 @@ class TestEndOfRunMonitor(unittest.TestCase):
                                     'WISH12346.nxs')
         updated_dict["data"] = new_data_loc
         self.assertEqual(message, updated_dict)
+
+    def test_write_last_run(self):
+        """
+        Test write of the last runs CSV file
+        """
+        write_last_run('GEM', '1234')
+        write_last_run('WISH', '1234')
+        write_last_run('POLARIS', '1234')
+
+        row_array = [['GEM', '1234'], ['WISH', '1234'], ['POLARIS', '1234']]
+
+        # Now read back using the CSV reader
+        with open(EORM_LAST_RUN_FILE, 'r') as last_run_file:
+            last_run_reader = csv.reader(last_run_file)
+            for (i, row) in enumerate(last_run_reader):
+                self.assertEqual(row_array[i][0], row[0])
+                self.assertEqual(row_array[i][1], row[1])
 
     def _get_message_from_queues(self):
         """

--- a/monitors/tests/test_health_check.py
+++ b/monitors/tests/test_health_check.py
@@ -4,8 +4,6 @@ Currently only running unit tests on linux
 """
 import unittest
 import time
-import csv
-import os
 import mock
 
 from monitors.health_check import HealthCheckThread

--- a/monitors/tests/test_health_check.py
+++ b/monitors/tests/test_health_check.py
@@ -4,11 +4,12 @@ Currently only running unit tests on linux
 """
 import unittest
 import time
+import csv
 import mock
 
 from monitors.health_check import HealthCheckThread
 from monitors.end_of_run_monitor import write_last_run
-from monitors.settings import EORM_LAST_RUN_FILE
+from monitors.settings import EORM_LAST_RUN_FILE, INSTRUMENTS
 
 
 def create_runs_csv():
@@ -41,6 +42,19 @@ class TestServiceUtils(unittest.TestCase):
     def test_health_check_restart(self, last_run):
         """ Health check where end of run monitor requires a restart """
         self.assertFalse(HealthCheckThread(0).health_check())
+
+    @mock.patch('monitors.icat_monitor.get_last_run', return_value='1234')
+    def test_create_last_runs_csv(self, last_run):
+        """ Test initial population of the last runs CSV file """
+        HealthCheckThread.create_last_runs_csv()
+        # Now read back using the CSV reader
+        with open(EORM_LAST_RUN_FILE, 'r') as last_run_file:
+            last_run_reader = csv.reader(last_run_file)
+            for (i, row) in enumerate(last_run_reader):
+                # File may be padded
+                if i < len(INSTRUMENTS):
+                    self.assertEqual(row[0], INSTRUMENTS[i]['name'])
+                    self.assertEqual(row[1], '1234')
 
     def test_stop(self):
         health_check_thread = HealthCheckThread(0)

--- a/monitors/tests/test_health_check.py
+++ b/monitors/tests/test_health_check.py
@@ -9,6 +9,7 @@ import mock
 from monitors.health_check import HealthCheckThread
 from monitors.end_of_run_monitor import write_last_run
 
+
 def create_runs_csv():
     """
     Create a test runs CSV file
@@ -17,7 +18,8 @@ def create_runs_csv():
     write_last_run('WISH', '1234')
     write_last_run('POLARIS', '1234')
 
-# pylint:disable=missing-docstring
+
+# pylint:disable=missing-docstring, unused-argument
 class TestServiceUtils(unittest.TestCase):
 
     def setUp(self):

--- a/monitors/tests/test_health_check.py
+++ b/monitors/tests/test_health_check.py
@@ -8,7 +8,8 @@ import csv
 import os
 import mock
 
-from monitors.health_check import HealthCheckThread, write_last_run
+from monitors.health_check import HealthCheckThread
+from monitors.end_of_run_monitor import write_last_run
 from monitors.settings import EORM_LAST_RUN_FILE
 
 
@@ -48,26 +49,6 @@ class TestServiceUtils(unittest.TestCase):
         self.assertFalse(health_check_thread.exit)
         health_check_thread.stop()
         self.assertTrue(health_check_thread.exit)
-
-    def test_write_last_run(self):
-        """
-        Test write of the last runs CSV file
-        """
-        test_file = "last_runs_test.csv"
-        write_last_run(test_file, 'GEM', '1234')
-        write_last_run(test_file, 'WISH', '1234')
-        write_last_run(test_file, 'POLARIS', '1234')
-
-        row_array = [['GEM', '1234'], ['WISH', '1234'], ['POLARIS', '1234']]
-
-        # Now read back using the CSV reader
-        with open(test_file, 'r') as last_run_file:
-            last_run_reader = csv.reader(last_run_file)
-            for (i, row) in enumerate(last_run_reader):
-                self.assertEqual(row_array[i][0], row[0])
-                self.assertEqual(row_array[i][1], row[1])
-
-        os.remove(test_file)
 
     def test_thread_start_stop(self):
         health_check_thread = HealthCheckThread(1)

--- a/monitors/tests/test_icat_monitor.py
+++ b/monitors/tests/test_icat_monitor.py
@@ -5,7 +5,6 @@ Unit tests for the ICAT monitor
 import unittest
 import datetime
 from mock import Mock
-from mock import patch
 
 import monitors.icat_monitor as icat_monitor
 from monitors.settings import INSTRUMENTS

--- a/monitors/tests/test_icat_monitor.py
+++ b/monitors/tests/test_icat_monitor.py
@@ -11,7 +11,7 @@ import monitors.icat_monitor as icat_monitor
 from monitors.settings import INSTRUMENTS
 
 
-# pylint:disable=too-few-public-methods
+# pylint:disable=too-few-public-methods,unused-argument
 class DataFile(object):
     """
     Basic data file representation for testing
@@ -99,4 +99,3 @@ class TestICATMonitor(unittest.TestCase):
         Should return None when no cycle dates are returned
         """
         self.assertIsNone(icat_monitor.get_last_run('GEM'))
-

--- a/monitors/tests/test_icat_monitor.py
+++ b/monitors/tests/test_icat_monitor.py
@@ -83,19 +83,3 @@ class TestICATMonitor(unittest.TestCase):
                                                  inst_name,
                                                  ('2018-10-18', '2018-10-19'))
         self.assertEqual(run, None)
-
-    @patch('monitors.icat_monitor.get_cycle_dates', return_value=('2018-10-03', '2018-10-30'))
-    @patch('monitors.icat_monitor.get_last_run_in_dates', return_value='1234')
-    def test_get_last_run(self, cycle, last_run):
-        """
-        Check that get_last_run returns the provided run
-        """
-        self.assertEqual(icat_monitor.get_last_run('GEM'), '1234')
-
-    @patch('monitors.icat_monitor.get_cycle_dates', return_value=None)
-    @patch('monitors.icat_monitor.get_last_run_in_dates', return_value='1234')
-    def test_get_last_run_invalid_cycles(self, cycle, last_run):
-        """
-        Should return None when no cycle dates are returned
-        """
-        self.assertIsNone(icat_monitor.get_last_run('GEM'))


### PR DESCRIPTION
Links the ICAT checker and end of run monitor. End of run monitor writes a CSV file with the last run number it has processed, which is then read by the health checker. The health checker then verifies that the runs present are the latest by checking with ICAT. If they aren't then the service is restarted.

I also added a test for icat_monitor.get_last_run.

Fixes #205 