### PR TITLE
Remove "Items per page" when filtering by RB

### DIFF
--- a/WebApp/autoreduce_webapp/templates/instrument_summary.html
+++ b/WebApp/autoreduce_webapp/templates/instrument_summary.html
@@ -65,9 +65,11 @@
                 <div class="col-md-3">
                     <h3>Sort by</h3>
                 </div>
+                {% if filtering == 'run' %}
                 <div class="col-md-3">
                     <h3>Items per page</h3>
                 </div>
+                {% endif %}
             </div>
             <div class="row">
                 <!-- Filter , Sort and Pagination options -->

--- a/WebApp/autoreduce_webapp/templates/instrument_summary.html
+++ b/WebApp/autoreduce_webapp/templates/instrument_summary.html
@@ -59,19 +59,6 @@
         <hr/>
             <!-- Display table for reduction jobs -->
             <div class="row">
-                <div class="col-md-3">
-                    <h3>Filter by</h3>
-                </div>
-                <div class="col-md-3">
-                    <h3>Sort by</h3>
-                </div>
-                {% if filtering == 'run' %}
-                <div class="col-md-3">
-                    <h3>Items per page</h3>
-                </div>
-                {% endif %}
-            </div>
-            <div class="row">
                 <!-- Filter , Sort and Pagination options -->
                 <form action="{{ request.path }}" method="get" id="filter_options">
                     <div class="col-md-3">


### PR DESCRIPTION
### Summary of work
Added a conditional on the "Items per page" header

_Before:_
![image](https://user-images.githubusercontent.com/31534888/74723273-376db300-5232-11ea-8699-3c40523b38cd.png)

_After:_
![image](https://user-images.githubusercontent.com/31534888/74723227-2329b600-5232-11ea-91c6-f7704b968b62.png)


### How to test your work
- Open the webapp
- Select an instrument
- Select Filter by RB Number from the drop down menu
- Click apply filter
- Check that "Items per page" has displayed

### Additional comments
We might want to have it such that "Items per page" disappears/reappears when the selection is made (rather than only after filtre is applied)

Fixes #441

**Before merging ensure the release notes have been updated**