### PR TITLE
459 Make code django3 compatible

### DIFF
--- a/WebApp/autoreduce_webapp/templates/base.html
+++ b/WebApp/autoreduce_webapp/templates/base.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-{% load static from staticfiles %}
+{% load static %}
 <html>
 <head>
     <meta charset="utf-8">

--- a/WebApp/autoreduce_webapp/templates/fail_queue.html
+++ b/WebApp/autoreduce_webapp/templates/fail_queue.html
@@ -2,7 +2,7 @@
 {% load colour_table_rows %}
 {% load get_user_name %}
 {% load naturaltime from humanize %}
-{% load static from staticfiles %}
+{% load static %}
 
 {% block body %}
     <title>Failed Jobs</title>

--- a/WebApp/autoreduce_webapp/templates/help.html
+++ b/WebApp/autoreduce_webapp/templates/help.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% load static from staticfiles %}
+{% load static %}
 
 {% block body %}
     <title>Help Pages</title>

--- a/WebApp/autoreduce_webapp/templates/instrument_summary.html
+++ b/WebApp/autoreduce_webapp/templates/instrument_summary.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 {% load view %}
-{% load static from staticfiles %}
+{% load static %}
 {% load colour_table_rows %}
 
 {% block body %}

--- a/WebApp/autoreduce_webapp/templates/instrument_variables.html
+++ b/WebApp/autoreduce_webapp/templates/instrument_variables.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 {% load view %}
-{% load static from staticfiles %}
+{% load static %}
 {% block body %}
     {% if instrument %}
         {% if instrument.is_active %}

--- a/WebApp/autoreduce_webapp/templates/navbar.html
+++ b/WebApp/autoreduce_webapp/templates/navbar.html
@@ -1,4 +1,4 @@
-{% load static from staticfiles %}
+{% load static %}
 
 <div class="navbar navbar-static-top navbar-default" role="navigation">
     <div class="container">

--- a/WebApp/autoreduce_webapp/templates/outdated_browser.html
+++ b/WebApp/autoreduce_webapp/templates/outdated_browser.html
@@ -1,4 +1,4 @@
-{% load static from staticfiles %}
+{% load static %}
 
 <!DOCTYPE html>
 <html lang="en">

--- a/WebApp/autoreduce_webapp/templates/overview.html
+++ b/WebApp/autoreduce_webapp/templates/overview.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% load static from staticfiles %}
+{% load static %}
 
 {% block body %}
 <div class="container-fluid">

--- a/WebApp/autoreduce_webapp/templates/run_confirmation.html
+++ b/WebApp/autoreduce_webapp/templates/run_confirmation.html
@@ -4,7 +4,7 @@
 {% load natural_time_difference %}
 {% load get_user_name %}
 {% load naturaltime from humanize %}
-{% load static from staticfiles %}
+{% load static %}
 
 {% block body %}
     {% if runs and not error %}

--- a/WebApp/autoreduce_webapp/templates/run_summary.html
+++ b/WebApp/autoreduce_webapp/templates/run_summary.html
@@ -5,7 +5,7 @@
 {% load get_user_name %}
 {% load replace %}
 {% load naturaltime from humanize %}
-{% load static from staticfiles %}
+{% load static %}
 
 {% block body %}
     {% if run %}

--- a/WebApp/autoreduce_webapp/templates/submit_runs.html
+++ b/WebApp/autoreduce_webapp/templates/submit_runs.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 {% load view %}
-{% load static from staticfiles %}
+{% load static %}
 
 {% block body %}
     {% if instrument %}

--- a/WebApp/autoreduce_webapp/templates/variables_summary.html
+++ b/WebApp/autoreduce_webapp/templates/variables_summary.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 {% load view %}
-{% load static from staticfiles %}
+{% load static %}
 {% block body %}
     {% if instrument %}
         <title>{{ instrument.name }} - Reduction variables</title>


### PR DESCRIPTION
### Summary of work
- Replaced all instances of deprecated `staticfiles` tags to their simplified 3.0 equivalent

### Additional comments
Solution source: https://stackoverflow.com/questions/55929472/django-templatesyntaxerror-staticfiles-is-not-a-registered-tag-library

Fixes #459 


**Before merging ensure the release notes have been updated**