### PR TITLE
CEPH link in webapp

### DIFF
--- a/QueueProcessors/AutoreductionProcessor/autoreduction_logging_setup.py
+++ b/QueueProcessors/AutoreductionProcessor/autoreduction_logging_setup.py
@@ -2,7 +2,7 @@
 import logging.handlers
 
 LOGGING_LEVEL = logging.INFO
-LOGGING_LOC = '/home/autoreduction/autoreduction/logs/autoreductionProcessor.log'
+LOGGING_LOC = '/home/isisautoreduce/logs/autoreductionProcessor.log'
 
 logger = logging.getLogger('AutoreductionProcessor')
 logger.setLevel(LOGGING_LEVEL)

--- a/QueueProcessors/AutoreductionProcessor/autoreduction_logging_setup.py
+++ b/QueueProcessors/AutoreductionProcessor/autoreduction_logging_setup.py
@@ -2,7 +2,7 @@
 import logging.handlers
 
 LOGGING_LEVEL = logging.INFO
-LOGGING_LOC = '/home/isisautoreduce/logs/autoreductionProcessor.log'
+LOGGING_LOC = '/home/autoreduction/autoreduction/logs/autoreductionProcessor.log'
 
 logger = logging.getLogger('AutoreductionProcessor')
 logger.setLevel(LOGGING_LEVEL)

--- a/WebApp/autoreduce_webapp/reduction_viewer/views.py
+++ b/WebApp/autoreduce_webapp/reduction_viewer/views.py
@@ -346,8 +346,11 @@ def run_summary(request, instrument_name=None, run_number=None, run_version=0):
                                        run_number=run_number,
                                        run_version=run_version)
         history = ReductionRun.objects.filter(run_number=run_number).order_by('-run_version')
-        reduction_location = str(run.reduction_location.all()[0])
-        ceph_location = get_ceph_location(reduction_location, instrument_name)
+        ceph_location = None
+        location_list = run.reduction_location.all()
+        if location_list:
+            reduction_location = str(location_list[0])
+            ceph_location = get_ceph_location(reduction_location, instrument_name)
         context_dictionary = {'run': run, 'history': history, 'ceph_location': ceph_location}
     except PermissionDenied:
         raise

--- a/WebApp/autoreduce_webapp/reduction_viewer/views.py
+++ b/WebApp/autoreduce_webapp/reduction_viewer/views.py
@@ -371,8 +371,8 @@ def get_ceph_location(reduction_location, instrument):
     except IndexError:
         # Return None if file path does not contain instrument name
         return None
-    ceph_location = ceph_root_level + instrument.upper() + '/rb' + data_location
-    return ceph_location.replace('\\', '/')
+    ceph_location = ceph_root_level + 'rb/' + instrument.upper() + data_location
+    return ceph_location.replace('/', '\\')
 
 
 @login_and_uows_valid

--- a/WebApp/autoreduce_webapp/templates/help.html
+++ b/WebApp/autoreduce_webapp/templates/help.html
@@ -17,6 +17,23 @@
         </div>
     </div>
 
+    <section class="help-topic panel panel-default" data-topics="link reduced data">
+        <div class="panel-heading">
+            <h4>How do I use the link to reduced data?</h4>
+        </div>
+        <div class="panel-body">
+            <p>
+                The link to reduced data points to a network drive that is accessible from within the RAL site (including by VPN).
+                On Windows, copy the link into the navigation bar at the top of a File Explorer window and hit enter.
+                Alternatively, the network drive (<code>\\data.analysis.stfc.ac.uk\rb\</code>) can be mapped to a location on your disk.
+            </p>
+            <p>
+                If you follow the instructions above and still can't access your reduced data, it may be that you don't have permission
+                to access the experiment's reduced data directory. Email <a href="mailto:isisreduce@stfc.ac.uk">isisreduce@stfc.ac.uk</a>
+                and state the experiment RB number you are trying to access.
+            </p>
+        </div>
+    </section>
     <section class="help-topic panel panel-default" data-topics="experiments mine investigations">
         <div class="panel-heading">
             <h4>Why can't I see my experiments?</h4>

--- a/WebApp/autoreduce_webapp/templates/run_summary.html
+++ b/WebApp/autoreduce_webapp/templates/run_summary.html
@@ -103,7 +103,9 @@
                             <div class="col-md-6">
                                 <div class="file-path">
                                     <strong>Reduced:</strong>
-                                    {% if run.reduction_location.all %}
+                                    {% if ceph_location %}
+                                        {{ ceph_location }}<br/>
+                                    {% elif run.reduction_location.all %}
                                         {% for location in run.reduction_location.all %}
                                             {{ location }}<br/>
                                         {% endfor %}
@@ -115,11 +117,6 @@
                             <div class="col-md-6">
                                 <strong>Logs:</strong>
                                 <a href="#" class="js-log-display">Show reduction logs</a>
-                            </div>
-                            <div class="col-md-6">
-                                {% if ceph_location %}
-                                    <a href='{{ ceph_location }}'>Download data</a>
-                                {% endif %}
                             </div>
                         </div>
                     </div>

--- a/WebApp/autoreduce_webapp/templates/run_summary.html
+++ b/WebApp/autoreduce_webapp/templates/run_summary.html
@@ -116,6 +116,11 @@
                                 <strong>Logs:</strong>
                                 <a href="#" class="js-log-display">Show reduction logs</a>
                             </div>
+                            <div class="col-md-6">
+                                {% if ceph_location %}
+                                    <a href='{{ ceph_location }}'>Download data</a>
+                                {% endif %}
+                            </div>
                         </div>
                     </div>
                 </div>

--- a/WebApp/autoreduce_webapp/templates/run_summary.html
+++ b/WebApp/autoreduce_webapp/templates/run_summary.html
@@ -105,6 +105,7 @@
                                     <strong>Reduced:</strong>
                                     {% if ceph_location %}
                                         {{ ceph_location }}<br/>
+                                        <a href="{% url 'help' %}" target="_blank">How to use this link</a>
                                     {% elif run.reduction_location.all %}
                                         {% for location in run.reduction_location.all %}
                                             {{ location }}<br/>
@@ -113,8 +114,6 @@
                                         <em>No reduced data found</em>
                                     {% endif %}
                                 </div>
-                            </div>
-                            <div class="col-md-6">
                                 <strong>Logs:</strong>
                                 <a href="#" class="js-log-display">Show reduction logs</a>
                             </div>

--- a/build/database/populate_reduction_viewer.sql
+++ b/build/database/populate_reduction_viewer.sql
@@ -74,7 +74,7 @@ VALUES
 INSERT INTO reduction_viewer_reductionlocation
     (id, file_path, reduction_run_id)
 VALUES
-    (1, 'path/to/reduced/data/1', 1),
+    (1, '\\some\\MUSR\\reduced\\data\\1', 1),
     (2, 'path/to/reduced/data/2', 2),
     (3, 'path/to/reduced/data/3', 3),
 


### PR DESCRIPTION
Add a link to the ceph data storage area for users to download their data. This link is currently available via the run summary page

### To test
* Open the webapp to the run summary page ensure that the link takes you to the right place (try this with several different runs) 

Fixes #236