### PR TITLE
Custom ceph paths

### DIFF
--- a/QueueProcessors/AutoreductionProcessor/test_settings.py
+++ b/QueueProcessors/AutoreductionProcessor/test_settings.py
@@ -22,7 +22,6 @@ MISC = {
     "mantid_path": "/opt/Mantid/bin",
     "scripts_directory": "/isis/NDX%s/user/scripts/autoreduction",
     "post_process_directory": os.path.join(os.path.dirname(os.path.realpath(__file__)), "post_process_admin.py"),
-    "ceph_directory": "/instrument/%s/RBNumber/RB%s/autoreduced/%s",
     "temp_root_directory": "/autoreducetmp",
     "excitation_instruments": ["LET", "MARI", "MAPS", "MERLIN", "WISH", "GEM"]
 }

--- a/monitors/end_of_run_monitor.py
+++ b/monitors/end_of_run_monitor.py
@@ -11,7 +11,8 @@ from watchdog.events import FileSystemEventHandler
 from watchdog.observers import Observer
 
 from monitors.settings import (INST_FOLDER, DATA_LOC, SUMMARY_LOC,
-                               LAST_RUN_LOC, EORM_LOG_FILE, INSTRUMENTS)
+                               LAST_RUN_LOC, EORM_LOG_FILE)
+from utils.autoreduction_instruments import INSTRUMENTS
 from utils.clients.queue_client import QueueClient
 
 logging.basicConfig(filename=EORM_LOG_FILE,
@@ -144,7 +145,7 @@ def main():
     message_lock = threading.Lock()
     for inst in INSTRUMENTS:
         # Create an event_handler, this will decide what to do when files are changed.
-        event_handler = InstrumentMonitor(inst['name'], inst['use_nexus'], connection, message_lock)
+        event_handler = InstrumentMonitor(inst.name(), inst.use_nexus(), connection, message_lock)
         # This will watch the folder the program is in and pick up all changes made in the folder.
         path = event_handler.get_watched_folder()
         # Tell the observer what to watch and give it the class that will handle the events.

--- a/monitors/health_check.py
+++ b/monitors/health_check.py
@@ -10,7 +10,7 @@ import json
 
 from monitors import end_of_run_monitor
 from monitors import icat_monitor
-from monitors.settings import INSTRUMENTS
+from utils.autoreduction_instruments import INSTRUMENTS
 from utils.clients.database_client import DatabaseClient
 from utils.clients.queue_client import QueueClient
 from utils.clients.connection_exception import ConnectionException
@@ -135,12 +135,12 @@ class HealthCheckThread(threading.Thread):
         icat_client = icat_monitor.icat_login()
 
         for inst in INSTRUMENTS:
-            db_last_run = HealthCheckThread.get_db_last_run(db_client, inst['name'])
-            icat_last_run = icat_monitor.get_last_run(icat_client, inst['name'])
+            db_last_run = HealthCheckThread.get_db_last_run(db_client, inst.name())
+            icat_last_run = icat_monitor.get_last_run(icat_client, inst.name())
 
             if db_last_run and icat_last_run:
                 logging.info("%s - Database: %i , ICAT: %i",
-                             inst['name'], db_last_run, icat_last_run)
+                             inst.name(), db_last_run, icat_last_run)
 
                 # Compare them and make sure the database isn't
                 # too far behind. There is a tolerance of 2 runs
@@ -148,7 +148,7 @@ class HealthCheckThread(threading.Thread):
                     logging.debug("Attempting to resubmit missing runs")
 
                     for run_number in range(db_last_run, icat_last_run + 1):
-                        HealthCheckThread.resubmit_run(icat_client, inst['name'], run_number)
+                        HealthCheckThread.resubmit_run(icat_client, inst.name(), run_number)
                     db_client.disconnect()
                     return False
 

--- a/monitors/test_settings.py
+++ b/monitors/test_settings.py
@@ -13,9 +13,3 @@ SUMMARY_LOC = os.path.join('logs', 'journal', 'summary.txt')
 LAST_RUN_LOC = os.path.join('logs', 'lastrun.txt')
 EORM_LOG_FILE = os.path.join(get_project_root(), 'logs', 'end_of_run_monitor.log')
 EORM_LAST_RUN_FILE = os.path.join(get_project_root(), 'logs', 'eorm_last_runs.csv')
-INSTRUMENTS = [{'name': 'WISH', 'use_nexus': True},
-               {'name': 'GEM', 'use_nexus': True},
-               {'name': 'OSIRIS', 'use_nexus': True},
-               {'name': 'POLARIS', 'use_nexus': True},
-               {'name': 'MUSR', 'use_nexus': True},
-               {'name': 'POLREF', 'use_nexus': True}]

--- a/monitors/tests/test_end_of_run_monitors.py
+++ b/monitors/tests/test_end_of_run_monitors.py
@@ -11,8 +11,9 @@ from watchdog.events import FileSystemEvent
 
 from monitors.end_of_run_monitor import (InstrumentMonitor, get_file_extension,
                                          get_data_and_check, stop, main)
-from monitors.settings import INSTRUMENTS
 from monitors.tests.helpers import TestListener, create_connection
+
+from utils.autoreduction_instruments import INSTRUMENTS
 from utils.clients.queue_client import QueueClient
 from utils.data_archive.data_archive_creator import DataArchiveCreator
 from utils.data_archive.archive_explorer import ArchiveExplorer

--- a/monitors/tests/test_icat_monitor.py
+++ b/monitors/tests/test_icat_monitor.py
@@ -7,7 +7,7 @@ import datetime
 from mock import Mock, patch
 
 import monitors.icat_monitor as icat_monitor
-from monitors.settings import INSTRUMENTS
+from utils.autoreduction_instruments import INSTRUMENTS
 
 
 # pylint:disable=too-few-public-methods,unused-argument,missing-docstring
@@ -74,7 +74,7 @@ class TestICATMonitor(unittest.TestCase):
         Test handling of run retrieval from ICAT
         """
         icat_client = Mock()
-        inst_name = INSTRUMENTS[0]['name']
+        inst_name = INSTRUMENTS[0].name()
         file_name = inst_name + '3223.nxs'
         icat_client.execute_query = Mock(return_value=[DataFile(file_name, None)])
         run = icat_monitor.get_last_run_in_dates(icat_client,
@@ -88,7 +88,7 @@ class TestICATMonitor(unittest.TestCase):
         Test handling of runs when no files are returned
         """
         icat_client = Mock()
-        inst_name = INSTRUMENTS[0]['name']
+        inst_name = INSTRUMENTS[0].name()
         icat_client.execute_query = Mock(return_value=[])
         run = icat_monitor.get_last_run_in_dates(icat_client,
                                                  inst_name,

--- a/utils/autoreduction_instruments.py
+++ b/utils/autoreduction_instruments.py
@@ -1,0 +1,39 @@
+"""
+List of all valid instruments used in ISIS autoreduction
+"""
+
+from utils.instruments import (Instrument, EnginX)
+
+
+INSTRUMENTS = [
+    EnginX(True, '/instrument/%s/RBNumber/RB%s/'),
+    Instrument('GEM',     True, '/instrument/%s/RBNumber/RB%s/autoreduced/%s'),
+    Instrument('MUSR',    True, '/instrument/%s/RBNumber/RB%s/autoreduced/%s'),
+    Instrument('OSIRIS',  True, '/instrument/%s/RBNumber/RB%s/autoreduced/%s'),
+    Instrument('POLARIS', True, '/instrument/%s/RBNumber/RB%s/autoreduced/%s'),
+    Instrument('POLREF',  True, '/instrument/%s/RBNumber/RB%s/autoreduced/%s'),
+    Instrument('WISH',    True, '/instrument/%s/RBNumber/RB%s/autoreduced/%s'),
+]
+
+
+def find_instrument_by_name(inst_name):
+    """
+    Find an instrument object based on it's name. Raise runtime error if can't be found
+    :param inst_name: the name of the instrument to search for
+    :return: the Instrument found by searching
+    """
+    for instrument in INSTRUMENTS:
+        if instrument.name.lower() == inst_name.lower():
+            return instrument
+    raise RuntimeError('Unable to find instrument with name {}'.format(inst_name))
+
+
+def get_instrument_names():
+    """
+    There are some cases where we only care about the names of the instruments
+    :return: A list of valid instrument names
+    """
+    instrument_names = []
+    for instrument in INSTRUMENTS:
+        instrument_names.append(instrument.name)
+    return instrument_names

--- a/utils/data_archive/data_archive_creator.py
+++ b/utils/data_archive/data_archive_creator.py
@@ -34,7 +34,7 @@ import os
 import shutil
 import time
 
-from utils.settings import VALID_INSTRUMENTS
+from utils.autoreduction_instruments import get_instrument_names
 
 GENERIC_CYCLE_PATH = os.path.join('NDX{}', 'Instrument', 'data', 'cycle_{}_{}')
 
@@ -107,10 +107,10 @@ class DataArchiveCreator(object):
         """
         Ensure that an instrument is valid - else throw an exception
         """
-        if instrument not in VALID_INSTRUMENTS:
+        if instrument not in get_instrument_names():
             raise ValueError("Instrument provided: \'{0}\' is not recognised as  a valid "
                              "instrument. Valid instruments are {1}".format(instrument,
-                                                                            VALID_INSTRUMENTS))
+                                                                            get_instrument_names()))
 
     def _make_cycle_directories(self, start_year, end_year, current_cycle, base_dir):
         """

--- a/utils/instruments/__init__.py
+++ b/utils/instruments/__init__.py
@@ -1,0 +1,6 @@
+"""
+Import sub packages for ease of use and shorter import lines
+"""
+from .instrument import Instrument
+from .enginx import EnginX
+

--- a/utils/instruments/enginx.py
+++ b/utils/instruments/enginx.py
@@ -1,0 +1,20 @@
+"""
+Instrument model for EnginX
+"""
+from utils.instruments.instrument import Instrument
+
+
+class EnginX(Instrument):
+
+    def __init__(self, use_nexus, output_directory):
+        Instrument.__init__(self, 'ENGINX', use_nexus, output_directory)
+
+    def format_output_directory(self, meta_data_dict):
+        """
+        Construct the output directory using the meta_data_dict
+        This should be overridden where required
+        :param meta_data_dict: A dictionary of meta data relating to
+        :return: A full path to the output data directory
+        """
+        return self.output_directory.format(self.name,
+                                            meta_data_dict['rb'])

--- a/utils/instruments/instrument.py
+++ b/utils/instruments/instrument.py
@@ -1,0 +1,26 @@
+"""
+Models an ISIS Instrument
+"""
+
+
+class Instrument(object):
+
+    name = None
+    use_nexus = True
+    output_directory = None
+
+    def __init__(self, name, use_nexus, output_directory):
+        self.name = name
+        self.use_nexus = use_nexus
+        self.output_directory = output_directory
+
+    def format_output_directory(self, meta_data_dict):
+        """
+        Construct the output directory using the meta_data_dict
+        This should be overridden where required
+        :param meta_data_dict: A dictionary of meta data relating to
+        :return: A full path to the output data directory
+        """
+        return self.output_directory.format(self.name,
+                                            meta_data_dict['rb'],
+                                            meta_data_dict['run'])

--- a/utils/instruments/tests/test_enginx.py
+++ b/utils/instruments/tests/test_enginx.py
@@ -1,0 +1,18 @@
+import unittest
+
+from utils.instruments import EnginX
+
+
+class TestEnginX(unittest.TestCase):
+
+    def setUp(self):
+        self.enginx = EnginX(True, '{}{}')
+
+    def test_name(self):
+        self.assertEqual(self.enginx.name, 'ENGINX')
+
+    def test_format_output_directory(self):
+        meta_data = {
+            'rb': '12345'
+        }
+        self.assertEqual(self.enginx.format_output_directory(meta_data), 'ENGINX12345')

--- a/utils/instruments/tests/test_instrument.py
+++ b/utils/instruments/tests/test_instrument.py
@@ -1,0 +1,21 @@
+import unittest
+
+from utils.instruments import Instrument
+
+
+class TestInstrument(unittest.TestCase):
+
+    def setUp(self):
+        self.instrument = Instrument('Test', True, '{}{}-{}')
+
+    def test_init(self):
+        self.assertEqual(self.instrument.name, 'Test')
+        self.assertTrue(self.instrument.use_nexus)
+        self.assertEqual(self.instrument.output_directory, '{}{}-{}')
+
+    def test_format_output_directory(self):
+        meta_data = {
+            'rb': '12345',
+            'run': '00000'
+        }
+        self.assertEqual(self.instrument.format_output_directory(meta_data), 'Test12345-00000')

--- a/utils/test_settings.py
+++ b/utils/test_settings.py
@@ -6,8 +6,6 @@ Settings for connecting to the test services that run locally
 from utils.clients.settings.client_settings_factory import ClientSettingsFactory
 
 
-VALID_INSTRUMENTS = ['GEM', 'POLARIS', 'WISH', 'OSIRIS', 'MUSR', 'POLREF']
-
 SETTINGS_FACTORY = ClientSettingsFactory()
 
 ICAT_SETTINGS = SETTINGS_FACTORY.create('icat',


### PR DESCRIPTION
Allow custom ceph paths to be used for data output 

This branch accomplishes this by adding an instrument class to hold data for a instrument (including a custom output path) 
The rest of the autoreduction system has been updated to use this functionality

At some stage, we should look to separate utils into better packages, e.g. ISIS specific, testing tools, environment tools, etc. 

Fixes #254 