### PR TITLE
Default to using the last row in the summary file

### DIFF
--- a/monitors/new_end_of_run_monitor.py
+++ b/monitors/new_end_of_run_monitor.py
@@ -129,7 +129,8 @@ class InstrumentMonitor(object):
             # each run number in the summary file. This means that the same run
             # number could occur more than once. It should be assumed that the
             # latest is the correct run.
-            for line in reversed(summary.readlines()):
+            summary_lines = summary.readlines()
+            for line in reversed(summary_lines):
                 line_parts = line.split()
 
                 if line_parts:
@@ -138,6 +139,13 @@ class InstrumentMonitor(object):
                     if summary_run in str(run_number):
                         # The last entry is the RB number
                         return line_parts[-1]
+
+            # Default to choosing the last row
+            last_line = summary_lines[-1]
+            line_parts = last_line.split()
+            if line_parts:
+                return line_parts[-1]
+
         raise InstrumentMonitorError("Unable to find run number in summary.txt '{}'"
                                      .format(run_number))
 

--- a/monitors/new_end_of_run_monitor.py
+++ b/monitors/new_end_of_run_monitor.py
@@ -141,6 +141,8 @@ class InstrumentMonitor(object):
                         return line_parts[-1]
 
             # Default to choosing the last row
+            EORM_LOG.info("Can't find run %s in summary file for %s defaulting to last entry",
+                          run_number, self.instrument_name)
             last_line = summary_lines[-1]
             line_parts = last_line.split()
             if line_parts:

--- a/monitors/tests/test_new_end_of_run_monitor.py
+++ b/monitors/tests/test_new_end_of_run_monitor.py
@@ -88,7 +88,6 @@ class TestEndOfRunMonitor(unittest.TestCase):
         self.assertEqual('WISH', last_run_data[0])
         self.assertEqual('00044733', last_run_data[1])
         self.assertEqual('0', last_run_data[2])
-        os.remove('test_lastrun.txt')
 
     # pylint:disable=invalid-name
     def test_read_instrument_last_run_invalid_length(self):
@@ -99,7 +98,6 @@ class TestEndOfRunMonitor(unittest.TestCase):
         inst_mon.last_run_file = 'test_lastrun.txt'
         with self.assertRaises(InstrumentMonitorError):
             inst_mon.read_instrument_last_run()
-        os.remove('test_lastrun.txt')
 
     # pylint:disable=invalid-name
     def test_read_rb_number_from_summary(self):
@@ -110,7 +108,6 @@ class TestEndOfRunMonitor(unittest.TestCase):
         inst_mon.summary_file = 'test_summary.txt'
         rb_number = inst_mon.read_rb_number_from_summary(44733)
         self.assertEqual('1820461', rb_number)
-        os.remove('test_summary.txt')
 
     def test_read_rb_number_from_summary_run_not_found(self):
         with open('test_summary.txt', 'w') as summary:
@@ -119,7 +116,6 @@ class TestEndOfRunMonitor(unittest.TestCase):
         inst_mon = InstrumentMonitor(None, 'WISH')
         inst_mon.summary_file = 'test_summary.txt'
         self.assertEqual('1820461', inst_mon.read_rb_number_from_summary(12345))
-        os.remove('test_summary.txt')
 
     def test_read_rb_number_from_summary_invalid(self):
         with open('test_summary.txt', 'w') as summary:
@@ -127,7 +123,6 @@ class TestEndOfRunMonitor(unittest.TestCase):
         inst_mon = InstrumentMonitor(None, 'WISH')
         inst_mon.summary_file = 'test_summary.txt'
         self.assertRaises(InstrumentMonitorError, inst_mon.read_rb_number_from_summary, 12345)
-        os.remove('test_summary.txt')
 
     def test_build_dict(self):
         client = QueueClient()
@@ -213,7 +208,6 @@ class TestEndOfRunMonitor(unittest.TestCase):
             csv_reader = csv.reader(csv_file)
             for row in csv_reader:
                 self.assertEqual('44736', row[1])
-        os.remove('test_last_runs.csv')
 
     @patch('monitors.new_end_of_run_monitor.InstrumentMonitor.__init__',
            return_value=None)
@@ -234,7 +228,6 @@ class TestEndOfRunMonitor(unittest.TestCase):
             csv_reader = csv.reader(csv_file)
             for row in csv_reader:
                 self.assertEqual('44733', row[1])
-        os.remove('test_last_runs.csv')
 
     @patch('monitors.new_end_of_run_monitor.update_last_runs')
     def test_main(self, update_last_runs_mock):

--- a/monitors/tests/test_new_end_of_run_monitor.py
+++ b/monitors/tests/test_new_end_of_run_monitor.py
@@ -34,6 +34,14 @@ CSV_FILE = "WISH,44733,lastrun_wish.txt,summary_wish.txt,data_dir,.nxs"
 
 # pylint:disable=missing-docstring,no-self-use,too-many-public-methods
 class TestEndOfRunMonitor(unittest.TestCase):
+    def tearDown(self):
+        if os.path.isfile('test_lastrun.txt'):
+            os.remove('test_lastrun.txt')
+        if os.path.isfile('test_summary.txt'):
+            os.remove('test_summary.txt')
+        if os.path.isfile('test_last_runs.csv'):
+            os.remove('test_last_runs.csv')
+
     def test_get_prefix_zeros(self):
         run_number = '00012345'
         zeros = eorm.get_prefix_zeros(run_number)
@@ -104,14 +112,21 @@ class TestEndOfRunMonitor(unittest.TestCase):
         self.assertEqual('1820461', rb_number)
         os.remove('test_summary.txt')
 
-    def test_read_rb_number_from_summary_invalid(self):
+    def test_read_rb_number_from_summary_run_not_found(self):
         with open('test_summary.txt', 'w') as summary:
             summary.write(SUMMARY_FILE)
 
         inst_mon = InstrumentMonitor(None, 'WISH')
         inst_mon.summary_file = 'test_summary.txt'
-        with self.assertRaises(InstrumentMonitorError):
-            inst_mon.read_rb_number_from_summary(12345)
+        self.assertEqual('1820461', inst_mon.read_rb_number_from_summary(12345))
+        os.remove('test_summary.txt')
+
+    def test_read_rb_number_from_summary_invalid(self):
+        with open('test_summary.txt', 'w') as summary:
+            summary.write(' ')
+        inst_mon = InstrumentMonitor(None, 'WISH')
+        inst_mon.summary_file = 'test_summary.txt'
+        self.assertRaises(InstrumentMonitorError, inst_mon.read_rb_number_from_summary, 12345)
         os.remove('test_summary.txt')
 
     def test_build_dict(self):


### PR DESCRIPTION
### Summary of work
Instrument summary files do not follow a well defined format, so there is a chance that the end of run monitor will encounter a case where it can't locate the correct run number. Rather than getting stuck on a run and being unable to move on, it should just select the last run as the most likely to be applicable.

### How to test your work
I have added a unit test for this case. It can be tested manually by making a copy of a summary file and removing an entry. Then point your lastruns.csv to this file and attempt to submit a run, check that it just submits the last entry.

Fixes #310 
