### PR TITLE
#496 Move run-count logic to views.py, pass via the context_dict

### DIFF
--- a/WebApp/autoreduce_webapp/reduction_viewer/views.py
+++ b/WebApp/autoreduce_webapp/reduction_viewer/views.py
@@ -536,6 +536,7 @@ def experiment_summary(request, reference_number=None):
         context_dictionary = {
             'experiment': experiment,
             'runs_with_started_by': runs_with_started_by,
+            'run_count': len(runs),
             'experiment_details': experiment_details,
             'data': data,
             'reduced_data': reduced_data,

--- a/WebApp/autoreduce_webapp/templates/experiment_summary.html
+++ b/WebApp/autoreduce_webapp/templates/experiment_summary.html
@@ -69,7 +69,7 @@
         <div class="row">
             <div class="col-md-12">
                 {% if runs_with_started_by %}
-                    <h4>Reduction Jobs ({{ runs_with_started_by.count }})</h4>
+                    <h4>Reduction Jobs ({{ run_count }})</h4>
                     <table class="table table-striped table-bordered">
                         <thead>
                             <tr>


### PR DESCRIPTION
### Summary of work
- This PR allows the 'Reduction Jobs' count (number within the parentheses) to populate.
- Previously, this would not populate at all

#### Existing behaviour
![image](https://user-images.githubusercontent.com/31534888/77897563-b7dff480-7271-11ea-9518-419e7c007cc4.png)

#### This PR
![image](https://user-images.githubusercontent.com/31534888/77897412-8a934680-7271-11ea-9e3f-2f1ebce63564.png)

### How to test your work
- Navigate to an experiment summary
- Ensure count is populating with the total number of runs

Fixes #496


**Before merging ensure the release notes have been updated**