### PR TITLE
Order database runs by run number

### DIFF
--- a/monitors/health_check.py
+++ b/monitors/health_check.py
@@ -63,7 +63,7 @@ class HealthCheckThread(threading.Thread):
             .join(db_cli.reduction_run().instrument) \
             .filter(db_cli.reduction_run().run_version == 0) \
             .filter(db_cli.instrument().name == inst) \
-            .order_by(db_cli.reduction_run().created.desc()) \
+            .order_by(db_cli.reduction_run().run_number.desc()) \
             .first()
         conn.commit()
         return result


### PR DESCRIPTION
### Summary of work
Modified the health checker last run query to order by run number rather than created date. This causes problems when an old run is resubmitted, leading the health checker to wrongly assert that the database is behind ICAT.

### How to test your work
Resubmit an old run and check to make sure the health checker uses the latest run number.

Fixes #273
