### PR TITLE
Read RB number from the Nexus file

### DIFF
--- a/monitors/new_end_of_run_monitor.py
+++ b/monitors/new_end_of_run_monitor.py
@@ -7,6 +7,7 @@ import csv
 import logging
 import os
 import json
+from nexusformat.nexus import nxload
 from filelock import (FileLock, Timeout)
 
 from monitors.settings import (LAST_RUNS_CSV, CYCLE_FOLDER)
@@ -60,6 +61,21 @@ def get_prefix_zeros(run_number_str):
     return zeros
 
 
+def read_rb_number_from_nexus_file(nxs_file_path):
+    """
+    Extract the experiment RB number from the Nexus file
+    :param nxs_file_path: Path to the Nexus file on disk
+    :return: The RB number or None
+    """
+    nxs_file = nxload(nxs_file_path)
+    for (_, entry) in nxs_file.iteritems():
+        if hasattr(entry, 'experiment_identifier'):
+            field_data = entry.experiment_identifier.nxdata
+            if field_data:
+                return field_data[0]
+    return None
+
+
 class InstrumentMonitor(object):
     """
     Checks the ISIS archive for new runs on an instrument and submits them to ActiveMQ
@@ -111,7 +127,7 @@ class InstrumentMonitor(object):
                                           location=file_location,
                                           run_number=run_number)
 
-    def submit_run(self, rb_number, run_number, file_name):
+    def submit_run(self, summary_rb_number, run_number, file_name):
         """
         Submit a run to ActiveMQ
         :param rb_number: RB number of the experiment
@@ -122,6 +138,10 @@ class InstrumentMonitor(object):
         file_path = os.path.join(self.data_dir, CYCLE_FOLDER, file_name)
 
         if os.path.isfile(file_path):
+            rb_number = read_rb_number_from_nexus_file(file_path)
+            if rb_number is None:
+                rb_number = summary_rb_number
+            EORM_LOG.info("Submitting '{}' with RB number '{}'".format(file_name, rb_number))
             data_dict = self.build_dict(rb_number, run_number, file_path)
             self.client.send('/queue/DataReady', json.dumps(data_dict), priority='9')
         else:
@@ -140,7 +160,7 @@ class InstrumentMonitor(object):
         local_run_int = int(local_last_run)
         instrument_run_int = int(instrument_last_run)
 
-        rb_number = self.read_rb_number_from_summary()
+        summary_rb_number = self.read_rb_number_from_summary()
         zeros = get_prefix_zeros(instrument_last_run)
         if instrument_run_int > local_run_int:
             EORM_LOG.info("Submitting runs in range %i - %i for %s",
@@ -152,7 +172,7 @@ class InstrumentMonitor(object):
                 run_number = zeros + str(i)
                 file_name = last_run_data[0] + run_number + self.file_ext
                 try:
-                    self.submit_run(rb_number, run_number, file_name)
+                    self.submit_run(summary_rb_number, run_number, file_name)
                 except FileNotFoundError as ex:
                     # If the file isn't found then just return the last file sent
                     # and try again next time

--- a/monitors/new_end_of_run_monitor.py
+++ b/monitors/new_end_of_run_monitor.py
@@ -7,7 +7,7 @@ import csv
 import logging
 import os
 import json
-import nexusformat
+from nexusformat.nexus import nxload
 from filelock import (FileLock, Timeout)
 
 from monitors.settings import (LAST_RUNS_CSV, CYCLE_FOLDER)
@@ -67,7 +67,7 @@ def read_rb_number_from_nexus_file(nxs_file_path):
     :param nxs_file_path: Path to the Nexus file on disk
     :return: The RB number or None
     """
-    nxs_file = nexusformat.nexus.nxload(nxs_file_path)
+    nxs_file = nxload(nxs_file_path)
     for (_, entry) in nxs_file.iteritems():
         if hasattr(entry, 'experiment_identifier'):
             field_data = entry.experiment_identifier.nxdata

--- a/monitors/new_end_of_run_monitor.py
+++ b/monitors/new_end_of_run_monitor.py
@@ -137,7 +137,7 @@ class InstrumentMonitor(object):
     def submit_run(self, summary_rb_number, run_number, file_name):
         """
         Submit a run to ActiveMQ
-        :param summary_rb_number: RB number of the experiment
+        :param summary_rb_number: RB number of the experiment as read from the summary file
         :param run_number: Run number as it appears in lastrun.txt
         :param file_name: File name e.g. GEM1234.nxs
         """

--- a/monitors/tests/test_new_end_of_run_monitor.py
+++ b/monitors/tests/test_new_end_of_run_monitor.py
@@ -161,14 +161,20 @@ class TestEndOfRunMonitor(unittest.TestCase):
         isfile_mock.assert_called_with(data_loc)
         read_rb_mock.assert_called_once_with(data_loc)
 
-    @patch('nexusformat.nexus.nxload', return_value=NXLOAD_MOCK)
+    @patch('monitors.new_end_of_run_monitor.nxload', return_value=NXLOAD_MOCK)
     def test_read_rb_number_from_nexus(self, nxload_mock):
         rb_num = eorm.read_rb_number_from_nexus_file('mynexus.nxs')
         self.assertEqual(rb_num, '1910232')
         nxload_mock.assert_called_once_with('mynexus.nxs')
 
-    @patch('nexusformat.nexus.nxload', return_value=NXLOAD_MOCK_EMPTY)
+    @patch('monitors.new_end_of_run_monitor.nxload', return_value=NXLOAD_MOCK_EMPTY)
     def test_read_rb_number_from_nexus_invalid(self, nxload_mock):
+        rb_num = eorm.read_rb_number_from_nexus_file('mynexus.nxs')
+        self.assertIsNone(rb_num)
+        nxload_mock.assert_called_once_with('mynexus.nxs')
+
+    @patch('monitors.new_end_of_run_monitor.nxload', side_effect=IOError('HDF4 file'))
+    def test_read_rb_number_from_nexus_hdf4(self, nxload_mock):
         rb_num = eorm.read_rb_number_from_nexus_file('mynexus.nxs')
         self.assertIsNone(rb_num)
         nxload_mock.assert_called_once_with('mynexus.nxs')

--- a/monitors/tests/test_new_end_of_run_monitor.py
+++ b/monitors/tests/test_new_end_of_run_monitor.py
@@ -29,6 +29,11 @@ RUN_DICT = {'instrument': 'WISH',
             'data': '/my/data/dir/cycle_18_4/WISH00044733.nxs',
             'rb_number': '1820461',
             'facility': 'ISIS'}
+RUN_DICT_SUMMARY = {'instrument': 'WISH',
+                    'run_number': '00044733',
+                    'data': '/my/data/dir/cycle_18_4/WISH00044733.nxs',
+                    'rb_number': '1820333',
+                    'facility': 'ISIS'}
 CSV_FILE = "WISH,44733,lastrun_wish.txt,summary_wish.txt,data_dir,.nxs"
 
 # nexusformat mock objects
@@ -126,7 +131,7 @@ class TestEndOfRunMonitor(unittest.TestCase):
         inst_mon.data_dir = '/my/data/dir'
         data_loc = os.path.join(inst_mon.data_dir, CYCLE_FOLDER, 'WISH00044733.nxs')
 
-        inst_mon.submit_run('1820461', '00044733', 'WISH00044733.nxs')
+        inst_mon.submit_run('1820333', '00044733', 'WISH00044733.nxs')
         client.send.assert_called_with('/queue/DataReady', json.dumps(RUN_DICT), priority='9')
         isfile_mock.assert_called_with(data_loc)
         read_rb_mock.assert_called_once_with(data_loc)
@@ -141,23 +146,25 @@ class TestEndOfRunMonitor(unittest.TestCase):
         inst_mon.data_dir = '/my/data/dir'
         data_loc = os.path.join(inst_mon.data_dir, CYCLE_FOLDER, 'WISH00044733.nxs')
         with self.assertRaises(FileNotFoundError):
-            inst_mon.submit_run('1820461', '00044733', 'WISH00044733.nxs')
+            inst_mon.submit_run('1820333', '00044733', 'WISH00044733.nxs')
         isfile_mock.assert_called_with(data_loc)
 
     @patch('os.path.isfile', return_vaule=True)
     @patch('monitors.new_end_of_run_monitor.read_rb_number_from_nexus_file',
-           return_vaule=None)
+           return_value=None)
     def test_submit_run_invalid_nexus(self, read_rb_mock, isfile_mock):
         client = Mock()
         client.send = Mock(return_value=None)
-        client.serialise_data = Mock(return_value=RUN_DICT)
+        client.serialise_data = Mock(return_value=RUN_DICT_SUMMARY)
 
         inst_mon = InstrumentMonitor(client, 'WISH')
         inst_mon.data_dir = '/my/data/dir'
         data_loc = os.path.join(inst_mon.data_dir, CYCLE_FOLDER, 'WISH00044733.nxs')
 
-        inst_mon.submit_run('1820461', '00044733', 'WISH00044733.nxs')
-        client.send.assert_called_with('/queue/DataReady', json.dumps(RUN_DICT), priority='9')
+        inst_mon.submit_run('1820333', '00044733', 'WISH00044733.nxs')
+        client.send.assert_called_with('/queue/DataReady',
+                                       json.dumps(RUN_DICT_SUMMARY),
+                                       priority='9')
         isfile_mock.assert_called_with(data_loc)
         read_rb_mock.assert_called_once_with(data_loc)
 

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,9 @@ setup_requires = ['Django',
                   'suds',
                   'Twisted',
                   'watchdog',
-                  'filelock']
+                  'filelock',
+                  'numpy',
+                  'nexusformat']
 
 if platform.system() == 'Windows':
     setup_requires.append('pypiwin32')


### PR DESCRIPTION
### Summary of work

The new EoRM now loads RB numbers from the Nexus file itself, falling back on the summary file if necessary. The summary file will definitely still be used on instruments that produce HDF4 Nexus files. I considered it not worthwhile to load HDF4 files given that all instruments that use HDF4 are fine with the summary file. Existing libraries that load HDF4 are also quite difficult to setup because they rely on a C++ library underneath.

### How to test your work

There is now a wiki entry for testing EoRM locally: https://github.com/ISISScientificComputing/autoreduce/wiki/Testing-the-new-End-of-Run-Monitor

There are two additional dependencies to be installed in the following order:
 * numpy
 * nexusformat

I have also pulled the new code onto the development node.

Fixes #338
