### PR TITLE
Populate started_by field in all cases

### DIFF
--- a/WebApp/autoreduce_webapp/reduction_variables/views.py
+++ b/WebApp/autoreduce_webapp/reduction_variables/views.py
@@ -537,11 +537,11 @@ def run_confirmation(request, instrument):
                 format(len(run_description), max_desc_len)
             return context_dictionary
 
-        new_job = ReductionRunUtils().createRetryRun(most_recent_previous_run,
+        new_job = ReductionRunUtils().createRetryRun(user_id=request.user.id,
+                                                     reduction_run=most_recent_previous_run,
                                                      script=script_text,
                                                      overwrite=overwrite_previous_data,
                                                      variables=new_variables,
-                                                     username=request.user.username,
                                                      description=run_description)
 
         try:

--- a/WebApp/autoreduce_webapp/reduction_viewer/utils.py
+++ b/WebApp/autoreduce_webapp/reduction_viewer/utils.py
@@ -147,8 +147,8 @@ class ReductionRunUtils(object):
 
     # pylint:disable=invalid-name,too-many-arguments,too-many-locals
     @staticmethod
-    def createRetryRun(reduction_run, overwrite=None, script=None,
-                       variables=None, delay=0, username=None, description=''):
+    def createRetryRun(user_id, reduction_run, overwrite=None, script=None,
+                       variables=None, delay=0, description=''):
         """
         Create a run ready for re-running based on the run provided.
         If variables (RunVariable) are provided, copy them and associate
@@ -158,9 +158,6 @@ class ReductionRunUtils(object):
         from reduction_variables.utils import InstrumentVariablesUtils
 
         run_last_updated = reduction_run.last_updated
-
-        if username == 'super':
-            username = 1
 
         # find the previous run version, so we don't create a duplicate
         last_version = -1
@@ -180,7 +177,7 @@ class ReductionRunUtils(object):
                                run_name=description,
                                run_version=last_version + 1,
                                experiment=reduction_run.experiment,
-                               started_by=username,
+                               started_by=user_id,
                                status=StatusUtils().get_queued(),
                                script=script_text,
                                overwrite=overwrite)

--- a/WebApp/autoreduce_webapp/reduction_viewer/views.py
+++ b/WebApp/autoreduce_webapp/reduction_viewer/views.py
@@ -179,7 +179,8 @@ def fail_queue(request):
 
                     ReductionRunUtils().cancelRun(reduction_run)
                     reduction_run.cancel = False
-                    new_job = ReductionRunUtils().createRetryRun(reduction_run)
+                    new_job = ReductionRunUtils().createRetryRun(user_id=request.user.id,
+                                                                 reduction_run=reduction_run)
 
                     try:
                         MessagingUtils().send_pending(new_job)

--- a/monitors/run_detection.py
+++ b/monitors/run_detection.py
@@ -123,7 +123,7 @@ class InstrumentMonitor:
                                           instrument=self.instrument_name,
                                           location=file_location,
                                           run_number=run_number,
-                                          started_by="run_detection")
+                                          started_by=0)
 
     def submit_run(self, summary_rb_number, run_number, file_name):
         """

--- a/monitors/run_detection.py
+++ b/monitors/run_detection.py
@@ -122,7 +122,8 @@ class InstrumentMonitor:
         return self.client.serialise_data(rb_number=rb_number,
                                           instrument=self.instrument_name,
                                           location=file_location,
-                                          run_number=run_number)
+                                          run_number=run_number,
+                                          started_by="run_detection")
 
     def submit_run(self, summary_rb_number, run_number, file_name):
         """

--- a/monitors/tests/test_run_detection.py
+++ b/monitors/tests/test_run_detection.py
@@ -27,7 +27,8 @@ RUN_DICT = {'instrument': 'WISH',
             'run_number': '00044733',
             'data': '/my/data/dir/cycle_18_4/WISH00044733.nxs',
             'rb_number': '1820461',
-            'facility': 'ISIS'}
+            'facility': 'ISIS',
+            'started_by': 0}
 RUN_DICT_SUMMARY = {'instrument': 'WISH',
                     'run_number': '00044733',
                     'data': '/my/data/dir/cycle_18_4/WISH00044733.nxs',

--- a/queue_processors/queue_processor/queue_processor.py
+++ b/queue_processors/queue_processor/queue_processor.py
@@ -177,7 +177,8 @@ class Listener:
                                      experiment_id=experiment.id,
                                      instrument_id=instrument.id,
                                      status_id=status.id,
-                                     script=script_text)
+                                     script=script_text,
+                                     started_by=self._data_dict['started_by'])
         session.add(reduction_run)
         session.commit()
 

--- a/queue_processors/queue_processor/queue_processor.py
+++ b/queue_processors/queue_processor/queue_processor.py
@@ -383,7 +383,7 @@ class Listener:
             # If we have already tried more than 5 times, we want to give up and we don't want
             # to retry the run
             if max_version <= 4:
-                self.retry_run(reduction_run, self._data_dict["retry_in"])
+                self.retry_run(self._data_dict["started_by"], reduction_run, self._data_dict["retry_in"])
             else:
                 # Need to delete the retry_in entry from the dictionary so that the front end
                 # doesn't report a false retry instance.
@@ -413,7 +413,7 @@ class Listener:
         return reduction_run
 
     @staticmethod
-    def retry_run(reduction_run, retry_in):
+    def retry_run(user_id, reduction_run, retry_in):
         """ Retry a reduction run. """
         if reduction_run.cancel:
             logger.info("Cancelling run retry")
@@ -421,7 +421,7 @@ class Listener:
 
         logger.info("Retrying run in %i seconds", retry_in)
 
-        new_job = ReductionRunUtils().create_retry_run(reduction_run, delay=retry_in)
+        new_job = ReductionRunUtils().create_retry_run(user_id=user_id, reduction_run=reduction_run, delay=retry_in)
         try:
             #  Seconds to Milliseconds
             MessagingUtils().send_pending(new_job, delay=retry_in * 1000)

--- a/queue_processors/queue_processor/queue_processor.py
+++ b/queue_processors/queue_processor/queue_processor.py
@@ -383,7 +383,10 @@ class Listener:
             # If we have already tried more than 5 times, we want to give up and we don't want
             # to retry the run
             if max_version <= 4:
-                self.retry_run(self._data_dict["started_by"], reduction_run, self._data_dict["retry_in"])
+                self.retry_run(
+                    self._data_dict["started_by"],
+                    reduction_run,
+                    self._data_dict["retry_in"])
             else:
                 # Need to delete the retry_in entry from the dictionary so that the front end
                 # doesn't report a false retry instance.
@@ -421,7 +424,10 @@ class Listener:
 
         logger.info("Retrying run in %i seconds", retry_in)
 
-        new_job = ReductionRunUtils().create_retry_run(user_id=user_id, reduction_run=reduction_run, delay=retry_in)
+        new_job = ReductionRunUtils().create_retry_run(
+            user_id=user_id,
+            reduction_run=reduction_run,
+            delay=retry_in)
         try:
             #  Seconds to Milliseconds
             MessagingUtils().send_pending(new_job, delay=retry_in * 1000)

--- a/queue_processors/queue_processor/queueproc_utils/reduction_run_utils.py
+++ b/queue_processors/queue_processor/queueproc_utils/reduction_run_utils.py
@@ -79,7 +79,7 @@ class ReductionRunUtils:
             reduction_run.retry_run.save()
 
     @staticmethod
-    def create_retry_run(reduction_run, script=None, variables=None, delay=0, username=None):
+    def create_retry_run(user_id, reduction_run, script=None, variables=None, delay=0):
         """
         Create a run ready for re-running based on the run provided. If variables (RunVariable) are
         provided, copy them and associate them with the new one, otherwise use the previous run's.
@@ -105,7 +105,7 @@ class ReductionRunUtils:
                                created=datetime.datetime.utcnow(),
                                last_updated=datetime.datetime.utcnow(),
                                message="",
-                               started_by=username,
+                               started_by=user_id,
                                cancel=0,
                                hidden_in_failviewer=0,
                                admin_log="",

--- a/scripts/manual_operations/manual_submission.py
+++ b/scripts/manual_operations/manual_submission.py
@@ -32,7 +32,7 @@ def submit_run(active_mq_client, rb_number, instrument, data_file_location, run_
                                                 instrument=instrument,
                                                 location=data_file_location,
                                                 run_number=run_number,
-                                                started_by="manual_submission")
+                                                started_by=-1)
 
     active_mq_client.send('/queue/DataReady', json.dumps(data_dict), priority=1)
     print("Submitted run: \r\n" + json.dumps(data_dict, indent=1))

--- a/scripts/manual_operations/manual_submission.py
+++ b/scripts/manual_operations/manual_submission.py
@@ -31,7 +31,8 @@ def submit_run(active_mq_client, rb_number, instrument, data_file_location, run_
     data_dict = active_mq_client.serialise_data(rb_number=rb_number,
                                                 instrument=instrument,
                                                 location=data_file_location,
-                                                run_number=run_number)
+                                                run_number=run_number,
+                                                started_by="manual_submission")
 
     active_mq_client.send('/queue/DataReady', json.dumps(data_dict), priority=1)
     print("Submitted run: \r\n" + json.dumps(data_dict, indent=1))

--- a/scripts/manual_operations/tests/test_manual_submission.py
+++ b/scripts/manual_operations/tests/test_manual_submission.py
@@ -23,7 +23,7 @@ class DataFile:
         self.name = df_name
 
 
-def get_json_object(rb_number, instrument, data_file_location, run_number):
+def get_json_object(rb_number, instrument, data_file_location, run_number, started_by):
     """
     Return the JSON object that should be sent to DataReady
     """
@@ -31,7 +31,8 @@ def get_json_object(rb_number, instrument, data_file_location, run_number):
                  "instrument": instrument,
                  "data": data_file_location,
                  "run_number": run_number,
-                 "facility": "ISIS"}
+                 "facility": "ISIS",
+                 "started_by": started_by}
     return json.dumps(data_dict)
 
 
@@ -65,5 +66,5 @@ class TestManualSubmission(unittest.TestCase):
         """
         active_mq_client = QueueClient()
         ms.submit_run(active_mq_client, "1812345", "GEM", "5454", "nxs")
-        json_obj = get_json_object("1812345", "GEM", "5454", "nxs")
+        json_obj = get_json_object("1812345", "GEM", "5454", "nxs", -1)
         send.assert_called_with('/queue/DataReady', json_obj, priority=1)

--- a/systemtests/test_end_to_end.py
+++ b/systemtests/test_end_to_end.py
@@ -62,6 +62,7 @@ if os.name != 'nt':
             self.instrument = 'WISH'
             self.rb_number = 222
             self.run_number = 101
+            self.started_by = 0
 
             reduce_script = \
                 'def main(input_file, output_dir):\n' \
@@ -78,7 +79,8 @@ if os.name != 'nt':
             data_ready_message = self.queue_client.serialise_data(rb_number=self.rb_number,
                                                                   instrument=self.instrument,
                                                                   location=file_location,
-                                                                  run_number=self.run_number)
+                                                                  run_number=self.run_number,
+                                                                  started_by=self.started_by)
             self.queue_client.send('/queue/DataReady',
                                    json.dumps(data_ready_message))
 

--- a/systemtests/test_end_to_end.py
+++ b/systemtests/test_end_to_end.py
@@ -62,7 +62,6 @@ if os.name != 'nt':
             self.instrument = 'WISH'
             self.rb_number = 222
             self.run_number = 101
-            self.started_by = 0
 
             reduce_script = \
                 'def main(input_file, output_dir):\n' \
@@ -80,7 +79,7 @@ if os.name != 'nt':
                                                                   instrument=self.instrument,
                                                                   location=file_location,
                                                                   run_number=self.run_number,
-                                                                  started_by=self.started_by)
+                                                                  started_by=0)
             self.queue_client.send('/queue/DataReady',
                                    json.dumps(data_ready_message))
 
@@ -110,7 +109,8 @@ if os.name != 'nt':
             data_ready_message = self.queue_client.serialise_data(instrument=self.instrument,
                                                                   rb_number=self.rb_number,
                                                                   run_number=self.run_number,
-                                                                  location=file_location)
+                                                                  location=file_location,
+                                                                  started_by=0)
             self.queue_client.send('/queue/DataReady',
                                    json.dumps(data_ready_message))
 

--- a/utils/clients/queue_client.py
+++ b/utils/clients/queue_client.py
@@ -121,9 +121,7 @@ class QueueClient(AbstractClient):
         self._connection.ack(frame)
 
     @staticmethod
-    # started_by defaults to None to account for message creation outside of
-    # manual_submission.py and run_detection.py
-    def serialise_data(rb_number, instrument, location, run_number, started_by=None):
+    def serialise_data(rb_number, instrument, location, run_number, started_by):
         """
         Packs the specified data into a dictionary ready to send to a processor queue
         """

--- a/utils/clients/queue_client.py
+++ b/utils/clients/queue_client.py
@@ -121,7 +121,9 @@ class QueueClient(AbstractClient):
         self._connection.ack(frame)
 
     @staticmethod
-    def serialise_data(rb_number, instrument, location, run_number):
+    # started_by defaults to "unknown" to account for message creation outside of
+    # manual_submission.py and run_detection.py
+    def serialise_data(rb_number, instrument, location, run_number, started_by="unknown"):
         """
         Packs the specified data into a dictionary ready to send to a processor queue
         """
@@ -129,7 +131,8 @@ class QueueClient(AbstractClient):
                 'instrument': instrument,
                 'data': location,
                 'run_number': run_number,
-                'facility': 'ISIS'}
+                'facility': 'ISIS',
+                'started_by': started_by}
 
     # pylint:disable=too-many-arguments
     def send(self, destination, message, persistent='true', priority='4', delay=None):

--- a/utils/clients/queue_client.py
+++ b/utils/clients/queue_client.py
@@ -121,9 +121,9 @@ class QueueClient(AbstractClient):
         self._connection.ack(frame)
 
     @staticmethod
-    # started_by defaults to "unknown" to account for message creation outside of
+    # started_by defaults to None to account for message creation outside of
     # manual_submission.py and run_detection.py
-    def serialise_data(rb_number, instrument, location, run_number, started_by="unknown"):
+    def serialise_data(rb_number, instrument, location, run_number, started_by=None):
         """
         Packs the specified data into a dictionary ready to send to a processor queue
         """

--- a/utils/clients/tests/test_queue_client.py
+++ b/utils/clients/tests/test_queue_client.py
@@ -72,12 +72,13 @@ class TestQueueClient(unittest.TestCase):
     def test_serialise_message(self):
         """ Test data is correctly serialised """
         client = QueueClient()
-        data = client.serialise_data('123', 'WISH', 'file/path', '001')
+        data = client.serialise_data('123', 'WISH', 'file/path', '001', 0)
         self.assertEqual(data['rb_number'], '123')
         self.assertEqual(data['instrument'], 'WISH')
         self.assertEqual(data['data'], 'file/path')
         self.assertEqual(data['run_number'], '001')
         self.assertEqual(data['facility'], 'ISIS')
+        self.assertEqual(data['started_by'], 0)
 
     # pylint:disable=no-self-use
     @patch('stomp.connect.StompConnection11.send')


### PR DESCRIPTION
### Summary of work
This PR ensures the `started_by` field is populated in all instances of the code where a run can be submitted.
- When a run is submitted via the webapp, the field is populated by the current user_id (tests _3._ and _4._ below).
- When submitted **automatically**, it is populated with a **`0`** (test _2._).
- When submitted **manually**, using the `manual_submission.py` script, it is populated with a **`-1`** (test _1._).

**Example database entries**
![image](https://user-images.githubusercontent.com/31534888/75233171-57f8b880-57b0-11ea-8c58-b8089a4785d2.png)
id=58540: automatic
id=58549: via webapp (Re-run past jobs) where user_id=1
id=58550: via webapp (Re-run past jobs) where user_id=2
id=58551: via webapp (Re-run reduction job) where user_id=2

### How to test your work
1. **Manual:** Submit run using the manual submission script `scripts/manual_operations/manual_submission.py` and ensure that a `-1` has been populated in the `started_by` field of the database.
2. **Automatic:** Add the changes to the development environment and wait for a run to be submitted automatically. Once the run has occured, ensure a `0` has been populated in the `started_by` field of the database.
3. **Webapp (Re-run past jobs)**: Login to the webapp and submit a run by selecting "Re-run past jobs. Ensure the user_id has been populated in the `started_by` field of the database."**
4. **Webapp (Re-run reduction job)**: Login to the webapp and submit a run by selecting a complete run, then complete and submit the "Re-run reduction job" section. Ensure the user_id has been populated in the `started_by` field of the database."

_Note:_ for _3._ and _4._ - if testing locally, the user will be the _superuser_ which has `user_id=2`.

### Additional comments
- I wasn't sure what to assign `started_by` to in the test code, so I've used **`-2`** for now. 

Fixes #380


**Before merging ensure the release notes have been updated**