### PR TITLE
Skip calibration RBs

### DIFF
--- a/Documentation/release-notes/20-1.md
+++ b/Documentation/release-notes/20-1.md
@@ -1,0 +1,7 @@
+# Release notes (ISIS Autoreduction v20.1)
+
+## Headlines
+*
+
+## Minor Changes (Improvements and bug fixes)
+* RB with a value of 0 or less or that are text are skipped in the autoreduction system. These runs will show up in the web app as being skipped.

--- a/queue_processors/queue_processor/queue_processor.py
+++ b/queue_processors/queue_processor/queue_processor.py
@@ -116,7 +116,8 @@ class Listener:
             self._data_dict['message'] = 'Reduction Skipped: {}. Assuming run number to be ' \
                                          'a calibration run.'.format(error_message)
             skipped_queue = ACTIVEMQ_SETTINGS.reduction_skipped
-            self._client.send(skipped_queue, self._data_dict)
+            self._client.send(skipped_queue, json.dumps(self._data_dict),
+                              priority=self._priority)
             return
 
         logger.info("Data ready for processing run %s on %s", run_no, instrument_name)

--- a/queue_processors/queue_processor/queue_processor.py
+++ b/queue_processors/queue_processor/queue_processor.py
@@ -49,7 +49,7 @@ def is_valid_rb(rb_number):
     :return: An error message if one is generated or None if the RB is valid
     """
     try:
-        int(rb_number)
+        rb_number = int(rb_number)
         if rb_number > 0:
             return None
         return "RB Number is less than or equal to 0"


### PR DESCRIPTION
### Summary of work
Ensure that RB0 or less AND String RBs are skipped and added to the skipped queue (not just never run)

### How to test your work
Manually submit an RB 0, ensure it shows up in the webapp as skipped and has an explanation 

Fixes #451


**Before merging ensure the release notes have been updated**