### PR TITLE
Fix test failure introduced due to resolveing merge conflict

### DIFF
--- a/monitors/tests/test_health_check.py
+++ b/monitors/tests/test_health_check.py
@@ -228,8 +228,7 @@ class TestServiceUtils(unittest.TestCase):
         icat_client.refresh.assert_called_once()
         mock_get_last_run.assert_called_once()
         mock_icat_last_run.assert_called_once()
-        expected_calls = [call(icat_client, 'WISH', 10),
-                          call(icat_client, 'WISH', 11),
+        expected_calls = [call(icat_client, 'WISH', 11),
                           call(icat_client, 'WISH', 12),
                           call(icat_client, 'WISH', 13)]
         mock_resubmit.assert_has_calls(expected_calls)


### PR DESCRIPTION
### Summary of work
* Updated test expected values to match what we expect

### How to test your work
* Ensure the unit tests pass of travis

### Additional comments
This was fixed prior, but must have been accidentally re-introduced due to a merge conflict

*No associated issue*
