### PR TITLE
486 submitted by on job queue page

### DIFF
--- a/Documentation/release-notes/20-1.md
+++ b/Documentation/release-notes/20-1.md
@@ -1,0 +1,4 @@
+# Release notes (ISIS Autoreduction v20.1)
+
+## Minor Changes (Improvements and bug fixes)
+* Information on who submitted a run is now displayed correctly in the web app

--- a/WebApp/autoreduce_webapp/reduction_viewer/views.py
+++ b/WebApp/autoreduce_webapp/reduction_viewer/views.py
@@ -411,6 +411,7 @@ def run_started_by(started_by=None):
                 started_by = f"{user_record.first_name} {user_record.last_name}"
             except ObjectDoesNotExist as exception:
                 LOGGER.error(exception)
+                started_by=None
         elif started_by < -1:
             started_by = None
     return started_by

--- a/WebApp/autoreduce_webapp/reduction_viewer/views.py
+++ b/WebApp/autoreduce_webapp/reduction_viewer/views.py
@@ -362,7 +362,6 @@ def load_runs(request, reference_number=None, instrument_name=None):
 @login_and_uows_valid
 @check_permissions
 @render_with('run_summary.html')
-#@render_with('run_queue.html')
 # pylint:disable=no-member,unused-argument
 def run_summary(request, instrument_name=None, run_number=None, run_version=0):
     """

--- a/WebApp/autoreduce_webapp/reduction_viewer/views.py
+++ b/WebApp/autoreduce_webapp/reduction_viewer/views.py
@@ -370,20 +370,7 @@ def run_summary(request, instrument_name=None, run_number=None, run_version=0):
                                        run_number=run_number,
                                        run_version=run_version)
         history = ReductionRun.objects.filter(run_number=run_number).order_by('-run_version')
-        started_by = None
-        if run.started_by is not None:
-            if run.started_by == -1:
-                started_by = "Development team"
-            elif run.started_by == 0:
-                started_by = "Autoreduction service"
-            elif run.started_by > 0:
-                try:
-                    user_record = User.objects.get(id=run.started_by)
-                    started_by = f"{user_record.first_name} {user_record.last_name}"
-                except ObjectDoesNotExist as exception:
-                    LOGGER.error(exception)
-            elif run.started_by < -1:
-                started_by = None
+        started_by = run_started_by(run.started_by)
 
         location_list = run.reduction_location.all()
         reduction_location = None
@@ -403,6 +390,26 @@ def run_summary(request, instrument_name=None, run_number=None, run_version=0):
 
     return context_dictionary
 
+def run_started_by(started_by=None):
+    """
+    Returns name of the user or team that submitted an autoreduction run
+    :param started_by:
+    :return:
+    """
+    if started_by is not None:
+        if started_by == -1:
+            started_by = "Development team"
+        elif started_by == 0:
+            started_by = "Autoreduction service"
+        elif started_by > 0:
+            try:
+                user_record = User.objects.get(id=started_by)
+                started_by = f"{user_record.first_name} {user_record.last_name}"
+            except ObjectDoesNotExist as exception:
+                LOGGER.error(exception)
+        elif started_by < -1:
+            started_by = None
+    return started_by
 
 @login_and_uows_valid
 @check_permissions

--- a/WebApp/autoreduce_webapp/templates/run_queue.html
+++ b/WebApp/autoreduce_webapp/templates/run_queue.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% load view %}
 {% load colour_table_rows %}
 {% load get_user_name %}
 {% load naturaltime from humanize %}
@@ -22,7 +23,8 @@
                 </tr>
             </thead>
             <tbody>
-                {% for job in queue %}
+                {% for job, started_by in queue %}
+                {% for job, started_by in queue %}
                     <tr class="{% colour_table_row job.status.value %}">
                         <td>
                             <a href="{% url 'run_summary' instrument_name=job.instrument.name run_number=job.run_number run_version=job.run_version %}">{{ job.title }}</a>
@@ -30,13 +32,7 @@
                         <td>{{ job.instrument.name }}</td>
                         <td><strong>{{ job.status.value }}</strong></td>
                         <td title="{{ job.created|date:'SHORT_DATETIME_FORMAT' }}">{{ job.created|naturaltime }}</td>
-                        <td>
-                            {% if job.started_by %}
-                                {% get_user_name job.started_by %}
-                            {% else %}
-                                Autoreduction Service
-                            {% endif %}
-                        </td>
+                        <td> {{ started_by }} </td>
                     </tr>
                 {% endfor %}
             </tbody>

--- a/WebApp/autoreduce_webapp/templates/run_queue.html
+++ b/WebApp/autoreduce_webapp/templates/run_queue.html
@@ -24,7 +24,6 @@
             </thead>
             <tbody>
                 {% for job, started_by in queue %}
-                {% for job, started_by in queue %}
                     <tr class="{% colour_table_row job.status.value %}">
                         <td>
                             <a href="{% url 'run_summary' instrument_name=job.instrument.name run_number=job.run_number run_version=job.run_version %}">{{ job.title }}</a>

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ setup_requires = ['dash',
                   'SQLAlchemy',
                   'stomp.py',
                   'suds-py3',
-                  'Twisted',
+                  'Twisted==19.10.0',
                   'PyYAML']
 
 


### PR DESCRIPTION
### Summary of work

- Refactored the code in views.py to have a method that looks up user/team names based on user ID to be used for assigning who submitted a run.
-Changed run_summary() and run_queue() in views.py to use this new method.
-Changed run_queue.html to correctly display the 'submitted by' information on the Run Queue page.
-Created new release notes.

### How to test your work
- Set your credentials.ini to point to the development environment start the webapp
- Navigate to (<webapp_address>/runs/GEM/90107/1/) and ensure that the user is stated as Started by: Development team
- Navigate to (<webapp_address>/runs/GEM/90107/) and ensure that the user is stated as Started by: Autoreduction service
- Navigate to (<webapp_address>/runs/GEM/90107/3/) and ensure that the user is stated as Started by: Elliot Oram
-Navigate to (<webapp_address>/runs/queue/) and ensure the 'Submitted By' columns is correctly populated.
### Additional comments
The way to iterate over more than one object simultaneously with Django is to zip the objects into the context dictionary.

Fixes #486 