### PR TITLE
Add apt-get update to Mantid install script

### DIFF
--- a/build/install/mantid.sh
+++ b/build/install/mantid.sh
@@ -16,4 +16,5 @@ sudo apt-add-repository "deb [arch=amd64] http://apt.isis.rl.ac.uk $(lsb_release
 wget -O - http://apt.isis.rl.ac.uk/2E10C193726B7213.asc -q | sudo apt-key add -
 sudo apt-add-repository ppa:mantid/mantid -y
 
+sudo apt-get update
 sudo apt-get install mantid -y


### PR DESCRIPTION
The Mantid install script does not work unless the package list is refreshed before attempting an install.