### PR TITLE
python 3 travis migration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,9 @@ dist/
 
 # Ignore virtual environment
 venv/
+venv3/
+venv36/
+venv37/
 
 # Ignore migrations files
 migrations/

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,10 +42,10 @@ script:
 
   # ================ pytest unit tests ================ #
   # Utils tests
-  - echo "Running Unit tests"
+  - echo "===================== UNIT TESTS ====================="
   - py.test --ignore=systemtests --cov=build --cov=monitors --cov=QueueProcessors --cov=scripts --cov=utils --cov=WebApp/autoreduce_webapp --cov=docker_reduction --cov=paths
 
-  - echo "Running System Tests"
+  - echo "==================== SYSTEM TESTS ===================="
   - py.test systemtests --cov-append
 
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,12 @@
 sudo: required
 language: python
 python:
-  - "2.7"
+  - "3.7"
 
 services:
   - mysql
 
-dist: trusty
+dist: xenial
 
 before_install:
   - mysql_upgrade --force
@@ -15,16 +15,16 @@ before_install:
 
 install:
   # Install autoreduction
-  - pip install -e .
+  - pip3 install -e .
   # Install test suite dependencies
-  - pip install -r requirements.txt
+  - pip3 install -r requirements.txt
 
   # ================== Test setup ==================== #
-  - python setup.py test_settings
+  - python3 setup.py test_settings
   # Externals must be after test_settings
-  - python setup.py externals -s activemq,icat
-  - python setup.py database
-  - sudo python setup.py start
+  - python3 setup.py externals -s activemq,icat
+  - python3 setup.py database
+  - sudo python3 setup.py start
 
 script:
   # ================ Assert Test Setup =============== #


### PR DESCRIPTION
### Summary of work
* Move the travis file to run with xenial ubunutu and python 3
* add python 3 venv names to git ignore

### How to test your work
* Ensure that the travis build is using python 3. For this pull request we are not concerned with the tests / pylint passing or failing

Fixes #397 
