### PR TITLE
Change WebApp form on filtre selection

### DIFF
--- a/WebApp/autoreduce_webapp/static/javascript/instrument_summary.js
+++ b/WebApp/autoreduce_webapp/static/javascript/instrument_summary.js
@@ -10,8 +10,7 @@
 
     var init = function init(){
         document.addEventListener("DOMContentLoaded", function(){
-            var thisElem = $(this);
-            setDefaultCursor(thisElem);
+            setDefaultCursor($(this));
         });
 
         var select = document.getElementById('filter_select');

--- a/WebApp/autoreduce_webapp/static/javascript/instrument_summary.js
+++ b/WebApp/autoreduce_webapp/static/javascript/instrument_summary.js
@@ -1,0 +1,11 @@
+(function(){
+    var init = function init(){
+        var select = document.getElementById('filter_select');
+        select.onchange = function(){
+            document.getElementById('filter_options').submit();
+        };
+
+    };
+
+    init();
+}())

--- a/WebApp/autoreduce_webapp/static/javascript/instrument_summary.js
+++ b/WebApp/autoreduce_webapp/static/javascript/instrument_summary.js
@@ -1,10 +1,29 @@
 (function(){
+    function setProgressCursor(elem) {
+        elem.css('cursor', 'progress');
+        $('body').css('cursor', 'progress');
+    }
+    function setDefaultCursor(elem) {
+        elem.css('cursor', '');
+        $('body').css('cursor', '');
+    }
+
     var init = function init(){
+        document.addEventListener("DOMContentLoaded", function(){
+            var thisElem = $(this);
+            setDefaultCursor(thisElem);
+        });
+
         var select = document.getElementById('filter_select');
         select.onchange = function(){
+            setProgressCursor($(this));
             document.getElementById('filter_options').submit();
         };
 
+        var apply = document.getElementById('apply_filters');
+        apply.onclick = function(){
+            setProgressCursor($(this));
+        }
     };
 
     init();

--- a/WebApp/autoreduce_webapp/templates/instrument_summary.html
+++ b/WebApp/autoreduce_webapp/templates/instrument_summary.html
@@ -202,4 +202,5 @@
     </script>
     <script src="{% static "javascript/pause_instrument.js" %}"></script>
     <script src="{% static "javascript/instrument_variables.js" %}"></script>
+    <script src="{% static "javascript/instrument_summary.js" %}"></script>
 {% endblock %}

--- a/WebApp/autoreduce_webapp/templates/instrument_summary.html
+++ b/WebApp/autoreduce_webapp/templates/instrument_summary.html
@@ -97,7 +97,7 @@
                     </div>
                     {% endif %}
                     <div class="col-md-3">
-                        <input class="btn btn-primary" type="submit" value="Apply filters">
+                        <input class="btn btn-primary" type="submit" value="Apply filters" id="apply_filters">
                     </div>
                 </form>
             </div>


### PR DESCRIPTION
### Summary of work
JavaScript for instrument_summary created to resubmit the form when the "Filter by" selection changes.
This causes the python conditions (injected within the HTML) to rerun and thereby redetermine the page structure based on the current field values.



### How to test your work
- Open the webapp
- Select an instrument
- Try both _Filter by_ values
- Ensure the page reloads with the expected form elements

### Additional comments
- This solution was chosen over adjusting the HTML within the JavaScript based on the "Filter by" value because this would result in duplicated functionality for hiding/showing elements.
- A side effect of this solution choice is that the "Filter by" value is always applied instantly and automatically on selection.

Fixes #464 


**Before merging ensure the release notes have been updated**