### PR TITLE
Add prepare_data

### DIFF
--- a/plotting/plot_meta_language/tests/test_prepare_data.py
+++ b/plotting/plot_meta_language/tests/test_prepare_data.py
@@ -1,0 +1,91 @@
+# ############################################################################### #
+# Autoreduction Repository : https://github.com/ISISScientificComputing/autoreduce
+#
+# Copyright &copy; 2020 ISIS Rutherford Appleton Laboratory UKRI
+# SPDX - License - Identifier: GPL-3.0-or-later
+# ############################################################################### #
+"""
+Test cases for the data preparation class
+"""
+import csv
+import unittest
+from mock import patch, mock_open, MagicMock
+
+from plotting.prepare_data import PrepareData
+
+
+class TestPrepareData(unittest.TestCase):
+    """
+    Exercises the PrepareData class
+    """
+    def setUp(self):
+        self.valid_first_row = "first"
+        self.valid_data = [
+            [self.valid_first_row + " "],
+            ["2"],
+            ["3.1", "3.2", "3.3"]
+        ]
+        self.valid_data = (
+            f"{self.valid_first_row}\n"
+            f"2\n"
+            f"3.1, 3.2, 3.3"
+        )
+        self.real_data = (
+            "# X , Y , E\n"
+            "1\n"
+            "100.25,8210,90.6091"
+        )
+
+    def test_default_init(self):
+        """ Test initialisation values are set """
+        prep = PrepareData()
+        self.assertIsNotNone(prep.expected_first_row)
+        self.assertIsNotNone(prep.columns)
+
+    def test_invalid_first_row(self):
+        prep = PrepareData()
+        valid_string = "0"
+        prep.expected_first_row = valid_string
+        first_row = self.valid_data.split("\n")[0]
+        with self.assertRaises(RuntimeError):
+            prep._check_first_row(first_row)
+
+    def test_valid_first_row(self):
+        """ Test _check_first_row removes appended whitespace
+        and returns True if matches expected_first_row """
+        prep = PrepareData()
+        prep.expected_first_row = self.valid_first_row
+        first_row = self.valid_data.split("\n")[0]
+        self.assertTrue(prep._check_first_row(first_row))
+
+    def test_invalid_second_row(self):
+        prep = PrepareData()
+        with self.assertRaises(RuntimeError):
+            prep._check_second_row("invalid")
+
+    def test_valid_second_row(self):
+        prep = PrepareData()
+        second_row = self.valid_data.split("\n")[1]
+        expected_return = int(second_row)
+        self.assertEqual(prep._check_second_row(second_row),
+                         expected_return)
+
+    def test_invalid_path(self):
+        prep = PrepareData()
+        with patch("builtins.open", side_effect=FileNotFoundError):
+            with self.assertRaises(FileNotFoundError):
+                prep.prepare_data("")
+
+    def test_valid_path(self):
+        first_row_with_newline = self.valid_data.split("\n")[0] + "\n"
+        second_row_with_newline = self.valid_data.split("\n")[1] + "\n"
+
+        prep = PrepareData()
+        prep._check_first_row = MagicMock(return_value=True)
+        second_row_check_return = int(second_row_with_newline)
+        prep._check_second_row = MagicMock(return_value=second_row_check_return)
+        with patch("builtins.open", mock_open(read_data=self.valid_data)):
+            prep.prepare_data("")
+
+        prep._check_first_row.assert_called_with(first_row_with_newline)
+        prep._check_second_row.assert_called_with(second_row_with_newline)

--- a/plotting/plot_meta_language/tests/test_prepare_data.py
+++ b/plotting/plot_meta_language/tests/test_prepare_data.py
@@ -40,9 +40,9 @@ class TestPrepareData(unittest.TestCase):
         prep = PrepareData()
         valid_string = "0"
         prep.expected_first_row = valid_string
-        first_row = self.valid_data.split("\n")[0]
+        invalid_first_row = self.valid_data.split("\n")[0]
         with self.assertRaises(RuntimeError):
-            prep._check_first_row(first_row)
+            prep._check_first_row(invalid_first_row)
 
     def test_valid_first_row(self):
         """ Test _check_first_row removes appended whitespace
@@ -89,8 +89,8 @@ class TestPrepareData(unittest.TestCase):
         prep._check_second_row = MagicMock(return_value=second_row_check_return)
         with patch("builtins.open", mock_open(read_data=self.valid_data)):
             data_frame = prep.prepare_data("")
+            self.assertIsInstance(data_frame, pd.DataFrame)
+            self.assertEqual(len(data_frame), (len(split_data) - 2))
 
         prep._check_first_row.assert_called_with(first_row_with_newline)
         prep._check_second_row.assert_called_with(second_row_with_newline)
-        self.assertIsInstance(data_frame, pd.DataFrame)
-        # self.assertEqual(len(data_frame), (len(split_data) - 2))

--- a/plotting/plot_meta_language/tests/test_prepare_data.py
+++ b/plotting/plot_meta_language/tests/test_prepare_data.py
@@ -93,6 +93,6 @@ class TestPrepareData(unittest.TestCase):
         prep._check_first_row.assert_called_with(first_row_with_newline)
         prep._check_second_row.assert_called_with(second_row_with_newline)
         self.assertIsInstance(data_frame, pd.DataFrame)
-        # TODO: Note - The assertion below works locally, but for some reason Travis reads
+        # TODO: Note - The assertion below works locally, but for some reason Travis reads  #pylint:disable=fixme
         #   len(data_frame) as 0 (empty) and thereby fails the test
         # self.assertEqual(len(data_frame), (len(split_data) - 2))

--- a/plotting/plot_meta_language/tests/test_prepare_data.py
+++ b/plotting/plot_meta_language/tests/test_prepare_data.py
@@ -93,4 +93,4 @@ class TestPrepareData(unittest.TestCase):
         prep._check_first_row.assert_called_with(first_row_with_newline)
         prep._check_second_row.assert_called_with(second_row_with_newline)
         self.assertIsInstance(data_frame, pd.DataFrame)
-        self.assertEqual(len(data_frame), (len(split_data) - 2))
+        # self.assertEqual(len(data_frame), (len(split_data) - 2))

--- a/plotting/plot_meta_language/tests/test_prepare_data.py
+++ b/plotting/plot_meta_language/tests/test_prepare_data.py
@@ -7,6 +7,7 @@
 """
 Test cases for the data preparation class
 """
+import os
 import unittest
 
 import pandas as pd
@@ -27,6 +28,12 @@ class TestPrepareData(unittest.TestCase):
             f"2\n"
             f"3.1, 3.2, 3.3"
         )
+        self.test_file_name = "test_data.csv"
+        with open(self.test_file_name, 'w') as file:
+            file.write(self.valid_data)
+
+    def tearDown(self):
+        os.remove(self.test_file_name)
 
     def test_default_init(self):
         """ Test initialisation values are set """
@@ -71,9 +78,8 @@ class TestPrepareData(unittest.TestCase):
     def test_invalid_path(self):
         """ Test a FileNotFoundError is raised if an invalid path is given """
         prep = PrepareData()
-        with patch("builtins.open", side_effect=FileNotFoundError):
-            with self.assertRaises(FileNotFoundError):
-                prep.prepare_data("")
+        with self.assertRaises(FileNotFoundError):
+            prep.prepare_data("invalid_path")
 
     def test_valid_path(self):
         """ Test that where a valid path is given, prepare_data validates the
@@ -87,8 +93,7 @@ class TestPrepareData(unittest.TestCase):
         prep._check_first_row = MagicMock(return_value=True)
         second_row_check_return = int(second_row_with_newline)
         prep._check_second_row = MagicMock(return_value=second_row_check_return)
-        with patch("builtins.open", mock_open(read_data=self.valid_data)):
-            data_frame = prep.prepare_data("")
+        data_frame = prep.prepare_data(self.test_file_name)
 
         prep._check_first_row.assert_called_with(first_row_with_newline)
         prep._check_second_row.assert_called_with(second_row_with_newline)

--- a/plotting/plot_meta_language/tests/test_prepare_data.py
+++ b/plotting/plot_meta_language/tests/test_prepare_data.py
@@ -30,11 +30,6 @@ class TestPrepareData(unittest.TestCase):
             f"2\n"
             f"3.1, 3.2, 3.3"
         )
-        self.real_data = (
-            "# X , Y , E\n"
-            "1\n"
-            "100.25,8210,90.6091"
-        )
 
     def test_default_init(self):
         """ Test initialisation values are set """

--- a/plotting/plot_meta_language/tests/test_prepare_data.py
+++ b/plotting/plot_meta_language/tests/test_prepare_data.py
@@ -89,8 +89,10 @@ class TestPrepareData(unittest.TestCase):
         prep._check_second_row = MagicMock(return_value=second_row_check_return)
         with patch("builtins.open", mock_open(read_data=self.valid_data)):
             data_frame = prep.prepare_data("")
-            self.assertIsInstance(data_frame, pd.DataFrame)
-            self.assertEqual(len(data_frame), (len(split_data) - 2))
 
         prep._check_first_row.assert_called_with(first_row_with_newline)
         prep._check_second_row.assert_called_with(second_row_with_newline)
+        self.assertIsInstance(data_frame, pd.DataFrame)
+        # TODO: Note - The assertion below works locally, but for some reason Travis reads
+        #   len(data_frame) as 0 (empty) and thereby fails the test
+        # self.assertEqual(len(data_frame), (len(split_data) - 2))

--- a/plotting/plot_meta_language/tests/test_prepare_data.py
+++ b/plotting/plot_meta_language/tests/test_prepare_data.py
@@ -11,7 +11,7 @@ import os
 import unittest
 
 import pandas as pd
-from mock import patch, mock_open, MagicMock
+from mock import MagicMock
 
 from plotting.prepare_data import PrepareData
 

--- a/plotting/plot_meta_language/tests/test_prepare_data.py
+++ b/plotting/plot_meta_language/tests/test_prepare_data.py
@@ -98,6 +98,4 @@ class TestPrepareData(unittest.TestCase):
         prep._check_first_row.assert_called_with(first_row_with_newline)
         prep._check_second_row.assert_called_with(second_row_with_newline)
         self.assertIsInstance(data_frame, pd.DataFrame)
-        # TODO: Note - The assertion below works locally, but for some reason Travis reads  #pylint:disable=fixme
-        #   len(data_frame) as 0 (empty) and thereby fails the test
-        # self.assertEqual(len(data_frame), (len(split_data) - 2))
+        self.assertEqual(len(data_frame), (len(split_data) - 2))

--- a/plotting/plot_meta_language/tests/test_prepare_data.py
+++ b/plotting/plot_meta_language/tests/test_prepare_data.py
@@ -16,16 +16,12 @@ from plotting.prepare_data import PrepareData
 
 
 class TestPrepareData(unittest.TestCase):
+    # pylint:disable=protected-access
     """
     Exercises the PrepareData class
     """
     def setUp(self):
         self.valid_first_row = "first"
-        self.valid_data = [
-            [self.valid_first_row + " "],
-            ["2"],
-            ["3.1", "3.2", "3.3"]
-        ]
         self.valid_data = (
             f"{self.valid_first_row}\n"
             f"2\n"

--- a/plotting/prepare_data.py
+++ b/plotting/prepare_data.py
@@ -12,57 +12,48 @@ from difflib import ndiff
 import pandas as pd
 import csv
 
+
 class PrepareData:
 
     def __init__(self):
-        self.expected_file_first_row = "# X , Y , E"
+        self.expected_first_row = "# X , Y , E"
         self.columns = ["Spectrum", "X", "Y", "E"]
 
-    # TODO: consider pd.read_csv VS individual lines processed in turn
-    #   Due to the file size, reading line by line might be more efficient
     def prepare_data(self, path):
-        with open(path, 'r', ) as input_file:
-            first_row = input_file.readline()
-            self._check_first_row(first_row)    # Using input_file to treat row as 1 string item
-
-            second_row = input_file.readline()
-            spectrum = self._check_first_row(second_row)
+        processed_data = []
+        with open(path, 'r') as input_file:
+            self._check_first_row(input_file.readline())    # Using input_file to treat row as 1 string item
+            spectrum = self._check_second_row(input_file.readline())
 
             reader = csv.reader(input_file)
-            processed_data = []
-            for i, row in enumerate(reader):
+            for row in reader:
                 float_list = [float(item) for item in row]  # Ensures
                 if len(float_list) is 1:
                     spectrum = int(row[0])
                 else:
                     processed_data.append([spectrum]+float_list)
 
-            return pd.DataFrame(processed_data, columns=self.columns)
+        return pd.DataFrame(processed_data, columns=self.columns)
 
-    def _check_first_row(self, row):
-        row = row.rstrip()
-        if row != self.expected_file_first_row:
+    def _check_first_row(self, row_as_string):
+        row = row_as_string.rstrip()
+        if row != self.expected_first_row:
             error_message = (f"Unexpected first row of file.\n"
-                             f"Expected:\t{self.expected_file_first_row}\n"
-                             f"Actual:\t\t{row}\n")
+                             f"Expected:\t{self.expected_first_row}\n"
+                             f"Actual:\t\t{row}\n"
+                             f"\nDifference Breakdown:\n")
+            error_message += "".join(ndiff(self.expected_first_row, row))
 
             raise RuntimeError(error_message)
         return True
 
     @staticmethod
-    def _check_second_row(row):
+    def _check_second_row(row_as_string):
         try:
-            first_spectrum = int(row)
+            first_spectrum = int(row_as_string)
         except ValueError:
             error_message = (f"Unexpected second row of file.\n"
                              f"Expected: Integer (first spectrum number)\n"
-                             f"Actual:\t\t{row}\n")
+                             f"Actual:\t\t{row_as_string}\n")
             raise RuntimeError(error_message)
         return first_spectrum
-
-
-# TODO: Note - below for testing only
-prep = PrepareData()
-in_path = r"C:\Git\autoreduction\plotting\multi_spectra_data_file.csv"
-df = prep.prepare_data(in_path)
-print(df)

--- a/plotting/prepare_data.py
+++ b/plotting/prepare_data.py
@@ -1,0 +1,45 @@
+# ############################################################################### #
+# Autoreduction Repository : https://github.com/ISISScientificComputing/autoreduce
+#
+# Copyright &copy; 2020 ISIS Rutherford Appleton Laboratory UKRI
+# SPDX - License - Identifier: GPL-3.0-or-later
+# ############################################################################### #
+"""
+Prepares raw 'XYE' data to be plotted by converting it into a data frame.
+"""
+from difflib import ndiff
+
+import pandas as pd
+import csv
+
+class PrepareData:
+
+    def __init__(self):
+        self.expected_file_first_line = "# X , Y , E"
+
+    # TODO: update draw.io
+    def prepare_data(self, in_path, out_path):
+        # TODO: consider pd.read_csv VS individual lines processed in turn
+        #   Due to the file size, reading line by line might be more efficient
+        with open(in_path, 'r') as in_file:
+            reader = csv.reader(in_file)
+            self._check_file_first_line(in_file.readline())
+
+            with open(out_path, 'w') as out_file:
+                for i, row in enumerate(reader):
+                    writer = csv.writer(out_path)
+                    if i > 20: break
+
+    def _check_file_first_line(self, line):
+        line = line.rstrip()
+        if line != self.expected_file_first_line:
+            error_message = (f"Unexpected first line of file.\n"
+                             f"Expected:\t{self.expected_file_first_line}\n"
+                             f"Actual:\t\t{line}\n")
+
+            raise RuntimeError(error_message)
+        return True
+
+prep = PrepareData()
+path = r"C:\Git\autoreduction\plotting\multi_spectra_data_file.csv"
+prep.prepare_data(path)

--- a/plotting/prepare_data.py
+++ b/plotting/prepare_data.py
@@ -41,8 +41,11 @@ class PrepareData:
             error_message = (f"Unexpected first row of file.\n"
                              f"Expected:\t{self.expected_first_row}\n"
                              f"Actual:\t\t{row}\n"
-                             f"\nDifference Breakdown:\n")
-            error_message += "".join(ndiff(self.expected_first_row, row))
+                             f"\nDifference breakdown:\n")
+
+            diff = ndiff(self.expected_first_row.splitlines(keepends=True),
+                         row.splitlines(keepends=True))
+            error_message += "\n".join(diff)
 
             raise RuntimeError(error_message)
         return True

--- a/plotting/prepare_data.py
+++ b/plotting/prepare_data.py
@@ -41,7 +41,7 @@ class PrepareData:
             reader = csv.reader(input_file)
             for row in reader:
                 float_list = [float(item) for item in row]
-                if len(float_list) is 1:     # pylint:disable=literal-comparison
+                if len(float_list) == 1:
                     spectrum = int(row[0])
                 else:
                     processed_data.append([spectrum]+float_list)

--- a/plotting/prepare_data.py
+++ b/plotting/prepare_data.py
@@ -9,11 +9,12 @@ Prepares raw 'XYE' data to be plotted by converting it into a data frame.
 """
 from difflib import ndiff
 
-import pandas as pd
 import csv
+import pandas as pd
 
 
 class PrepareData:
+    # pylint:disable=too-few-public-methods
     """
     This class prepares data to be plotted by first reading it from a given path,
     validating initial rows are as expected, and ultimately converting the data
@@ -34,13 +35,13 @@ class PrepareData:
         """
         processed_data = []
         with open(path, 'r') as input_file:
-            self._check_first_row(input_file.readline())    # Using input_file to treat row as 1 string item
+            self._check_first_row(input_file.readline())
             spectrum = self._check_second_row(input_file.readline())
 
             reader = csv.reader(input_file)
             for row in reader:
-                float_list = [float(item) for item in row]  # Ensures
-                if len(float_list) is 1:
+                float_list = [float(item) for item in row]
+                if len(float_list) is 1:     # pylint:disable=literal-comparison
                     spectrum = int(row[0])
                 else:
                     processed_data.append([spectrum]+float_list)
@@ -78,7 +79,7 @@ class PrepareData:
         (i.e. that it is the first spectrum number)
         :param row_as_string: The second row of the data in it's natural string format
         :return: The row converted to an integer
-        :raises RuntimeError: If the row cannot be cast to an interge.
+        :raises RuntimeError: If the row cannot be cast to an integer.
         """
         try:
             first_spectrum = int(row_as_string)

--- a/plotting/prepare_data.py
+++ b/plotting/prepare_data.py
@@ -14,12 +14,24 @@ import csv
 
 
 class PrepareData:
+    """
+    This class prepares data to be plotted by first reading it from a given path,
+    validating initial rows are as expected, and ultimately converting the data
+    into a pandas data frame.
+    """
 
     def __init__(self):
         self.expected_first_row = "# X , Y , E"
         self.columns = ["Spectrum", "X", "Y", "E"]
 
     def prepare_data(self, path):
+        """
+        Reads raw XYE data from a given path.
+        Validates initial 2 rows are as expected.
+        Converts the data into a pandas.DataFrame
+        :param path: The location of the XYE data to be prepared
+        :return: The pandas.DataFrame comprising the data
+        """
         processed_data = []
         with open(path, 'r') as input_file:
             self._check_first_row(input_file.readline())    # Using input_file to treat row as 1 string item
@@ -36,6 +48,15 @@ class PrepareData:
         return pd.DataFrame(processed_data, columns=self.columns)
 
     def _check_first_row(self, row_as_string):
+        """
+        Validates the first row of the data by comparing it with the
+        predefined expected_first_row
+        :param row_as_string: The first row of the data in it's natural string format
+        :return: True if the row matches the expected_first_row
+        :raises RuntimeError: If the row does not match the expected_first_row.
+            A breakdown of the differences between the expected and actual
+            first row is provided.
+        """
         row = row_as_string.rstrip()
         if row != self.expected_first_row:
             error_message = (f"Unexpected first row of file.\n"
@@ -52,6 +73,13 @@ class PrepareData:
 
     @staticmethod
     def _check_second_row(row_as_string):
+        """
+        Validates the second row of the data can be converted into an integer
+        (i.e. that it is the first spectrum number)
+        :param row_as_string: The second row of the data in it's natural string format
+        :return: The row converted to an integer
+        :raises RuntimeError: If the row cannot be cast to an interge.
+        """
         try:
             first_spectrum = int(row_as_string)
         except ValueError:

--- a/scripts/tests/__init__.py
+++ b/scripts/tests/__init__.py
@@ -1,0 +1,6 @@
+# ############################################################################### #
+# Autoreduction Repository : https://github.com/ISISScientificComputing/autoreduce
+#
+# Copyright &copy; 2020 ISIS Rutherford Appleton Laboratory UKRI
+# SPDX - License - Identifier: GPL-3.0-or-later
+# ############################################################################### #

--- a/scripts/tests/__init__.py
+++ b/scripts/tests/__init__.py
@@ -1,6 +1,0 @@
-# ############################################################################### #
-# Autoreduction Repository : https://github.com/ISISScientificComputing/autoreduce
-#
-# Copyright &copy; 2020 ISIS Rutherford Appleton Laboratory UKRI
-# SPDX - License - Identifier: GPL-3.0-or-later
-# ############################################################################### #


### PR DESCRIPTION
### Summary of work
- This PR adds a `prepare_data.py` component, along with tests.
- `prepare_data.py` primary function is to load a CSV file from a given path, converts it into a `pandas.DataFrame` and returns this.
- Formats are outlined below:

#### Expected input [example]
```
# X , Y , E 
1
1.0, 2.0, 3.0 
4.0, 5.0, 6.0
1.0, 2.0, 3.0
```
_Note:_ Line 1 above specified by instance variable `PrepareData.expected_first_row`


#### Output [example]
```
|Spectrum | X     | Y   | E   |
| :---    | :---: |:---:| ---:|
| 1       |       |     |     |
| 1       | 1.0   | 2.0 | 3.0 |
| 1       | 4.0   | 5.0 | 6.0 |
| 2       | 1.0   | 2.0 | 3.0 |
```

### How to test your work
* Review code
* Run tests: `\plotting\plot_meta_language\tests\test_prepare_data.py`

Fixes #473


**Before merging ensure the release notes have been updated**