### PR TITLE
Stop collapse from blocking the RB-number-link

### DIFF
--- a/WebApp/autoreduce_webapp/templates/instrument_summary.html
+++ b/WebApp/autoreduce_webapp/templates/instrument_summary.html
@@ -122,7 +122,7 @@
                                 <div class="col-md-12 run-row" data-toggle="collapse" data-target="#RB{{ experiment.reference_number }}">
                             {% endif %}
                                 <div class="col-md-1"></div>
-                                <a href="{% url 'experiment_summary' experiment.reference_number %}"> RB{{ experiment.reference_number }}</a>
+                                <a href="{% url 'experiment_summary' experiment.reference_number %}" onClick="event.stopPropagation();"> RB{{ experiment.reference_number }}</a>
                             </div>
                             <div id="RB{{ experiment.reference_number }}" class="collapse">
                                 {% for run in associated_runs %}


### PR DESCRIPTION
### Summary of work
- This PR simply sets the `onClick` attribute of the RB number link (in the instrument summary table when filtred by jobs) to `event.stopPropagation();` 
- This stops the `collapse` toggle from being called instead of the link when the user specifically clicks the link.
- If the user clicks the box around the text, collapse is called instead of the link.

### How to test your work
* Open the web app
* Select an instrument
* Change to filter by RB_number
* Click on an RB number and observe that you go to the experiment summary page
* Go back 
* Click around the RB Number (on the row) and ensure it expands the list of runs

Fixes #440

**Before merging ensure the release notes have been updated**