### PR TITLE
Remove imp and email functionality

### DIFF
--- a/queue_processors/autoreduction_processor/post_process_admin.py
+++ b/queue_processors/autoreduction_processor/post_process_admin.py
@@ -26,7 +26,7 @@ import time
 import types
 import traceback
 from contextlib import contextmanager
-from importlib.machinery import SourceFileLoader
+import importlib.util as imp
 
 from sentry_sdk import init
 
@@ -305,7 +305,9 @@ class PostProcessAdmin:
                     # Add Mantid path to system path so we can use Mantid to run the user's script
                     sys.path.append(MISC["mantid_path"])
                     reduce_script_location = self._load_reduction_script(self.instrument)
-                    reduce_script = SourceFileLoader('reducescript', reduce_script_location).load_module()
+                    spec = imp.spec_from_file_location('reducescript', reduce_script_location)
+                    reduce_script = imp.module_from_spec(spec)
+                    spec.loader.exec_module(reduce_script)
 
                     try:
                         skip_numbers = reduce_script.SKIP_RUNS

--- a/queue_processors/autoreduction_processor/post_process_admin.py
+++ b/queue_processors/autoreduction_processor/post_process_admin.py
@@ -16,7 +16,6 @@ Post Process Administrator. It kicks off cataloging and reduction jobs.
 """
 import io
 import errno
-import imp
 import json
 import logging
 import os
@@ -24,8 +23,10 @@ import shutil
 import socket
 import sys
 import time
+import types
 import traceback
 from contextlib import contextmanager
+from importlib.machinery import SourceFileLoader
 
 from sentry_sdk import init
 
@@ -173,7 +174,7 @@ class PostProcessAdmin:
             merge_dict_to_name(dict_name, encoded_dict)
 
         if not hasattr(reduce_script, "web_var"):
-            reduce_script.web_var = imp.new_module("reduce_vars")
+            reduce_script.web_var = types.ModuleType("reduce_vars")
         map(merge_dicts, ["standard_vars", "advanced_vars"])
         return reduce_script
 
@@ -304,7 +305,7 @@ class PostProcessAdmin:
                     # Add Mantid path to system path so we can use Mantid to run the user's script
                     sys.path.append(MISC["mantid_path"])
                     reduce_script_location = self._load_reduction_script(self.instrument)
-                    reduce_script = imp.load_source('reducescript', reduce_script_location)
+                    reduce_script = SourceFileLoader('reducescript', reduce_script_location).load_module()
 
                     try:
                         skip_numbers = reduce_script.SKIP_RUNS

--- a/queue_processors/queue_processor/test_settings.py
+++ b/queue_processors/queue_processor/test_settings.py
@@ -83,11 +83,3 @@ else:
 
     TEST_REDUCTION_DIRECTORY = '/reducedev/isis/output/NDX%s/user/scripts/autoreduction'
     TEST_ARCHIVE_DIRECTORY = '/isis/NDX%s/Instrument/data/cycle_%s/autoreduced/%s/%s'
-
-# Email for notifications
-EMAIL_BACKEND = 'django.core.mail.backends.smtp.EmailBackend'
-EMAIL_HOST = 'exchsmtp.stfc.ac.uk'
-EMAIL_PORT = 25
-EMAIL_ERROR_RECIPIENTS = ['YOUR-EMAIL']
-EMAIL_ERROR_SENDER = 'autoreduce@reduce.isis.cclrc.ac.uk'
-BASE_URL = 'http://reduce.isis.cclrc.ac.uk/'


### PR DESCRIPTION
### Summary of work
* Remove the use of deprecate imp in queue processor
* Remove email functionality from queue processor as it was never used and doesn't appear to work. Furthermore, I don't think we want this functionality