### PR TITLE
Empty Web application validation

### DIFF
--- a/WebApp/autoreduce_webapp/reduction_viewer/utils.py
+++ b/WebApp/autoreduce_webapp/reduction_viewer/utils.py
@@ -42,7 +42,7 @@ class StatusUtils(object):
         name or create one if it doesn't yet exist
         """
         # pylint:disable=no-member
-        status = Status.objects.get(value=status_value)
+        status = Status.objects.get_or_create(value=status_value)
         return status
 
     def get_error(self):

--- a/WebApp/autoreduce_webapp/templates/run_list.html
+++ b/WebApp/autoreduce_webapp/templates/run_list.html
@@ -48,7 +48,8 @@
     {% else %}
         <div class="row">
             <div class="col-md-12 text-center">
-                <h3>No reduction runs found. <i class="fa fa-frown-o"></i></h3>
+                <h3>No reduction runs found</h3>
+                <h4>If this problem persists, please contact <a href="mailto:ISISREDUCE@stfc.ac.uk?subject=Web%20Application%20-%20No%20Runs%20found">Autoreduction support</a></h4>
             </div>
         </div>
     {% endif %} 


### PR DESCRIPTION
### Summary of work
* Ensure that the Status records are made by the web app if they do not exist
* Add a mailto link to our support email in the case of there being no runs available

### How to test
* Ensure you are on a local machine or if testing on the dev environment no one is using it / needs any data on it
* Delete the local database:
```
$ mysql -u root -p
> drop database autoreduction;
> exit
$ mysql -u root < build/database/test_db_setup.sql
$ python setup.py database
```
to use the script to wipe the database:
```
$ python scripts/database_management/reset_database_post_cycle.py
```
Then follow the options to first backup, and then wipe the database

* Now load the webapp and ensure it does not error
* Instead you should see a page telling you there are no runs and given you an email link to the autoreduction support email

Fixes #177 
