### PR TITLE
Remove resubmit of first run from EoRM health check

### DIFF
--- a/monitors/health_check.py
+++ b/monitors/health_check.py
@@ -147,7 +147,7 @@ class HealthCheckThread(threading.Thread):
                 if db_last_run < icat_last_run - 2:
                     logging.debug("Attempting to resubmit missing runs")
 
-                    for run_number in range(db_last_run, icat_last_run + 1):
+                    for run_number in range(db_last_run + 1, icat_last_run + 1):
                         HealthCheckThread.resubmit_run(icat_client, inst['name'], run_number)
                     db_client.disconnect()
                     return False

--- a/monitors/tests/test_health_check.py
+++ b/monitors/tests/test_health_check.py
@@ -203,8 +203,7 @@ class TestServiceUtils(unittest.TestCase):
         mock_icat_login.assert_called_once()
         mock_get_last_run.assert_called_once()
         mock_icat_last_run.assert_called_once()
-        expected_calls = [call(None, 'WISH', 10),
-                          call(None, 'WISH', 11),
+        expected_calls = [call(None, 'WISH', 11),
                           call(None, 'WISH', 12),
                           call(None, 'WISH', 13)]
         mock_resubmit.assert_has_calls(expected_calls)


### PR DESCRIPTION
Ensure that we are not resubmitting the first entry that is already in the database. The updates to the tests show that this will avoid a resubmission. 