### PR TITLE
Reduce logging from Health check

### DIFF
--- a/monitors/health_check.py
+++ b/monitors/health_check.py
@@ -134,10 +134,8 @@ class HealthCheckThread(threading.Thread):
             icat_last_run = icat_monitor.get_last_run(icat_client, inst['name'])
 
             if db_last_run and icat_last_run:
-                logging.info("Found last run from database on %s of %i",
-                             inst['name'], db_last_run)
-                logging.info("Found last run from ICAT on %s of %i",
-                             inst['name'], icat_last_run)
+                logging.info("%s - Database: %i , ICAT: %i",
+                             inst['name'], db_last_run, icat_last_run)
 
                 # Compare them and make sure the database isn't
                 # too far behind. There is a tolerance of 2 runs


### PR DESCRIPTION
The logging in the Health check for the end of run monitor is a bit too noisy. This should reduce the logging output by half and make the logs a little cleaner