### PR TITLE
Credentials file for services

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@
 
 # Ignore settings files
 settings.py
+credentials.ini
 
 # Ignore distutils installation
 dist/

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,10 +32,11 @@ install:
   - python setup.py externals -s activemq,icat
   - python setup.py database
   - sudo python setup.py start
-
+  - cat build.log
 script:
   # ================ Assert Test Setup =============== #
   - pytest build/tests/test_db_generation.py
+  - exit(1)
 
   # ================ Static Analysis ================= #
   - ./build/tests/test_pylint.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,11 +32,10 @@ install:
   - python setup.py externals -s activemq,icat
   - python setup.py database
   - sudo python setup.py start
-  - cat build.log
+
 script:
   # ================ Assert Test Setup =============== #
   - pytest build/tests/test_db_generation.py
-  - exit(1)
 
   # ================ Static Analysis ================= #
   - ./build/tests/test_pylint.sh

--- a/WebApp/autoreduce_webapp/autoreduce_webapp/test_settings.py
+++ b/WebApp/autoreduce_webapp/autoreduce_webapp/test_settings.py
@@ -6,8 +6,15 @@
 # ############################################################################### #
 # pylint: skip-file
 import os
+import configparser
+
 
 BASE_DIR = os.path.dirname(os.path.dirname(__file__))
+
+# Read the utilities .ini file that contains service credentials
+INI_FILE = os.path.join(os.path.dirname(os.path.dirname(BASE_DIR)), 'utils', 'credentials.ini')
+CONFIG = configparser.ConfigParser()
+CONFIG.read(INI_FILE)
 
 # Quick-start development settings - unsuitable for production
 # See https://docs.djangoproject.com/en/dev/howto/deployment/checklist/
@@ -54,6 +61,11 @@ MIDDLEWARE_CLASSES = [
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
 ]
 
+# Add debug toolbar only if in DEBUG mode
+if DEBUG:
+    INSTALLED_APPS.append('debug_toolbar')
+    MIDDLEWARE_CLASSES.insert(3, 'debug_toolbar.middleware.DebugToolbarMiddleware')
+
 AUTHENTICATION_BACKENDS = [
     'autoreduce_webapp.backends.UOWSAuthenticationBackend',
     'django.contrib.auth.backends.ModelBackend',
@@ -87,11 +99,11 @@ WSGI_APPLICATION = 'autoreduce_webapp.wsgi.application'
 DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.mysql',
-        'NAME': 'autoreduction',
-        'USER': 'test-user',
-        'PASSWORD': 'pass',
-        'HOST': 'localhost',
-        'PORT': '3306',
+        'NAME': CONFIG.get('DATABASE', 'name'),
+        'USER': CONFIG.get('DATABASE', 'user'),
+        'PASSWORD': CONFIG.get('DATABASE', 'password'),
+        'HOST': CONFIG.get('DATABASE', 'host'),
+        'PORT': CONFIG.get('DATABASE', 'port'),
         'OPTIONS': {
             'init_command': "SET sql_mode='STRICT_TRANS_TABLES'",
         },
@@ -168,9 +180,9 @@ ACTIVEMQ = {
         '/queue/ReductionComplete',
         '/queue/ReductionError'
     ],
-    'username': 'admin',
-    'password': 'admin',
-    'broker': [("127.0.1.1", 61613)],
+    'username': CONFIG.get('QUEUE', 'user'),
+    'password': CONFIG.get('QUEUE', 'password'),
+    'broker': [(CONFIG.get('QUEUE', 'host'), CONFIG.get('QUEUE', 'port'))],
     'SSL': False
 }
 
@@ -193,10 +205,10 @@ else:
 # ICAT
 
 ICAT = {
-    'AUTH': 'YOUR-ICAT-AUTH',
-    'URL': 'YOUR-ICAT-WSDL',
-    'USER': 'YOUR-ICAT-USERNAME',
-    'PASSWORD': 'YOUR-ICAT-PASSWORD'
+    'AUTH': CONFIG.get('ICAT', 'auth'),
+    'URL': CONFIG.get('ICAT', 'host'),
+    'USER': CONFIG.get('ICAT', 'user'),
+    'PASSWORD': CONFIG.get('ICAT', 'password')
 }
 
 # Outdated Browsers

--- a/WebApp/autoreduce_webapp/autoreduce_webapp/test_settings.py
+++ b/WebApp/autoreduce_webapp/autoreduce_webapp/test_settings.py
@@ -16,6 +16,11 @@ INI_FILE = os.path.join(os.path.dirname(os.path.dirname(BASE_DIR)), 'utils', 'cr
 CONFIG = configparser.ConfigParser()
 CONFIG.read(INI_FILE)
 
+
+def get_str(section, key):
+    return str(CONFIG.get(section, key))
+
+
 # Quick-start development settings - unsuitable for production
 # See https://docs.djangoproject.com/en/dev/howto/deployment/checklist/
 
@@ -46,7 +51,6 @@ INSTALLED_APPS = [
     'autoreduce_webapp',
     'reduction_viewer',
     'reduction_variables',
-    'django_user_agents',
 ]
 
 MIDDLEWARE_CLASSES = [
@@ -60,11 +64,6 @@ MIDDLEWARE_CLASSES = [
     'django_user_agents.middleware.UserAgentMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
 ]
-
-# Add debug toolbar only if in DEBUG mode
-if DEBUG:
-    INSTALLED_APPS.append('debug_toolbar')
-    MIDDLEWARE_CLASSES.insert(3, 'debug_toolbar.middleware.DebugToolbarMiddleware')
 
 AUTHENTICATION_BACKENDS = [
     'autoreduce_webapp.backends.UOWSAuthenticationBackend',
@@ -99,11 +98,11 @@ WSGI_APPLICATION = 'autoreduce_webapp.wsgi.application'
 DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.mysql',
-        'NAME': CONFIG.get('DATABASE', 'name'),
-        'USER': CONFIG.get('DATABASE', 'user'),
-        'PASSWORD': CONFIG.get('DATABASE', 'password'),
-        'HOST': CONFIG.get('DATABASE', 'host'),
-        'PORT': CONFIG.get('DATABASE', 'port'),
+        'NAME': get_str('DATABASE', 'name'),
+        'USER': get_str('DATABASE', 'user'),
+        'PASSWORD': get_str('DATABASE', 'password'),
+        'HOST': get_str('DATABASE', 'host'),
+        'PORT': get_str('DATABASE', 'port'),
         'OPTIONS': {
             'init_command': "SET sql_mode='STRICT_TRANS_TABLES'",
         },
@@ -180,9 +179,9 @@ ACTIVEMQ = {
         '/queue/ReductionComplete',
         '/queue/ReductionError'
     ],
-    'username': CONFIG.get('QUEUE', 'user'),
-    'password': CONFIG.get('QUEUE', 'password'),
-    'broker': [(CONFIG.get('QUEUE', 'host'), CONFIG.get('QUEUE', 'port'))],
+    'username': get_str('QUEUE', 'user'),
+    'password': get_str('QUEUE', 'password'),
+    'broker': [(get_str('QUEUE', 'host'), get_str('QUEUE', 'port'))],
     'SSL': False
 }
 
@@ -205,10 +204,10 @@ else:
 # ICAT
 
 ICAT = {
-    'AUTH': CONFIG.get('ICAT', 'auth'),
-    'URL': CONFIG.get('ICAT', 'host'),
-    'USER': CONFIG.get('ICAT', 'user'),
-    'PASSWORD': CONFIG.get('ICAT', 'password')
+    'AUTH': get_str('ICAT', 'auth'),
+    'URL': get_str('ICAT', 'host'),
+    'USER': get_str('ICAT', 'user'),
+    'PASSWORD': get_str('ICAT', 'password')
 }
 
 # Outdated Browsers

--- a/build/commands/migrate_settings.py
+++ b/build/commands/migrate_settings.py
@@ -41,15 +41,16 @@ class MigrateTestSettings(Command):
                                                  'AutoreductionProcessor'),
                                     os.path.join(ROOT_DIR, 'QueueProcessors',
                                                  'QueueProcessor')]
+        self.utils_path = os.path.join(ROOT_DIR, 'utils')
 
     def run(self):
         """ Copy all test files from the test files list to desired locations """
         BUILD_LOGGER.print_and_log("================== Migrate test settings ====================")
-        self._migrate_test_settings(self.test_settings_paths)
+        self._migrate_test_settings(self.test_settings_paths, self.utils_path)
         BUILD_LOGGER.print_and_log("Test settings successfully migrated\n")
 
     @staticmethod
-    def _migrate_test_settings(all_paths):
+    def _migrate_test_settings(all_paths, utils_path):
         """
         Copy any test_settings.py files in given directory list to settings.py files
         :param all_paths: All directories containing test_settings.py
@@ -59,6 +60,13 @@ class MigrateTestSettings(Command):
                 test_settings_path = os.path.join(path_to_dir, 'test_settings.py')
                 settings_path = os.path.join(path_to_dir, 'settings.py')
                 copyfile(test_settings_path, settings_path)
+        except OSError as error:
+            BUILD_LOGGER.logger.error(error)
+            raise
+        try:
+            test_credentials_path = os.path.join(utils_path, 'test_credentials.ini')
+            credentials_path = os.path.join(utils_path, 'credentials.ini')
+            copyfile(test_credentials_path, credentials_path)
         except OSError as error:
             BUILD_LOGGER.logger.error(error)
             raise

--- a/utils/test_credentials.ini
+++ b/utils/test_credentials.ini
@@ -1,0 +1,19 @@
+## Credentials for external services that autoreduction contects to
+[DATABASE]
+user=test-user
+password=pass
+host=localhost
+port=3306
+name=autoreduction
+
+[ICAT]
+user=username
+password=password
+host=icat-url
+auth=simple
+
+[QUEUE]
+user=admin
+password=admin
+host=127.0.1.1
+port=61613

--- a/utils/test_credentials.ini
+++ b/utils/test_credentials.ini
@@ -7,9 +7,9 @@ port=3306
 name=autoreduction
 
 [ICAT]
-user=username
-password=password
-host=icat-url
+user=YOUR-ICAT-USERNAME
+password=YOUR-PASSWORD
+host=YOUR-ICAT-WSDL-URL
 auth=simple
 
 [QUEUE]

--- a/utils/test_settings.py
+++ b/utils/test_settings.py
@@ -9,6 +9,9 @@
 Settings for connecting to the test services that run locally
 """
 import configparser
+import os
+
+from utils.project.structure import get_project_root
 from utils.clients.settings.client_settings_factory import ClientSettingsFactory
 
 
@@ -16,24 +19,32 @@ VALID_INSTRUMENTS = ['GEM', 'POLARIS', 'WISH', 'OSIRIS', 'MUSR', 'POLREF']
 
 
 CONFIG = configparser.ConfigParser()
+INI_FILE = os.path.join(get_project_root(), 'utils', 'credentials.ini')
+CONFIG.read(INI_FILE)
+
+
+def get_str(section, key):
+    return str(CONFIG.get(section, key))
+
+
 SETTINGS_FACTORY = ClientSettingsFactory()
 
 ICAT_SETTINGS = SETTINGS_FACTORY.create('icat',
-                                        username=CONFIG.get('ICAT', 'user'),
-                                        password=CONFIG.get('ICAT', 'password'),
-                                        host=CONFIG.get('ICAT', 'host'),
+                                        username=get_str('ICAT', 'user'),
+                                        password=get_str('ICAT', 'password'),
+                                        host=get_str('ICAT', 'host'),
                                         port='',
-                                        authentication_type=CONFIG.get('ICAT', 'auth'))
+                                        authentication_type=get_str('ICAT', 'auth'))
 
 MYSQL_SETTINGS = SETTINGS_FACTORY.create('database',
-                                         username=CONFIG.get('DATABASE', 'user'),
-                                         password=CONFIG.get('DATABASE', 'password'),
-                                         host=CONFIG.get('DATABASE', 'host'),
-                                         port=CONFIG.get('DATABASE', 'port'),
-                                         database_name=CONFIG.get('DATABASE', 'name'))
+                                         username=get_str('DATABASE', 'user'),
+                                         password=get_str('DATABASE', 'password'),
+                                         host=get_str('DATABASE', 'host'),
+                                         port=get_str('DATABASE', 'port'),
+                                         database_name=get_str('DATABASE', 'name'))
 
 ACTIVEMQ_SETTINGS = SETTINGS_FACTORY.create('queue',
-                                            username=CONFIG.get('QUEUE', 'user'),
-                                            password=CONFIG.get('QUEUE', 'password'),
-                                            host=CONFIG.get('QUEUE', 'host'),
-                                            port=CONFIG.get('QUEUE', 'port'))
+                                            username=get_str('QUEUE', 'user'),
+                                            password=get_str('QUEUE', 'password'),
+                                            host=get_str('QUEUE', 'host'),
+                                            port=get_str('QUEUE', 'port'))

--- a/utils/test_settings.py
+++ b/utils/test_settings.py
@@ -8,30 +8,32 @@
 """
 Settings for connecting to the test services that run locally
 """
-
+import configparser
 from utils.clients.settings.client_settings_factory import ClientSettingsFactory
 
 
 VALID_INSTRUMENTS = ['GEM', 'POLARIS', 'WISH', 'OSIRIS', 'MUSR', 'POLREF']
 
+
+CONFIG = configparser.ConfigParser()
 SETTINGS_FACTORY = ClientSettingsFactory()
 
 ICAT_SETTINGS = SETTINGS_FACTORY.create('icat',
-                                        username='YOUR-ICAT-USERNAME',
-                                        password='YOUR-PASSWORD',
-                                        host='YOUR-ICAT-WSDL-URL',
+                                        username=CONFIG.get('ICAT', 'user'),
+                                        password=CONFIG.get('ICAT', 'password'),
+                                        host=CONFIG.get('ICAT', 'host'),
                                         port='',
-                                        authentication_type='simple')
+                                        authentication_type=CONFIG.get('ICAT', 'auth'))
 
 MYSQL_SETTINGS = SETTINGS_FACTORY.create('database',
-                                         username='test-user',
-                                         password='pass',
-                                         host='localhost',
-                                         port='3306',
-                                         database_name='autoreduction')
+                                         username=CONFIG.get('DATABASE', 'user'),
+                                         password=CONFIG.get('DATABASE', 'password'),
+                                         host=CONFIG.get('DATABASE', 'host'),
+                                         port=CONFIG.get('DATABASE', 'port'),
+                                         database_name=CONFIG.get('DATABASE', 'name'))
 
 ACTIVEMQ_SETTINGS = SETTINGS_FACTORY.create('queue',
-                                            username='admin',
-                                            password='admin',
-                                            host='127.0.1.1',
-                                            port='61613')
+                                            username=CONFIG.get('QUEUE', 'user'),
+                                            password=CONFIG.get('QUEUE', 'password'),
+                                            host=CONFIG.get('QUEUE', 'host'),
+                                            port=CONFIG.get('QUEUE', 'port'))


### PR DESCRIPTION
### Summary of work
* Add an `.ini` file that holds all the credentials for services
* update build script to move test `.ini` file

### How to test your work
* Run `python setup.py test_settings` from the root directory of the project
* Enter valid credentials into the `utils/credentials.ini`
  * I would suggest trying this with local settings first then development settings
* Run the webapp: python Webapp/autoreduce_webapp/manage.py runserver
* Check it is using the expected settings
* Use manual submission to submit a run
* Ensure this run appears in the webapp (the 2 are using the same settings)

Fixes #320
