### PR TITLE
Improve info message on resubmit field

### DIFF
--- a/WebApp/autoreduce_webapp/templates/submit_runs.html
+++ b/WebApp/autoreduce_webapp/templates/submit_runs.html
@@ -35,7 +35,7 @@
                             <div class="row">
                                 <label for="run_range" class="control-label col-md-3">
                                     Run Numbers
-                                    <a href="#" data-toggle="popover" data-content="A list of runs to re-run, the list can include ranges e.g. 1, 4-6" data-trigger="hover click focus" data-placement="top" data-container="body"><i class="fa fa-info-circle"></i></a>
+                                    <a href="#" data-toggle="popover" data-content="A list of run number to re-run, the list can include ranges e.g. 1, 4-6. All the run numbers must be in the same experiment in order to apply the desired variables." data-trigger="hover click focus" data-placement="top" data-container="body"><i class="fa fa-info-circle"></i></a>
                                 </label>
                                 <div class="col-md-5">
                                     <input type="text" id="run_range" name="run_range" value="{{last_instrument_run.run_number}}" class="form-control"/>


### PR DESCRIPTION
### Summary of work
* Now informs users that all run numbers must be in the same experiment

### How to test your work
* Load the Webapp re-run past jobs page e.g. `webapp-address/instrument/GEM/submit_runs/`
* Hover over the `i` icon on the page and ensure it displays a better help message

### Additional comments
* This would be better as validation in the future but will be fine for now

Fixes #48
