### PR TITLE
Increase test coverage in the monitors package

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -5,4 +5,5 @@ omit =
     *.so
 
 [report]
-exclude_lines = 
+exclude_lines =
+    pragma: no cover

--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,6 @@ apache_django_wsgi.conf
 
 # Ignore coverage logs
 .coverage
+
+# Include the coverage configuration file
+!.coveragerc

--- a/monitors/end_of_run_monitor.py
+++ b/monitors/end_of_run_monitor.py
@@ -163,5 +163,5 @@ def stop():
     observer.join()
 
 
-if __name__ == "__main__":  # pragma: no cover
-    main()
+if __name__ == "__main__":
+    main()  # pragma: no cover

--- a/monitors/end_of_run_monitor.py
+++ b/monitors/end_of_run_monitor.py
@@ -97,18 +97,27 @@ class InstrumentMonitor(FileSystemEventHandler):
         """ Returns the watched folder location. """
         return os.path.join(self.instrument_folder, 'logs')
 
+    # pylint:disable=no-self-use
+    def split_path_into_folders(self, file_path):
+        """
+        Return the the directories in a path as a list
+        Including the file name at the end of the path
+        :param file_path: the path to split
+        :return: a list of directories and the file name
+        """
+        if os.name == "nt":
+            return file_path.split("\\")
+        return file_path.split("/")
+
     # send thread to sleep, use Timer objects
     def on_modified(self, event):
         """ Handler when last_run.txt modified event received. """
         try:
             logging.debug("Received modified from %s", str(event.src_path))
             # Storing folders into variables.
-            if os.name == "nt":
-                list_of_folders = event.src_path.split("\\")
-            else:
-                list_of_folders = event.src_path.split("/")
+
             # This will ensure to only execute the code for a specific file.
-            if list_of_folders[-1] == "lastrun.txt":
+            if self.split_path_into_folders(event.src_path)[-1] == "lastrun.txt":
                 with open(self.instrument_last_run_loc) as lastrun:
                     data = get_data_and_check(lastrun)
                 # This code checks out the modified data and then it logs the changes.
@@ -154,5 +163,5 @@ def stop():
     observer.join()
 
 
-if __name__ == "__main__":
+if __name__ == "__main__":  # pragma: no cover
     main()

--- a/monitors/health_check.py
+++ b/monitors/health_check.py
@@ -22,8 +22,7 @@ class HealthCheckThread(threading.Thread):
         Perform a service health check every time_interval
         """
         while self.exit is False:
-            service_okay = self.health_check()
-            if service_okay:
+            if self.health_check():
                 logging.info("No Problems detected with service")
             else:
                 logging.warning("Problem detected with service. Restarting service...")

--- a/monitors/tests/test_health_check.py
+++ b/monitors/tests/test_health_check.py
@@ -5,6 +5,8 @@ Currently only running unit tests on linux
 import unittest
 import time
 
+from mock import patch
+
 from monitors.health_check import HealthCheckThread
 
 
@@ -34,3 +36,29 @@ class TestServiceUtils(unittest.TestCase):
             alive = health_check_thread.is_alive()
             attempts += 1
         self.assertFalse(alive)
+
+    # pylint:disable=no-self-use
+    @patch('monitors.end_of_run_monitor.stop')
+    @patch('monitors.end_of_run_monitor.main')
+    def test_restart(self, mock_eorm_start, mock_eorm_stop):
+        """
+        Ensure that restart calls the main(start) and stop functions of the End of Run Monitor
+        """
+        health_check_thread = HealthCheckThread(0)
+        health_check_thread.restart_service()
+        mock_eorm_start.assert_called_once()
+        mock_eorm_stop.assert_called_once()
+
+    # pylint:disable=no-self-use
+    @patch('monitors.health_check.HealthCheckThread.restart_service')
+    @patch('monitors.health_check.HealthCheckThread.health_check', return_value=False)
+    def test_service_problem(self, health_check_mock, restart_service_mock):
+        """
+        Ensure that the restart service has been called if the heath check returns false
+        """
+        health_check_thread = HealthCheckThread(2)
+        health_check_thread.start()
+        time.sleep(1)
+        health_check_mock.assert_called_once()
+        restart_service_mock.assert_called_once()
+        health_check_thread.exit = True


### PR DESCRIPTION
This should increase test coverage in the end of run monitor package to 100% for all files except the win_service file which can not be tested on linux. We can add test coverage for this once we have a travis  windows build.