### PR TITLE
DataArchiveCreator reduce.py and reduce_vars.py

### DIFF
--- a/utils/data_archive/archive_explorer.py
+++ b/utils/data_archive/archive_explorer.py
@@ -101,3 +101,19 @@ class ArchiveExplorer(object):
         if valid_files:
             return valid_files[-1]
         return None
+
+    # ============================= Script Directories ===================================== #
+    def get_script_directory(self, instrument):
+        """ :return: archive_directory/NDXGEM/user/scripts/autoreduce"""
+        return self._file_path_exists(os.path.join(self.get_user_directory(instrument), 'scripts',
+                                                   'autoreduction'))
+
+    def get_reduce_file(self, instrument):
+        """ :return: archive_directory/NDXGEM/user/scripts/autoreduce/reduce.py"""
+        return self._file_path_exists(os.path.join(self.get_script_directory(instrument),
+                                                   'reduce.py').format(instrument))
+
+    def get_reduce_vars_file(self, instrument):
+        """ :return: archive_directory/NDXGEM/user/scripts/autoreduce/reduce.py"""
+        return self._file_path_exists(os.path.join(self.get_script_directory(instrument),
+                                                   'reduce_vars.py'))

--- a/utils/data_archive/data_archive_creator.py
+++ b/utils/data_archive/data_archive_creator.py
@@ -182,9 +182,32 @@ class DataArchiveCreator(object):
         self._check_valid_inst(instrument)
         path_to_log_file = os.path.join(self._archive_dir, 'NDX{}',
                                         'Instrument', 'logs',
-                                        'journal').format(instrument)
-        self.create_file_at_location(os.path.join(path_to_log_file, 'summary.txt'),
-                                     str(file_contents))
+                                        'journal', 'summary.txt').format(instrument)
+        self.create_file_at_location(path_to_log_file, str(file_contents))
+
+    def add_reduce_script(self, instrument, file_content):
+        """
+        Adds the reduce.py file to the /user/scripts/autoreduce directory
+        :param instrument: The instrument to add the file for
+        :param file_content: The content of the file
+        """
+        self._check_valid_inst(instrument)
+        path_to_reduce_file = os.path.join(self._archive_dir, 'NDX{}',
+                                           'user', 'scripts',
+                                           'autoreduction', 'reduce.py').format(instrument)
+        self.create_file_at_location(path_to_reduce_file, file_content)
+
+    def add_reduce_vars_script(self, instrument, file_content):
+        """
+        Adds the reduce.py file to the /user/scripts/autoreduce directory
+        :param instrument: The instrument to add the file for
+        :param file_content: The content of the file
+        """
+        self._check_valid_inst(instrument)
+        path_to_reduce_file = os.path.join(self._archive_dir, 'NDX{}',
+                                           'user', 'scripts',
+                                           'autoreduction', 'reduce_vars.py').format(instrument)
+        self.create_file_at_location(path_to_reduce_file, file_content)
 
     def add_last_run_file(self, instrument, file_contents):
         """

--- a/utils/data_archive/data_archive_creator.py
+++ b/utils/data_archive/data_archive_creator.py
@@ -95,10 +95,13 @@ class DataArchiveCreator(object):
         user_dir_path = os.path.join(ndx_dir_path, 'user')
         data_dir_path = os.path.join(inst_dir_path, 'data')
         jrnl_dir_path = os.path.join(logs_dir_path, 'journal')
+        scrp_dir_path = os.path.join(user_dir_path, 'scripts')
+        auto_dir_path = os.path.join(scrp_dir_path, 'autoreduction')
         for instrument in instruments:
             os.makedirs(user_dir_path.format(instrument))
             os.makedirs(data_dir_path.format(instrument))
             os.makedirs(jrnl_dir_path.format(instrument))
+            os.makedirs(auto_dir_path.format(instrument))
             self._make_cycle_directories(start_year, end_year, current_cycle,
                                          inst_dir_path.format(instrument))
 

--- a/utils/data_archive/tests/test_archive_explorer.py
+++ b/utils/data_archive/tests/test_archive_explorer.py
@@ -11,7 +11,7 @@ from utils.data_archive.data_archive_creator import DataArchiveCreator
 from utils.data_archive.archive_explorer import ArchiveExplorer
 
 
-# pylint:disable=invalid-name
+# pylint:disable=invalid-name,too-many-public-methods
 class TestArchiveExplorer(unittest.TestCase):
     """
     Test all the functionality of the archive explorer
@@ -80,6 +80,22 @@ class TestArchiveExplorer(unittest.TestCase):
         expected = os.path.join(self.archive_directory, 'NDXGEM', 'Instrument', 'logs',
                                 'journal', 'summary.txt')
         actual = self.explorer.get_summary_file('GEM')
+        self.assertEqual(actual, expected)
+
+    def test_reduce_file_path(self):
+        """ Test path to reduce.py file """
+        self.dac.add_reduce_script('GEM', 'test')
+        expected = os.path.join(self.archive_directory, 'NDXGEM', 'user', 'scripts',
+                                'autoreduction', 'reduce.py')
+        actual = self.explorer.get_reduce_file('GEM')
+        self.assertEqual(actual, expected)
+
+    def test_reduce_vars_file_path(self):
+        """ Test path to reduce_vars.py file """
+        self.dac.add_reduce_vars_script('GEM', 'test')
+        expected = os.path.join(self.archive_directory, 'NDXGEM', 'user', 'scripts',
+                                'autoreduction', 'reduce_vars.py')
+        actual = self.explorer.get_reduce_vars_file('GEM')
         self.assertEqual(actual, expected)
 
     def test_data_dir_path(self):

--- a/utils/data_archive/tests/test_data_archive_creator.py
+++ b/utils/data_archive/tests/test_data_archive_creator.py
@@ -114,14 +114,14 @@ class TestDataArchiveCreator(unittest.TestCase):
         self.dac.make_data_archive(['GEM'], 18, 18, 1)
         self.dac.add_reduce_script('GEM', 'test')
         expected_file_path = os.path.join(self.test_output_directory, 'data-archive', 'NDXGEM',
-                                          'user', 'scripts', 'autoreduce', 'reduce.py')
+                                          'user', 'scripts', 'autoreduction', 'reduce.py')
         self.assertTrue(os.path.isfile(expected_file_path))
 
     def test_add_reduce_vars_script_valid(self):
         self.dac.make_data_archive(['GEM'], 18, 18, 1)
         self.dac.add_reduce_vars_script('GEM', 'test')
         expected_file_path = os.path.join(self.test_output_directory, 'data-archive', 'NDXGEM',
-                                          'user', 'scripts', 'autoreduce', 'reduce_vars.py')
+                                          'user', 'scripts', 'autoreduction', 'reduce_vars.py')
         self.assertTrue(os.path.isfile(expected_file_path))
 
     def test_add_last_run_without_archive(self):

--- a/utils/data_archive/tests/test_data_archive_creator.py
+++ b/utils/data_archive/tests/test_data_archive_creator.py
@@ -110,6 +110,20 @@ class TestDataArchiveCreator(unittest.TestCase):
                                           'Instrument', 'logs', 'journal', 'summary.txt')
         self.assertTrue(os.path.isfile(expected_file_path))
 
+    def test_add_reduce_script_valid(self):
+        self.dac.make_data_archive(['GEM'], 18, 18, 1)
+        self.dac.add_reduce_script('GEM', 'test')
+        expected_file_path = os.path.join(self.test_output_directory, 'data-archive', 'NDXGEM',
+                                          'user', 'scripts', 'autoreduce', 'reduce.py')
+        self.assertTrue(os.path.isfile(expected_file_path))
+
+    def test_add_reduce_vars_script_valid(self):
+        self.dac.make_data_archive(['GEM'], 18, 18, 1)
+        self.dac.add_reduce_vars_script('GEM', 'test')
+        expected_file_path = os.path.join(self.test_output_directory, 'data-archive', 'NDXGEM',
+                                          'user', 'scripts', 'autoreduce', 'reduce_vars.py')
+        self.assertTrue(os.path.isfile(expected_file_path))
+
     def test_add_last_run_without_archive(self):
         self.assertRaisesRegexp(RuntimeError, "Unable to create file at ",
                                 self.dac.add_last_run_file, 'GEM', 'test')


### PR DESCRIPTION
### Summary of work
* Added ability to create `reduce.py` and `reduce_vars.py` to a fake data archive via the use of the `DataArchiveCreator`
* Added the ability to search for `reduce.py` and `reduce_vars.py` in a data archive via the `ArchiveExplorer`

### How to test your work
* Code review
* Check the instructions in #266

### Additional comments
This is blocking continuation of #28 

Fixes #266
