### PR TITLE
Change mantid properties file to log at notice level

### DIFF
--- a/docker_reduction/mantid/Mantid.user.properties
+++ b/docker_reduction/mantid/Mantid.user.properties
@@ -10,8 +10,7 @@
 # to look for files other than data, e.g. scripts
 #usersearch.directories=
 
-logging.loggers.root.level=debug
-logging.channels.fileFilterChannel.level=debug
+logging.loggers.root.level=notice
 #logging.channels.fileFilterChannel.level=0
 
 # By default logging is send to stderr. Here change this to stdout


### PR DESCRIPTION
### Summary of work
Changed logging level in mantid properties file

### How to test your work
None required

### Additional comments
The logging of the autoreduction process is actually performed mainly by the reduction script and in part by the post_process_admin.py hence there are no changes to make here that I am aware of.

Fixes #356 
