### PR TITLE
New End of Run Monitor

### DIFF
--- a/monitors/README.md
+++ b/monitors/README.md
@@ -1,4 +1,32 @@
-# Monitors *(Windows Only)*
+# New End of Run Monitor *(Any Platform)*
+
+This End of Run Monitor can be run on any platform either standalone on the command line or
+as a scheduled task. All it requires is a CSV file of the following format:
+
+```
+WISH,1234,wish_lastrun.txt,wish_summary.txt,/archive/wish/data,.nxs
+GEM,1234,gem_lastrun.txt,gem_summary.txt,/archive/gem/data,.nxs
+```
+
+In order, the fields are: instrument name, last run number observed on the instrument, location
+of this instrument's lastrun.txt, location of this instrument's summary.txt, data location
+(parent of cycle folder), file extension of data to reduce. The last observed run is updated
+whenever EoRM submits a new run.
+
+There are two settings in settings.py for this script:
+
+* LAST_RUNS_CSV - Location of the CSV file described above
+* CYCLE_FOLDER - Folder for the current cycle in the instrument data directory.
+
+## Production Configuration
+
+In production, it is recommended to run this script as a Cron job on Linux or using the task
+scheduler on Windows. The period should be a minute or less so that runs are processed
+as soon as they arrive.
+
+The cycle folder in settings.py must be updated at the beginning of each new cycle.
+
+# Original End of Run Monitor *(Windows Only)*
 
 Scripts used to check for new runs from the instruments at ISIS.
 

--- a/monitors/README.md
+++ b/monitors/README.md
@@ -8,10 +8,10 @@ WISH,1234,wish_lastrun.txt,wish_summary.txt,/archive/wish/data,.nxs
 GEM,1234,gem_lastrun.txt,gem_summary.txt,/archive/gem/data,.nxs
 ```
 
-In order, the fields are: instrument name, last run number observed on the instrument, location
-of this instrument's lastrun.txt, location of this instrument's summary.txt, data location
-(parent of cycle folder), file extension of data to reduce. The last observed run is updated
-whenever EoRM submits a new run.
+In order, the fields are: instrument name, last run number observed on the instrument 
+(without leading zeros), location of this instrument's lastrun.txt, location of this
+instrument's summary.txt, data location (parent of cycle folder), file extension of
+data to reduce. The last observed run is updated whenever EoRM submits a new run.
 
 There are two settings in settings.py for this script:
 

--- a/monitors/new_end_of_run_monitor.py
+++ b/monitors/new_end_of_run_monitor.py
@@ -1,0 +1,84 @@
+import csv
+import os
+import logging
+from settings import (CYCLE_FOLDER, LAST_RUNS_CSV)
+
+from utils.project.structure import get_log_file
+from utils.project.static_content import LOG_FORMAT
+logging.basicConfig(filename=get_log_file('end_of_run_monitor.log'), level=logging.INFO,
+                    format=LOG_FORMAT)
+
+
+class InvalidLastRunError(Exception):
+    pass
+
+
+class InstrumentMonitor(object):
+    """
+    Checks the ISIS archive for new runs on an instrument and submits them to ActiveMQ
+    """
+    def __init__(self, instrument_name, last_run_file, summary_file, data_dir):
+        self.instrument_name = instrument_name
+        self.summary_file = summary_file
+        self.last_run_file = last_run_file
+        self.data_dir = data_dir
+
+    def read_instrument_last_run(self):
+        """
+        Read the last run recorded by the instrument from its lastrun.txt
+        :return: Last run on the instrument as a string
+        """
+        with open(self.last_run_file, 'r') as fp:
+            line_parts = fp.readline().split()
+            if len(line_parts) != 3:
+                raise InvalidLastRunError("Unexpected last run file format for {}".format(self.last_run_file))
+            last_run = line_parts[1]
+        return last_run
+
+    def read_rb_number_from_summary(self, run_number):
+        """
+        Loads the summary file and reads off the experiment RB number
+        :param run_number: Run number to lookup
+        :return: Experiment RB number
+        """
+        # Detect run number as a substring
+        return None
+
+    def submit_run(self, run_number):
+        """
+        Submit a run to ActiveMQ
+        :param run_number: Particular run to submit
+        """
+        # Check to see if the last run exists, if not then raise an exception
+
+        # Submit run to ActiveMQ
+        return None
+
+    def submit_run_difference(self, local_last_run):
+        """
+        Submit the difference between the last run on the archive for this
+        instrument
+        :param local_last_run: Local last run to check against
+        """
+        # Get archive lastrun.txt
+        instrument_last_run = self.read_instrument_last_run()
+        print("Instrument last run is %s" % instrument_last_run)
+
+
+def update_last_runs():
+    # Acquire a lock on the last runs CSV file
+
+    # Loop over instruments
+    with open(LAST_RUNS_CSV, 'rb') as csv_file:
+        csv_reader = csv.reader(csv_file)
+        for row in csv_reader:
+            inst_mon = InstrumentMonitor(row[0], row[2], row[3], row[4])
+            inst_mon.submit_run_difference(row[1])
+
+
+def main():
+    update_last_runs()
+
+
+if __name__ == '__main__':
+    main()

--- a/monitors/new_end_of_run_monitor.py
+++ b/monitors/new_end_of_run_monitor.py
@@ -146,7 +146,10 @@ class InstrumentMonitor(object):
         rb_number = self.read_rb_number_from_summary(str(instrument_run_int))
         zeros = get_prefix_zeros(instrument_last_run)
         if instrument_run_int > local_run_int:
-            EORM_LOG.info("Submitting runs in range %i - %i", local_run_int, instrument_run_int)
+            EORM_LOG.info("Submitting runs in range %i - %i for %s",
+                          local_run_int,
+                          instrument_run_int,
+                          self.instrument_name)
             for i in range(local_run_int + 1, instrument_run_int + 1):
                 # Construct the file name and run number
                 run_number = zeros + str(i)

--- a/monitors/new_end_of_run_monitor.py
+++ b/monitors/new_end_of_run_monitor.py
@@ -77,8 +77,8 @@ class InstrumentMonitor(object):
         Read the last run recorded by the instrument from its lastrun.txt
         :return: Last run on the instrument as a string
         """
-        with open(self.last_run_file, 'r') as last_run_fp:
-            line_parts = last_run_fp.readline().split()
+        with open(self.last_run_file, 'r') as last_run:
+            line_parts = last_run.readline().split()
             if len(line_parts) != 3:
                 raise InstrumentMonitorError("Unexpected last run file format for '{}'"
                                              .format(self.last_run_file))
@@ -91,8 +91,8 @@ class InstrumentMonitor(object):
         :return: Experiment RB number
         """
         # Detect run number as a substring
-        with open(self.summary_file, 'rb') as summary_fp:
-            for line in summary_fp:
+        with open(self.summary_file, 'rb') as summary:
+            for line in summary:
                 line_parts = line.split()
                 # Detect the run as a substring in summary.txt
                 if str(run_number) in line_parts[0]:

--- a/monitors/new_end_of_run_monitor.py
+++ b/monitors/new_end_of_run_monitor.py
@@ -1,39 +1,68 @@
 import csv
-import os
 import logging
+import os
+import json
 from filelock import (FileLock, Timeout)
-from settings import LAST_RUNS_CSV
 
+from settings import (LAST_RUNS_CSV, CYCLE_FOLDER)
+
+from utils.clients.queue_client import QueueClient
 from utils.project.structure import get_log_file
 from utils.project.static_content import LOG_FORMAT
-logging.basicConfig(filename=get_log_file('end_of_run_monitor.log'), level=logging.INFO,
-                    format=LOG_FORMAT)
+
+# Setup logging
+eorm_log = logging.getLogger('end_of_run_monitor')
+eorm_log.setLevel(logging.INFO)
+
+fh = logging.FileHandler(get_log_file('end_of_run_monitor.log'))
+ch = logging.StreamHandler()
+formatter = logging.Formatter(LOG_FORMAT)
+fh.setFormatter(formatter)
+ch.setFormatter(formatter)
+
+eorm_log.addHandler(fh)
+eorm_log.addHandler(ch)
 
 
 class InstrumentMonitorError(Exception):
     pass
 
 
+def get_prefix_zeros(run_number_str):
+    """
+    Get the number of zeros prepended to a string
+    :param run_number_str: Run number as a string
+    :return: The zeros
+    """
+    zeros = ''
+    for c in run_number_str:
+        if c == '0':
+            zeros += '0'
+        else:
+            return zeros
+
+
 class InstrumentMonitor(object):
     """
     Checks the ISIS archive for new runs on an instrument and submits them to ActiveMQ
     """
-    def __init__(self, instrument_name, last_run_file, summary_file):
+    def __init__(self, client, instrument_name, last_run_file, summary_file, data_dir):
+        self.client = client
         self.instrument_name = instrument_name
         self.summary_file = summary_file
         self.last_run_file = last_run_file
+        self.data_dir = data_dir
 
     def read_instrument_last_run(self):
         """
         Read the last run recorded by the instrument from its lastrun.txt
-        :return: Last run on the instrument as an integer
+        :return: Last run on the instrument as a string
         """
         with open(self.last_run_file, 'r') as fp:
             line_parts = fp.readline().split()
             if len(line_parts) != 3:
                 raise InstrumentMonitorError("Unexpected last run file format for '{}'".format(self.last_run_file))
-            last_run = int(line_parts[1])
-        return last_run
+        return line_parts
 
     def read_rb_number_from_summary(self, run_number):
         """
@@ -51,13 +80,32 @@ class InstrumentMonitor(object):
                     return line_parts[-1]
         raise InstrumentMonitorError("Unable to find run number in summary.txt '{}'".format(run_number))
 
-    def submit_run(self, run_number):
+    def build_dict(self, rb_number, run_number, file_location):
+        """
+        Build the data dictionary for a reduction job submission.
+        :param rb_number: Experiment RB number
+        :param run_number: Run number as it appears in lastrun.txt
+        :param file_location: Absolute path to the data file
+        :return: Data dictionary for submission
+        """
+        return self.client.serialise_data(rb_number=rb_number,
+                                          instrument=self.instrument_name,
+                                          location=file_location,
+                                          run_number=run_number)
+
+    def submit_run(self, rb_number, run_number, file_name):
         """
         Submit a run to ActiveMQ
-        :param run_number: Particular run to submit
+        :param rb_number: RB number of the experiment
+        :param run_number: Run number as it appears in lastrun.txt
+        :param file_name: File name e.g. GEM1234.nxs
         """
         # Check to see if the last run exists, if not then raise an exception
+        file_path = os.path.join(self.data_dir, CYCLE_FOLDER, file_name)
+        eorm_log.info("Submitting: %s", file_path)
 
+        data_dict = self.build_dict(rb_number, run_number, file_path)
+        self.client.send('/queue/DataReady', json.dumps(data_dict), priority='9')
 
         # Submit run to ActiveMQ
         return None
@@ -69,25 +117,39 @@ class InstrumentMonitor(object):
         :param local_last_run: Local last run to check against
         """
         # Get archive lastrun.txt
-        instrument_last_run = self.read_instrument_last_run()
+        last_run_data = self.read_instrument_last_run()
+        instrument_last_run = last_run_data[1]
+
         rb_number = self.read_rb_number_from_summary(instrument_last_run)
-        for i in range(local_last_run + 1, instrument_last_run + 1):
-            self.submit_run(i)
-            print("Submitting %i" % i)
-        print("Instrument last run is %s" % instrument_last_run)
-        print("RB number is %s" % rb_number)
+
+        local_run_int = int(local_last_run)
+        instrument_run_int = int(instrument_last_run)
+
+        zeros = get_prefix_zeros(instrument_last_run)
+        if instrument_run_int > local_run_int:
+            eorm_log.info("Submitting runs in range %i - %i", local_run_int, instrument_run_int)
+            for i in range(local_run_int + 1, instrument_run_int + 1):
+                run_number = zeros + str(i)
+                file_name = last_run_data[0] + run_number + '.nxs'
+                self.submit_run(rb_number, run_number, file_name)
 
 
 def update_last_runs():
+    """
+    Read the last runs CSV file and bring it up to date with the
+    instrument lastrun.txt
+    """
+    connection = QueueClient()
+
     # Loop over instruments
     with open(LAST_RUNS_CSV, 'rb') as csv_file:
         csv_reader = csv.reader(csv_file)
         for row in csv_reader:
-            inst_mon = InstrumentMonitor(row[0], row[2], row[3])
+            inst_mon = InstrumentMonitor(connection, row[0], row[2], row[3], row[4])
             try:
-                inst_mon.submit_run_difference(int(row[1]))
+                inst_mon.submit_run_difference(row[1])
             except InstrumentMonitorError as ex:
-                logging.error(ex.message)
+                eorm_log.error(ex.message)
 
 
 def main():
@@ -97,8 +159,8 @@ def main():
         with FileLock("{}.lock".format(LAST_RUNS_CSV), timeout=1):
             update_last_runs()
     except Timeout:
-        logging.warn(("Error acquiring lock on last runs CSV."
-                      " There may be another instance running."))
+        eorm_log.warn(("Error acquiring lock on last runs CSV."
+                       " There may be another instance running."))
 
 
 if __name__ == '__main__':

--- a/monitors/new_end_of_run_monitor.py
+++ b/monitors/new_end_of_run_monitor.py
@@ -159,7 +159,7 @@ class InstrumentMonitor(object):
                 except FileNotFoundError as ex:
                     # If the file isn't found then just return the last file sent
                     # and try again next time
-                    EORM_LOG.error(ex.message)
+                    EORM_LOG.error(ex)
                     return str(i - 1)
         return str(instrument_run_int)
 
@@ -187,7 +187,7 @@ def update_last_runs(csv_name):
                 last_run = inst_mon.submit_run_difference(row[1])
                 row[1] = last_run
             except InstrumentMonitorError as ex:
-                EORM_LOG.error(ex.message)
+                EORM_LOG.error(ex)
             output.append(row)
 
     # Write any changes to the CSV

--- a/monitors/new_end_of_run_monitor.py
+++ b/monitors/new_end_of_run_monitor.py
@@ -164,16 +164,17 @@ class InstrumentMonitor(object):
         return str(instrument_run_int)
 
 
-def update_last_runs():
+def update_last_runs(csv_name):
     """
     Read the last runs CSV file and bring it up to date with the
     instrument lastrun.txt
+    :param csv_name: File name of the local last runs CSV file
     """
     connection = QueueClient()
 
     # Loop over instruments
     output = []
-    with open(LAST_RUNS_CSV, 'rb') as csv_file:
+    with open(csv_name, 'rb') as csv_file:
         csv_reader = csv.reader(csv_file)
         for row in csv_reader:
             inst_mon = InstrumentMonitor(connection, row[0])
@@ -190,7 +191,7 @@ def update_last_runs():
             output.append(row)
 
     # Write any changes to the CSV
-    with open(LAST_RUNS_CSV, 'wb') as csv_file:
+    with open(csv_name, 'wb') as csv_file:
         csv_writer = csv.writer(csv_file)
         for row in output:
             csv_writer.writerow(row)
@@ -204,7 +205,7 @@ def main():
     # by other instances of this script
     try:
         with FileLock("{}.lock".format(LAST_RUNS_CSV), timeout=1):
-            update_last_runs()
+            update_last_runs(LAST_RUNS_CSV)
     except Timeout:
         EORM_LOG.error(("Error acquiring lock on last runs CSV."
                         " There may be another instance running."))

--- a/monitors/test_settings.py
+++ b/monitors/test_settings.py
@@ -25,3 +25,7 @@ INSTRUMENTS = [{'name': 'WISH', 'use_nexus': True},
                {'name': 'POLARIS', 'use_nexus': True},
                {'name': 'MUSR', 'use_nexus': True},
                {'name': 'POLREF', 'use_nexus': True}]
+
+# New EoRM
+CYCLE_FOLDER = "cycle_18_4"
+LAST_RUNS_CSV = "lastruns.csv"

--- a/monitors/tests/test_new_end_of_run_monitor.py
+++ b/monitors/tests/test_new_end_of_run_monitor.py
@@ -1,3 +1,6 @@
+"""
+Unit tests for the end of run monitor
+"""
 import unittest
 import os
 import json
@@ -13,9 +16,12 @@ from monitors.new_end_of_run_monitor import (InstrumentMonitor,
                                              main)
 
 # Test data
-SUMMARY_FILE = ("WIS44731Hayden,Waite,CanfielCeAuSb2 MRSX ROT=15.05 s28-MAR-2019 09:14:23    34.3 1820461\n"
-                "WIS44732Hayden,Waite,CanfielCeAuSb2 MRSX ROT=15.05 s28-MAR-2019 10:23:47    40.0 1820461\n"
-                "WIS44733Hayden,Waite,CanfielCeAuSb2 MRSX ROT=15.05 s28-MAR-2019 11:34:25     9.0 1820461\n")
+SUMMARY_FILE = ("WIS44731Hayden,Waite,"
+                "CanfielCeAuSb2 MRSX ROT=15.05 s28-MAR-2019 09:14:23    34.3 1820461\n"
+                "WIS44732Hayden,Waite,"
+                "CanfielCeAuSb2 MRSX ROT=15.05 s28-MAR-2019 10:23:47    40.0 1820461\n"
+                "WIS44733Hayden,Waite,"
+                "CanfielCeAuSb2 MRSX ROT=15.05 s28-MAR-2019 11:34:25     9.0 1820461\n")
 LAST_RUN_FILE = "WISH 00044733 0 \n"
 RUN_DICT = {'instrument': 'WISH',
             'run_number': '00044733',
@@ -25,10 +31,8 @@ RUN_DICT = {'instrument': 'WISH',
 CSV_FILE = "WISH,44733,lastrun_wish.txt,summary_wish.txt,data_dir,.nxs"
 
 
+# pylint:disable=missing-docstring,no-self-use
 class TestEndOfRunMonitor(unittest.TestCase):
-    """
-    Test the end of run monitor
-    """
     def test_get_prefix_zeros(self):
         run_number = '00012345'
         zeros = get_prefix_zeros(run_number)
@@ -52,6 +56,7 @@ class TestEndOfRunMonitor(unittest.TestCase):
         self.assertEqual('0', last_run_data[2])
         os.remove('test_lastrun.txt')
 
+    # pylint:disable=invalid-name
     def test_read_rb_number_from_summary(self):
         with open('test_summary.txt', 'w') as summary_fp:
             summary_fp.write(SUMMARY_FILE)

--- a/monitors/tests/test_new_end_of_run_monitor.py
+++ b/monitors/tests/test_new_end_of_run_monitor.py
@@ -18,12 +18,12 @@ from monitors.new_end_of_run_monitor import (InstrumentMonitor,
                                              main)
 
 # Test data
-SUMMARY_FILE = ("WIS44731Hayden,Waite,"
-                "CanfielCeAuSb2 MRSX ROT=15.05 s28-MAR-2019 09:14:23    34.3 1820461\n"
-                "WIS44732Hayden,Waite,"
-                "CanfielCeAuSb2 MRSX ROT=15.05 s28-MAR-2019 10:23:47    40.0 1820461\n"
-                "WIS44733Hayden,Waite,"
-                "CanfielCeAuSb2 MRSX ROT=15.05 s28-MAR-2019 11:34:25     9.0 1820461\n")
+SUMMARY_FILE = ("WIS44731Smith,Smith,"
+                "SmithCeAuSb2 MRSX ROT=15.05 s28-MAR-2019 09:14:23    34.3 1820461\n"
+                "WIS44732Smith,Smith,"
+                "SmithCeAuSb2 MRSX ROT=15.05 s28-MAR-2019 10:23:47    40.0 1820461\n"
+                "WIS44733Smith,Smith,"
+                "SmithCeAuSb2 MRSX ROT=15.05 s28-MAR-2019 11:34:25     9.0 1820461\n")
 LAST_RUN_FILE = "WISH 00044733 0 \n"
 INVALID_LAST_RUN_FILE = "INVALID LAST RUN FILE"
 RUN_DICT = {'instrument': 'WISH',

--- a/monitors/tests/test_new_end_of_run_monitor.py
+++ b/monitors/tests/test_new_end_of_run_monitor.py
@@ -1,0 +1,63 @@
+import unittest
+import os
+
+from utils.clients.queue_client import QueueClient
+from monitors.new_end_of_run_monitor import (InstrumentMonitor, get_prefix_zeros)
+
+# Test data
+SUMMARY_FILE = ("WIS44731Hayden,Waite,CanfielCeAuSb2 MRSX ROT=15.05 s28-MAR-2019 09:14:23    34.3 1820461\n"
+                "WIS44732Hayden,Waite,CanfielCeAuSb2 MRSX ROT=15.05 s28-MAR-2019 10:23:47    40.0 1820461\n"
+                "WIS44733Hayden,Waite,CanfielCeAuSb2 MRSX ROT=15.05 s28-MAR-2019 11:34:25     9.0 1820461\n")
+LAST_RUN_FILE = "WISH 00044733 0 \n"
+
+
+class TestEndOfRunMonitor(unittest.TestCase):
+    """
+    Test the end of run monitor
+    """
+    def test_get_prefix_zeros(self):
+        run_number = '00012345'
+        zeros = get_prefix_zeros(run_number)
+        self.assertEqual('000', zeros)
+
+    def test_get_prefix_zeros_no_zeros(self):
+        run_number = '12345'
+        zeros = get_prefix_zeros(run_number)
+        self.assertEqual('', zeros)
+
+    def test_read_instrument_last_run(self):
+        with open('test_lastrun.txt', 'w') as last_run_fp:
+            last_run_fp.write(LAST_RUN_FILE)
+
+        inst_mon = InstrumentMonitor(None, 'WISH')
+        inst_mon.last_run_file = 'test_lastrun.txt'
+        last_run_data = inst_mon.read_instrument_last_run()
+
+        self.assertEqual('WISH', last_run_data[0])
+        self.assertEqual('00044733', last_run_data[1])
+        self.assertEqual('0', last_run_data[2])
+        os.remove('test_lastrun.txt')
+
+    def test_read_rb_number_from_summary(self):
+        with open('test_summary.txt', 'w') as summary_fp:
+            summary_fp.write(SUMMARY_FILE)
+
+        inst_mon = InstrumentMonitor(None, 'WISH')
+        inst_mon.summary_file = 'test_summary.txt'
+        rb_number = inst_mon.read_rb_number_from_summary(44733)
+        self.assertEqual('1820461', rb_number)
+        os.remove('test_summary.txt')
+
+    def test_build_dict(self):
+        client = QueueClient()
+        inst_mon = InstrumentMonitor(client, 'WISH')
+        data_loc = '/my/data/dir/cycle_18_4/WISH00044733.nxs'
+        rb_number = '1820461'
+        run_number = '00044733'
+        data_dict = inst_mon.build_dict(rb_number, run_number, data_loc)
+        expected = {'instrument': 'WISH',
+                    'run_number': run_number,
+                    'data': data_loc,
+                    'rb_number': rb_number,
+                    'facility': 'ISIS'}
+        self.assertEqual(expected, data_dict)

--- a/monitors/tests/test_new_end_of_run_monitor.py
+++ b/monitors/tests/test_new_end_of_run_monitor.py
@@ -52,8 +52,8 @@ class TestEndOfRunMonitor(unittest.TestCase):
         self.assertEqual(run_number, zeros)
 
     def test_read_instrument_last_run(self):
-        with open('test_lastrun.txt', 'w') as last_run_fp:
-            last_run_fp.write(LAST_RUN_FILE)
+        with open('test_lastrun.txt', 'w') as last_run:
+            last_run.write(LAST_RUN_FILE)
 
         inst_mon = InstrumentMonitor(None, 'WISH')
         inst_mon.last_run_file = 'test_lastrun.txt'
@@ -66,8 +66,8 @@ class TestEndOfRunMonitor(unittest.TestCase):
 
     # pylint:disable=invalid-name
     def test_read_instrument_last_run_invalid_length(self):
-        with open('test_lastrun.txt', 'w') as last_run_fp:
-            last_run_fp.write(INVALID_LAST_RUN_FILE)
+        with open('test_lastrun.txt', 'w') as last_run:
+            last_run.write(INVALID_LAST_RUN_FILE)
 
         inst_mon = InstrumentMonitor(None, 'WISH')
         inst_mon.last_run_file = 'test_lastrun.txt'
@@ -77,8 +77,8 @@ class TestEndOfRunMonitor(unittest.TestCase):
 
     # pylint:disable=invalid-name
     def test_read_rb_number_from_summary(self):
-        with open('test_summary.txt', 'w') as summary_fp:
-            summary_fp.write(SUMMARY_FILE)
+        with open('test_summary.txt', 'w') as summary:
+            summary.write(SUMMARY_FILE)
 
         inst_mon = InstrumentMonitor(None, 'WISH')
         inst_mon.summary_file = 'test_summary.txt'
@@ -87,8 +87,8 @@ class TestEndOfRunMonitor(unittest.TestCase):
         os.remove('test_summary.txt')
 
     def test_read_rb_number_from_summary_invalid(self):
-        with open('test_summary.txt', 'w') as summary_fp:
-            summary_fp.write(SUMMARY_FILE)
+        with open('test_summary.txt', 'w') as summary:
+            summary.write(SUMMARY_FILE)
 
         inst_mon = InstrumentMonitor(None, 'WISH')
         inst_mon.summary_file = 'test_summary.txt'
@@ -167,8 +167,8 @@ class TestEndOfRunMonitor(unittest.TestCase):
            return_value='44736')
     def test_update_last_runs(self, run_diff_mock, inst_mon_mock):
         # Setup test
-        with open('test_last_runs.csv', 'w') as last_runs_fp:
-            last_runs_fp.write(CSV_FILE)
+        with open('test_last_runs.csv', 'w') as last_runs:
+            last_runs.write(CSV_FILE)
 
         # Perform test
         update_last_runs('test_last_runs.csv')
@@ -188,8 +188,8 @@ class TestEndOfRunMonitor(unittest.TestCase):
            side_effect=InstrumentMonitorError('Error'))
     def test_update_last_runs_with_error(self, run_diff_mock, inst_mon_mock):
         # Setup test
-        with open('test_last_runs.csv', 'w') as last_runs_fp:
-            last_runs_fp.write(CSV_FILE)
+        with open('test_last_runs.csv', 'w') as last_runs:
+            last_runs.write(CSV_FILE)
 
         # Perform test
         update_last_runs('test_last_runs.csv')

--- a/monitors/tests/test_new_end_of_run_monitor.py
+++ b/monitors/tests/test_new_end_of_run_monitor.py
@@ -1,14 +1,28 @@
 import unittest
 import os
+import json
+import csv
+from mock import (Mock, patch, call)
 
 from utils.clients.queue_client import QueueClient
-from monitors.new_end_of_run_monitor import (InstrumentMonitor, get_prefix_zeros)
+from monitors.settings import (CYCLE_FOLDER, LAST_RUNS_CSV)
+from monitors.new_end_of_run_monitor import (InstrumentMonitor,
+                                             get_prefix_zeros,
+                                             FileNotFoundError,
+                                             update_last_runs,
+                                             main)
 
 # Test data
 SUMMARY_FILE = ("WIS44731Hayden,Waite,CanfielCeAuSb2 MRSX ROT=15.05 s28-MAR-2019 09:14:23    34.3 1820461\n"
                 "WIS44732Hayden,Waite,CanfielCeAuSb2 MRSX ROT=15.05 s28-MAR-2019 10:23:47    40.0 1820461\n"
                 "WIS44733Hayden,Waite,CanfielCeAuSb2 MRSX ROT=15.05 s28-MAR-2019 11:34:25     9.0 1820461\n")
 LAST_RUN_FILE = "WISH 00044733 0 \n"
+RUN_DICT = {'instrument': 'WISH',
+            'run_number': '00044733',
+            'data': '/my/data/dir/cycle_18_4/WISH00044733.nxs',
+            'rb_number': '1820461',
+            'facility': 'ISIS'}
+CSV_FILE = "WISH,44733,lastrun_wish.txt,summary_wish.txt,data_dir,.nxs"
 
 
 class TestEndOfRunMonitor(unittest.TestCase):
@@ -55,9 +69,72 @@ class TestEndOfRunMonitor(unittest.TestCase):
         rb_number = '1820461'
         run_number = '00044733'
         data_dict = inst_mon.build_dict(rb_number, run_number, data_loc)
-        expected = {'instrument': 'WISH',
-                    'run_number': run_number,
-                    'data': data_loc,
-                    'rb_number': rb_number,
-                    'facility': 'ISIS'}
-        self.assertEqual(expected, data_dict)
+        self.assertEqual(RUN_DICT, data_dict)
+
+    @patch('os.path.isfile', return_value=True)
+    def test_submit_run(self, isfile_mock):
+        client = Mock()
+        client.send = Mock(return_value=None)
+        client.serialise_data = Mock(return_value=RUN_DICT)
+
+        inst_mon = InstrumentMonitor(client, 'WISH')
+        inst_mon.data_dir = '/my/data/dir'
+        data_loc = os.path.join(inst_mon.data_dir, CYCLE_FOLDER, 'WISH00044733.nxs')
+        inst_mon.submit_run('1820461', '00044733', 'WISH00044733.nxs')
+        client.send.assert_called_with('/queue/DataReady', json.dumps(RUN_DICT), priority='9')
+        isfile_mock.assert_called_with(data_loc)
+
+    @patch('os.path.isfile', return_value=False)
+    def test_submit_run_file_not_found(self, isfile_mock):
+        client = Mock()
+        client.send = Mock(return_value=None)
+        client.serialise_data = Mock(return_value=RUN_DICT)
+
+        inst_mon = InstrumentMonitor(client, 'WISH')
+        inst_mon.data_dir = '/my/data/dir'
+        data_loc = os.path.join(inst_mon.data_dir, CYCLE_FOLDER, 'WISH00044733.nxs')
+        with self.assertRaises(FileNotFoundError):
+            inst_mon.submit_run('1820461', '00044733', 'WISH00044733.nxs')
+        isfile_mock.assert_called_with(data_loc)
+
+    def test_submit_run_difference(self):
+        # Setup test
+        inst_mon = InstrumentMonitor(None, 'WISH')
+        inst_mon.submit_run = Mock(return_value=None)
+        inst_mon.file_ext = '.nxs'
+        inst_mon.read_instrument_last_run = Mock(return_value=['WISH',
+                                                               '00044733',
+                                                               '0'])
+        inst_mon.read_rb_number_from_summary = Mock(return_value='1820461')
+
+        # Perform test
+        inst_mon.submit_run_difference(44731)
+        inst_mon.submit_run.assert_has_calls([call('1820461', '00044732', 'WISH00044732.nxs'),
+                                              call('1820461', '00044733', 'WISH00044733.nxs')])
+
+    @patch('monitors.new_end_of_run_monitor.InstrumentMonitor.__init__',
+           return_value=None)
+    @patch('monitors.new_end_of_run_monitor.InstrumentMonitor.submit_run_difference',
+           return_value='44736')
+    def test_update_last_runs(self, run_diff_mock, inst_mon_mock):
+        # Setup test
+        with open('test_last_runs.csv', 'w') as last_runs_fp:
+            last_runs_fp.write(CSV_FILE)
+
+        # Perform test
+        update_last_runs('test_last_runs.csv')
+        inst_mon_mock.assert_called()
+        run_diff_mock.assert_called_with('44733')
+
+        # Read the CSV and ensure it has been updated
+        with open('test_last_runs.csv') as csv_file:
+            csv_reader = csv.reader(csv_file)
+            for row in csv_reader:
+                self.assertEqual('44736', row[1])
+        os.remove('test_last_runs.csv')
+
+    @patch('monitors.new_end_of_run_monitor.update_last_runs')
+    def test_main(self, update_last_runs_mock):
+        main()
+        update_last_runs_mock.assert_called_with(LAST_RUNS_CSV)
+        update_last_runs_mock.assert_called_once()

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,8 @@ setup_requires = ['Django',
                   'stomp.py',
                   'suds',
                   'Twisted',
-                  'watchdog']
+                  'watchdog',
+                  'filelock']
 
 if platform.system() == 'Windows':
     setup_requires.append('pypiwin32')

--- a/utils/clients/queue_client.py
+++ b/utils/clients/queue_client.py
@@ -147,4 +147,3 @@ class QueueClient(AbstractClient):
                               persistent=persistent,
                               priority=priority,
                               delay=delay)
-        self.disconnect()

--- a/utils/clients/queue_client.py
+++ b/utils/clients/queue_client.py
@@ -147,3 +147,4 @@ class QueueClient(AbstractClient):
                               persistent=persistent,
                               priority=priority,
                               delay=delay)
+        self._connection.disconnect()

--- a/utils/clients/queue_client.py
+++ b/utils/clients/queue_client.py
@@ -147,4 +147,4 @@ class QueueClient(AbstractClient):
                               persistent=persistent,
                               priority=priority,
                               delay=delay)
-        self._connection.disconnect()
+        self.disconnect()


### PR DESCRIPTION
### Summary of work

Implementation of the new end of run monitor design.

### How to test your work

See updated README file for details on how to setup locally.

Unit tests can be run without any setup. Just type ```pytest test_new_end_of_run_monitor.py```

### Additional comments

I have made the cycle folder a setting that has to be manually adjusted. The reason I did this is to minimise the knowledge of the archive that's written into the code itself, this helps with testing because we don't have to go about setting up fake archives. At the same time, I thought it would be too cumbersome to have to adjust the cycle folder on every instrument in the CSV file, so I put it in settings.py. Let me know what you think is best.

I experienced difficulty with the EoRM logging config being overwritten by that of the queue client. That's why I have set up a logger in a slightly different way.

Fixes #299
