### PR TITLE
Fix TypeError on WebApp graph request

### DIFF
--- a/WebApp/autoreduce_webapp/reduction_viewer/views.py
+++ b/WebApp/autoreduce_webapp/reduction_viewer/views.py
@@ -567,7 +567,7 @@ def graph_instrument(request, instrument_name):
 
     try:
         if 'last' in request.GET:
-            runs = runs[:request.GET.get('last')]
+            runs = runs[:int(request.GET.get('last'))]
     except ValueError:
         # Non integer value entered as 'last' parameter.
         # Just show all runs.

--- a/WebApp/autoreduce_webapp/templates/admin/graph_instrument.html
+++ b/WebApp/autoreduce_webapp/templates/admin/graph_instrument.html
@@ -22,7 +22,7 @@ var reductionRuns = [
         'runNumber': '{{ run.run_number}}',
         'runVersion': '{{ run.run_version}}',
         'executionTime': '{{ run.run_time }}',
-        'status': '{{ run.status }}',
+        'status': '{{ run.status.value }}',
         'created': '{{ run.created }}'
     },
     {% endfor %}


### PR DESCRIPTION
### Summary of work
I've simply cast a return value to an integer.
I presume that an implicit integer conversion was allowed through the old Python version, but no longer allowed in 3.

### How to test your work
- Open the web app and sign in as admin (or use the development server / local)
- Click graphs from the top right menu
- Try to generate any of the graphs for the instruments on this page with the Graph button
- All graphs should generate with no issue

Fixes #462


**Before merging ensure the release notes have been updated**