### PR TITLE
Change for the user office update

### DIFF
--- a/WebApp/autoreduce_webapp/autoreduce_webapp/uows_client.py
+++ b/WebApp/autoreduce_webapp/autoreduce_webapp/uows_client.py
@@ -56,7 +56,7 @@ class UOWSClient(object):
         Checks if a session ID is still active and valid
         """
         try:
-            return self.client.service.checkSession(session_id)
+            return self.client.service.isTokenValid(session_id)
         except suds.WebFault:
             LOGGER.warn("Session ID is not valid: %s", session_id)
             return False


### PR DESCRIPTION
### Summary of work
Modified code to authenticate with the user office after their update that deprecates certain methods.

### How to test your work
Turn off ```DEVELOPMENT_MODE``` in the web app settings files. Ensure that the development WSDL and user office site are being used. Then attempt to login to the web app. This will only work on the Autoreduce development machine due to the user office only permitting redirects to certain URLs.

Fixes #265 
