### PR TITLE
Take last RB number from summary

### DIFF
--- a/monitors/new_end_of_run_monitor.py
+++ b/monitors/new_end_of_run_monitor.py
@@ -60,19 +60,6 @@ def get_prefix_zeros(run_number_str):
     return zeros
 
 
-def is_integer(int_str):
-    """
-    Test to see if the provided string is an integer
-    :param int_str: Integer as a string
-    :return: True if the string represents an integer
-    """
-    try:
-        int(int_str)
-        return True
-    except ValueError:
-        return False
-
-
 class InstrumentMonitor(object):
     """
     Checks the ISIS archive for new runs on an instrument and submits them to ActiveMQ
@@ -97,7 +84,7 @@ class InstrumentMonitor(object):
                                              .format(self.last_run_file))
         return line_parts
 
-    def read_rb_number_from_summary(self, run_number):
+    def read_rb_number_from_summary(self):
         """
         Loads the summary file and reads off the experiment RB number
         :param run_number: Run number to lookup
@@ -110,8 +97,7 @@ class InstrumentMonitor(object):
             if line_parts:
                 return line_parts[-1]
 
-        raise InstrumentMonitorError("Unable to read RB number from summary.txt '{}'"
-                                     .format(run_number))
+        raise InstrumentMonitorError("Unable to read RB number from summary.txt")
 
     def build_dict(self, rb_number, run_number, file_location):
         """
@@ -155,7 +141,7 @@ class InstrumentMonitor(object):
         local_run_int = int(local_last_run)
         instrument_run_int = int(instrument_last_run)
 
-        rb_number = self.read_rb_number_from_summary(str(instrument_run_int))
+        rb_number = self.read_rb_number_from_summary()
         zeros = get_prefix_zeros(instrument_last_run)
         if instrument_run_int > local_run_int:
             EORM_LOG.info("Submitting runs in range %i - %i for %s",

--- a/monitors/new_end_of_run_monitor.py
+++ b/monitors/new_end_of_run_monitor.py
@@ -73,26 +73,6 @@ def is_integer(int_str):
         return False
 
 
-def extract_run_number_from_summary(first_part):
-    """
-    Look for the run number in the provided summary entry
-    :param first_part: First part of the summary entry
-    :return: Run number as printed in the summary file
-    """
-    run_number = ""
-    reading_run_number = False
-    for char in first_part:
-        # Find the first integer
-        if is_integer(char):
-            run_number += char
-            reading_run_number = True
-        elif reading_run_number:
-            # The first non-integer character indicates the end
-            # of the run number
-            return run_number
-    return run_number
-
-
 class InstrumentMonitor(object):
     """
     Checks the ISIS archive for new runs on an instrument and submits them to ActiveMQ

--- a/monitors/new_end_of_run_monitor.py
+++ b/monitors/new_end_of_run_monitor.py
@@ -123,32 +123,14 @@ class InstrumentMonitor(object):
         :param run_number: Run number to lookup
         :return: Experiment RB number
         """
-        # Detect run number as a substring
         with open(self.summary_file, 'rb') as summary:
-            # Traverse file in reverse order because some instruments truncate
-            # each run number in the summary file. This means that the same run
-            # number could occur more than once. It should be assumed that the
-            # latest is the correct run.
             summary_lines = summary.readlines()
-            for line in reversed(summary_lines):
-                line_parts = line.split()
-
-                if line_parts:
-                    # Detect the run as a substring in summary.txt
-                    summary_run = extract_run_number_from_summary(line_parts[0])
-                    if summary_run in str(run_number):
-                        # The last entry is the RB number
-                        return line_parts[-1]
-
-            # Default to choosing the last row
-            EORM_LOG.info("Can't find run %s in summary file for %s defaulting to last entry",
-                          run_number, self.instrument_name)
             last_line = summary_lines[-1]
             line_parts = last_line.split()
             if line_parts:
                 return line_parts[-1]
 
-        raise InstrumentMonitorError("Unable to find run number in summary.txt '{}'"
+        raise InstrumentMonitorError("Unable to read RB number from summary.txt '{}'"
                                      .format(run_number))
 
     def build_dict(self, rb_number, run_number, file_location):

--- a/monitors/new_end_of_run_monitor.py
+++ b/monitors/new_end_of_run_monitor.py
@@ -87,7 +87,6 @@ class InstrumentMonitor(object):
     def read_rb_number_from_summary(self):
         """
         Loads the summary file and reads off the experiment RB number
-        :param run_number: Run number to lookup
         :return: Experiment RB number
         """
         with open(self.summary_file, 'rb') as summary:

--- a/monitors/tests/test_new_end_of_run_monitor.py
+++ b/monitors/tests/test_new_end_of_run_monitor.py
@@ -89,14 +89,6 @@ class TestEndOfRunMonitor(unittest.TestCase):
         rb_number = inst_mon.read_rb_number_from_summary()
         self.assertEqual('1820461', rb_number)
 
-    def test_read_rb_number_from_summary_run_not_found(self):
-        with open('test_summary.txt', 'w') as summary:
-            summary.write(SUMMARY_FILE)
-
-        inst_mon = InstrumentMonitor(None, 'WISH')
-        inst_mon.summary_file = 'test_summary.txt'
-        self.assertEqual('1820461', inst_mon.read_rb_number_from_summary())
-
     def test_read_rb_number_from_summary_invalid(self):
         with open('test_summary.txt', 'w') as summary:
             summary.write(' ')

--- a/monitors/tests/test_new_end_of_run_monitor.py
+++ b/monitors/tests/test_new_end_of_run_monitor.py
@@ -52,12 +52,6 @@ class TestEndOfRunMonitor(unittest.TestCase):
         zeros = eorm.get_prefix_zeros(run_number)
         self.assertEqual('', zeros)
 
-    def test_is_integer(self):
-        self.assertTrue(eorm.is_integer("3"))
-
-    def test_is_integer_not_integer(self):
-        self.assertFalse(eorm.is_integer("F"))
-
     def test_get_prefix_zeros_all_zeros(self):
         run_number = '00000'
         zeros = eorm.get_prefix_zeros(run_number)
@@ -92,7 +86,7 @@ class TestEndOfRunMonitor(unittest.TestCase):
 
         inst_mon = InstrumentMonitor(None, 'WISH')
         inst_mon.summary_file = 'test_summary.txt'
-        rb_number = inst_mon.read_rb_number_from_summary(44733)
+        rb_number = inst_mon.read_rb_number_from_summary()
         self.assertEqual('1820461', rb_number)
 
     def test_read_rb_number_from_summary_run_not_found(self):
@@ -101,14 +95,14 @@ class TestEndOfRunMonitor(unittest.TestCase):
 
         inst_mon = InstrumentMonitor(None, 'WISH')
         inst_mon.summary_file = 'test_summary.txt'
-        self.assertEqual('1820461', inst_mon.read_rb_number_from_summary(12345))
+        self.assertEqual('1820461', inst_mon.read_rb_number_from_summary())
 
     def test_read_rb_number_from_summary_invalid(self):
         with open('test_summary.txt', 'w') as summary:
             summary.write(' ')
         inst_mon = InstrumentMonitor(None, 'WISH')
         inst_mon.summary_file = 'test_summary.txt'
-        self.assertRaises(InstrumentMonitorError, inst_mon.read_rb_number_from_summary, 12345)
+        self.assertRaises(InstrumentMonitorError, inst_mon.read_rb_number_from_summary)
 
     def test_build_dict(self):
         client = QueueClient()

--- a/monitors/tests/test_new_end_of_run_monitor.py
+++ b/monitors/tests/test_new_end_of_run_monitor.py
@@ -58,20 +58,6 @@ class TestEndOfRunMonitor(unittest.TestCase):
     def test_is_integer_not_integer(self):
         self.assertFalse(eorm.is_integer("F"))
 
-    # pylint:disable=invalid-name
-    def test_extract_run_number_from_summary(self):
-        test_part = "OSI38828Smith,Smith0.5ML"
-        self.assertEqual("38828", eorm.extract_run_number_from_summary(test_part))
-
-    # pylint:disable=invalid-name
-    def test_extract_run_number_from_summary_no_run(self):
-        test_part = "hello"
-        self.assertEqual("", eorm.extract_run_number_from_summary(test_part))
-
-    def test_extract_run_number_from_summary_run_only(self):
-        test_part = "MUSR1234"
-        self.assertEqual("1234", eorm.extract_run_number_from_summary(test_part))
-
     def test_get_prefix_zeros_all_zeros(self):
         run_number = '00000'
         zeros = eorm.get_prefix_zeros(run_number)


### PR DESCRIPTION
### Summary of work
Now just takes last RB number from the summary file.

### How to test your work
Run on the development node and ensure all RB numbers are reported correctly. It should be clear whether it is running correctly after a few days.

Fixes #329 
