### PR TITLE
Default items per page

### DIFF
--- a/WebApp/autoreduce_webapp/reduction_viewer/views.py
+++ b/WebApp/autoreduce_webapp/reduction_viewer/views.py
@@ -431,7 +431,7 @@ def instrument_summary(request, instrument=None):
                 experiments_and_runs[experiment] = associated_runs
             context_dictionary['experiments'] = experiments_and_runs
         else:
-            max_items_per_page = request.GET.get('pagination', 10)
+            max_items_per_page = request.GET.get('pagination', 50)
             custom_paginator = CustomPaginator(page_type=sort_by,
                                                query_set=runs,
                                                items_per_page=max_items_per_page,

--- a/WebApp/autoreduce_webapp/reduction_viewer/views.py
+++ b/WebApp/autoreduce_webapp/reduction_viewer/views.py
@@ -431,7 +431,7 @@ def instrument_summary(request, instrument=None):
                 experiments_and_runs[experiment] = associated_runs
             context_dictionary['experiments'] = experiments_and_runs
         else:
-            max_items_per_page = request.GET.get('pagination', 50)
+            max_items_per_page = request.GET.get('pagination', 10)
             custom_paginator = CustomPaginator(page_type=sort_by,
                                                query_set=runs,
                                                items_per_page=max_items_per_page,

--- a/WebApp/autoreduce_webapp/templates/instrument_summary.html
+++ b/WebApp/autoreduce_webapp/templates/instrument_summary.html
@@ -89,7 +89,7 @@
                         <select title="The number of reduction jobs that should be shown per page" class="form-control" name="pagination" form="filter_options" id="pagination_select">
                             <option {% if max_items == '10' %}selected="selected"{% endif %}>10</option>
                             <option {% if max_items == '25' %}selected="selected"{% endif %}>25</option>
-                            <option selected=""selected" {% if max_items == '50' %}selected="selected"{% endif %}>50</option>
+                            <option {% if max_items == '50' %}selected="selected"{% endif %}>50</option>
                             <option {% if max_items == '100' %}selected="selected"{% endif %}>100</option>
                             <option {% if max_items == '250' %}selected="selected"{% endif %}>250</option>
                             <option {% if max_items == '500' %}selected="selected"{% endif %}>500</option>

--- a/WebApp/autoreduce_webapp/templates/instrument_summary.html
+++ b/WebApp/autoreduce_webapp/templates/instrument_summary.html
@@ -89,7 +89,7 @@
                         <select title="The number of reduction jobs that should be shown per page" class="form-control" name="pagination" form="filter_options" id="pagination_select">
                             <option {% if max_items == '10' %}selected="selected"{% endif %}>10</option>
                             <option {% if max_items == '25' %}selected="selected"{% endif %}>25</option>
-                            <option {% if max_items == '50' %}selected="selected"{% endif %}>50</option>
+                            <option selected=""selected" {% if max_items == '50' %}selected="selected"{% endif %}>50</option>
                             <option {% if max_items == '100' %}selected="selected"{% endif %}>100</option>
                             <option {% if max_items == '250' %}selected="selected"{% endif %}>250</option>
                             <option {% if max_items == '500' %}selected="selected"{% endif %}>500</option>


### PR DESCRIPTION
### Summary of work
The default number of items in a page default to 50 and this is represented in the options dropdown

### How to test your work
Load the page and see if the dropdown menu corresponds with the number of items in the page by default.

Fixes #358 