### PR TITLE
Added date to error messages on the run summary page

### DIFF
--- a/WebApp/autoreduce_webapp/templates/run_summary.html
+++ b/WebApp/autoreduce_webapp/templates/run_summary.html
@@ -20,7 +20,7 @@
         </div>
         {% if run.message %}
             <div class="alert alert-{% replace run.status.value 'Error' 'danger' %} word-wrap" role="alert">
-                <i class="fa fa-{% replace run.status.value 'Error' 'exclamation' %} fa-{% replace run.status.value 'Error' 'exclamation' %}-circle fa-lg"></i> <a href="#" class="js-log-display">{{ run.message }}</a>
+                <i class="fa fa-{% replace run.status.value 'Error' 'exclamation' %} fa-{% replace run.status.value 'Error' 'exclamation' %}-circle fa-lg"></i> <a href="#" class="js-log-display">[{{ run.finished }}] {{ run.message }}</a>
             </div>
         {% endif %}
         <div class="row">


### PR DESCRIPTION
### Summary of work
Added a date to the error messages displayed on the run summary page. I assume that the error is generated when the run is marked as finished.

### How to test your work
Load a failed run in the webapp and see that the date is correctly displayed.

Fixes #294 
