### PR TITLE
Display "started_by" on WebApp

### DIFF
--- a/WebApp/autoreduce_webapp/reduction_viewer/views.py
+++ b/WebApp/autoreduce_webapp/reduction_viewer/views.py
@@ -381,6 +381,8 @@ def run_summary(request, instrument_name=None, run_number=None, run_version=0):
                     started_by = f"{user_record.first_name} {user_record.last_name}"
                 except ObjectDoesNotExist as exception:
                     LOGGER.error(exception)
+            elif run.started_by < -1:
+                started_by = None
 
         location_list = run.reduction_location.all()
         reduction_location = None

--- a/WebApp/autoreduce_webapp/reduction_viewer/views.py
+++ b/WebApp/autoreduce_webapp/reduction_viewer/views.py
@@ -376,21 +376,9 @@ def run_summary(request, instrument_name=None, run_number=None, run_version=0):
             elif run.started_by == 0:
                 started_by = "Autoreduction service"
             elif run.started_by > 0:
-                user_id = 5
                 try:
-                    user_record = User.objects.get(id=user_id)
-
-                    # started_by = f"{user_record.first_name} {user_record.last_name}"
-
-                    # NOTE: I've written the below to be robust to where first_name or surname do not exist,
-                    #       and extensible (more name_items can be added to the list easily).
-                    #       But it is lengthier and less intuitive that the alternative (commented above)
-                    started_by = ""
-                    name_items = [user_record.first_name, user_record.last_name]
-                    for i, item in enumerate(name_items):
-                        started_by += item
-                        if i < len(name_items) - 1:
-                            started_by += " "
+                    user_record = User.objects.get(id=run.started_by)
+                    started_by = f"{user_record.first_name} {user_record.last_name}"
                 except ObjectDoesNotExist as exception:
                     LOGGER.error(exception)
 

--- a/WebApp/autoreduce_webapp/templates/run_summary.html
+++ b/WebApp/autoreduce_webapp/templates/run_summary.html
@@ -36,6 +36,11 @@
                         <div class="row">
                             <div class="col-md-6">
                                 <div>
+                                    {% if started_by is not null %}
+                                    <strong>Started by:</strong> {{ started_by }}
+                                    {% endif %}
+                                </div>
+                                <div>
                                     <strong>Status:</strong> <strong class="text-{% colour_table_row run.status.value %}">{{ run.status.value }}</strong>
                                 </div>
                                 <div>


### PR DESCRIPTION
### Summary of work
This PR adds a Started by field to the run summary.
The value of this field is determined by the value of `run.started_by` through the following conditional flow:

If `run.started_by` is `None` or _<-1_
- The "Started_by" field does not appear.

If `run.started_by` is _-1_
- "Started_by: Development team"

If `run.started_by` is _0_
- "Started_by: Autoreduction service"

If `run.started_by` is _>0_
- "Started by: [first_name] [last name]" _e.g. "Started by: Joe Bloggs"_
- In this case, the value of `started_by` is assumed to be the user id- which is used to retrieve the first and last name from the User database.
- **Note:** If the value of `started_by` does not match a user id: an exception is raised and the code continues as though `started_by = None` (the first condition of this list)

### How to test your work
* Set your `credentials.ini` to point to the development environment
* start the webapp
* Navigate to (<webapp_address>/runs/GEM/90107/1/)
	* Ensure that the user is stated as `Started by: Development team`
* Navigate to (<webapp_address>/runs/GEM/90107/)
	* Ensure that the user is stated as `Started by: Autoreduction service`
* Navigate to (<webapp_address>/runs/GEM/90107/3/)
    * Ensure that the user is stated as `Started by: Elliot Oram`
* Navigate to (<webapp_address>/runs/GEM/90050/)
    * Ensure that the there is no `Started by:` field present in the meta data table 

### Additional comments

1. I've put "Started by" as the top field for now, but this can be reordered simply by moving the <div>
2. For some reason, this code change causes a space to appear between "Retrying" and "Reduced"
![image](https://user-images.githubusercontent.com/31534888/75771690-67dd4300-5d42-11ea-95f3-e6d18ccf7251.png)
3. This new functionality of views.py can be refactored into its own method, allowing other areas of the code to utilise it (e.g. the Job Queue page, for which currently the "started_by" always displays "Autoreduction Service").


Fixes #478 


**Before merging ensure the release notes have been updated**