### PR TITLE
Basic AMQ message class

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ script:
   - py.test build/tests/test_db_generation.py  # perform initial check of database
   # ================ Functional tests =============== #
   - echo "Running Unit tests"
-  - py.test --ignore=systemtests --cov=build --cov=monitors --cov=queue_processors --cov=scripts --cov=utils --cov=WebApp/autoreduce_webapp --cov=docker_reduction --cov=paths --cov=plotting
+  - py.test --ignore=systemtests --cov=build --cov=monitors --cov=queue_processors --cov=scripts --cov=utils --cov=WebApp/autoreduce_webapp --cov=docker_reduction --cov=paths --cov=plotting --cov=message
 
   - echo "Running System Tests"
   - py.test systemtests --cov-append
@@ -48,7 +48,6 @@ script:
   - pylint systemtests
   - pylint utils
   - pylint plotting
-
 
 after_success:
   - coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,12 +41,14 @@ script:
   # ToDo: These should all be collapsed into one once autoreduction gets a single code package
   - pylint build
   - pylint docker_reduction
+  - pylint message
   - pylint monitors
   - pylint queue_processors
   - pylint scripts
   - pylint systemtests
   - pylint utils
   - pylint plotting
+
 
 after_success:
   - coveralls

--- a/message/__init__.py
+++ b/message/__init__.py
@@ -1,0 +1,6 @@
+# ############################################################################### #
+# Autoreduction Repository : https://github.com/ISISScientificComputing/autoreduce
+#
+# Copyright &copy; 2020 ISIS Rutherford Appleton Laboratory UKRI
+# SPDX - License - Identifier: GPL-3.0-or-later
+# ############################################################################### #

--- a/message/job.py
+++ b/message/job.py
@@ -6,54 +6,39 @@
 # ############################################################################### #
 """ Represents the messages passed between AMQ queues"""
 import json
+import attr
 
 
 # pylint:disable=too-many-instance-attributes
+@attr.s
 class Message:
     """
     A class that represents an AMQ Message, these can be both serialised and un-serialised
     for sending messages to and from AMQ
     """
-
-    def __init__(self, serialised_object=None, overwrite=True):
-        """
-        If a serialised object is supplied then the class will be populated
-        :param serialised_object: a serialised json object (json.dumps)
-        :param overwrite: Should we overwrite existing variables?
-        """
-        self.description = None
-        self.facility = None
-        self.run_number = None
-        self.instrument = None
-        self.rb_number = None
-        self.started_by = None
-        self.file_path = None
-        self.overwrite = None
-        self.run_version = None
-        self.job_id = None
-        self.reduction_script = None
-        self.reduction_arguments = None
-        self.reduction_log = None
-        self.admin_log = None
-        self.return_message = None
-        self.retry_in = None
-        if serialised_object:
-            self.un_serialise(serialised_object, overwrite)
-
-    def to_dict(self):
-        """
-        Create a dictionary of all the class member variables
-        :return: member variables dictionary
-        """
-        return {key: value for key, value in self.__dict__.items()
-                if not key.startswith('__') and not callable(key)}
+    description = attr.ib(default=None)
+    facility = attr.ib(default=None)
+    run_number = attr.ib(default=None)
+    instrument = attr.ib(default=None)
+    rb_number = attr.ib(default=None)
+    started_by = attr.ib(default=None)
+    file_path = attr.ib(default=None)
+    overwrite = attr.ib(default=None)
+    run_version = attr.ib(default=None)
+    job_id = attr.ib(default=None)
+    reduction_script = attr.ib(default=None)
+    reduction_arguments = attr.ib(default=None)
+    reduction_log = attr.ib(default=None)
+    admin_log = attr.ib(default=None)
+    return_message = attr.ib(default=None)
+    retry_in = attr.ib(default=None)
 
     def serialise(self):
         """
         serialised member variables as a json dump
         :return: json dump of a dictionary representing the member variables
         """
-        return json.dumps(self.to_dict())
+        return json.dumps(attr.asdict(self))
 
     def un_serialise(self, serialised_object, overwrite=True):
         """
@@ -62,7 +47,7 @@ class Message:
         :param overwrite: Should we overwrite any existing variables?
         """
         un_serialised_dict = json.loads(serialised_object)
-        self_dict = self.to_dict()
+        self_dict = attr.asdict(self)
         for key, value in un_serialised_dict.items():
             if key in self_dict.keys():
                 current_value = self_dict[key]

--- a/message/job.py
+++ b/message/job.py
@@ -8,7 +8,12 @@
 import json
 
 
+# pylint:disable=too-many-instance-attributes
 class Message:
+    """
+    A class that represents an AMQ Message, these can be both serialised and un-serialised
+    for sending messages to and from AMQ
+    """
 
     def __init__(self, serialised_object=None, overwrite=True):
         """

--- a/message/job.py
+++ b/message/job.py
@@ -4,7 +4,9 @@
 # Copyright &copy; 2020 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 # ############################################################################### #
-""" Represents the messages passed between AMQ queues"""
+"""
+Represents the messages passed between AMQ queues
+"""
 import json
 import attr
 
@@ -13,8 +15,8 @@ import attr
 @attr.s
 class Message:
     """
-    A class that represents an AMQ Message, these can be both serialized and deserialized
-    for sending messages to and from AMQ
+    A class that represents an AMQ Message.
+    Messages can be serialized and deserialized for sending messages to and from AMQ
     """
     description = attr.ib(default=None)
     facility = attr.ib(default=None)
@@ -35,17 +37,17 @@ class Message:
 
     def serialize(self):
         """
-        serialized member variables as a json dump
-        :return: json dump of a dictionary representing the member variables
+        Serialized member variables as a json dump
+        :return: JSON dump of a dictionary representing the member variables
         """
         return json.dumps(attr.asdict(self))
 
     @staticmethod
     def deserialize(serialized_object):
         """
-        deserialize an object and return a dictionary of that object
+        Deserialize an object and return a dictionary of that object
         :param serialized_object: The object to deserialize
-        :return: dictionary of deserialized object
+        :return: Dictionary of deserialized object
         """
         return json.loads(serialized_object)
 
@@ -53,10 +55,10 @@ class Message:
         """
         Populate the class from either a serialised object or a dictionary optionally retaining
         or overwriting existing values of attributes
-        :param source: object to populate class from
+        :param source: Object to populate class from
         :param overwrite: If True, overwrite existing values of attributes
         """
-        if type(source) is str:
+        if isinstance(source, str):
             try:
                 source = self.deserialize(source)
             except json.decoder.JSONDecodeError:

--- a/message/job.py
+++ b/message/job.py
@@ -1,0 +1,66 @@
+# ############################################################################### #
+# Autoreduction Repository : https://github.com/ISISScientificComputing/autoreduce
+#
+# Copyright &copy; 2020 ISIS Rutherford Appleton Laboratory UKRI
+# SPDX - License - Identifier: GPL-3.0-or-later
+# ############################################################################### #
+""" Represents the messages passed between AMQ queues"""
+import json
+
+
+class Message:
+
+    def __init__(self, serialised_object=None, overwrite=True):
+        """
+        If a serialised object is supplied then the class will be populated
+        :param serialised_object: a serialised json object (json.dumps)
+        :param overwrite: Should we overwrite existing variables?
+        """
+        self.description = None
+        self.facility = None
+        self.run_number = None
+        self.instrument = None
+        self.rb_number = None
+        self.started_by = None
+        self.file_path = None
+        self.overwrite = None
+        self.run_version = None
+        self.job_id = None
+        self.reduction_script = None
+        self.reduction_arguments = None
+        self.reduction_log = None
+        self.admin_log = None
+        self.return_message = None
+        self.retry_in = None
+        if serialised_object:
+            self.un_serialise(serialised_object, overwrite)
+
+    def to_dict(self):
+        """
+        Create a dictionary of all the class member variables
+        :return: member variables dictionary
+        """
+        return {key: value for key, value in self.__dict__.items()
+                if not key.startswith('__') and not callable(key)}
+
+    def serialise(self):
+        """
+        serialised member variables as a json dump
+        :return: json dump of a dictionary representing the member variables
+        """
+        return json.dumps(self.to_dict())
+
+    def un_serialise(self, serialised_object, overwrite=True):
+        """
+        un serialise an object and use its values to populate member variables in this class
+        :param serialised_object: The object to un-serialise
+        :param overwrite: Should we overwrite any existing variables?
+        """
+        un_serialised_dict = json.loads(serialised_object)
+        self_dict = self.to_dict()
+        for key, value in un_serialised_dict.items():
+            if key in self_dict.keys():
+                current_value = self_dict[key]
+                if overwrite or current_value is None:
+                    # Set the value of the variable on this object accessing it by name
+                    setattr(self, key, value)

--- a/message/tests/__init__.py
+++ b/message/tests/__init__.py
@@ -1,0 +1,6 @@
+# ############################################################################### #
+# Autoreduction Repository : https://github.com/ISISScientificComputing/autoreduce
+#
+# Copyright &copy; 2020 ISIS Rutherford Appleton Laboratory UKRI
+# SPDX - License - Identifier: GPL-3.0-or-later
+# ############################################################################### #

--- a/message/tests/test_job.py
+++ b/message/tests/test_job.py
@@ -4,6 +4,9 @@
 # Copyright &copy; 2020 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 # ############################################################################### #
+"""
+Test the Message class
+"""
 import unittest
 import json
 
@@ -13,6 +16,9 @@ from message.job import Message
 
 
 class TestMessage(unittest.TestCase):
+    """
+    Test cases for the Message class used with AMQ
+    """
 
     def setUp(self):
         self.msg = Message()
@@ -29,6 +35,10 @@ class TestMessage(unittest.TestCase):
 
     @patch('message.job.Message.un_serialise')
     def test_init(self, mock_un_serialise):
+        """
+        Test all the member variables are created and we do not call
+        un-serialise if no object is provided
+        """
         self.assertIsNone(self.msg.description)
         self.assertIsNone(self.msg.facility)
         self.assertIsNone(self.msg.run_number)
@@ -47,18 +57,28 @@ class TestMessage(unittest.TestCase):
         self.assertIsNone(self.msg.retry_in)
         self.assertFalse(mock_un_serialise.called)
 
+    # pylint:disable=no-self-use
     @patch('message.job.Message.un_serialise')
     def test_init_with_serialised_obj(self, mock_un_serialise):
+        """
+        Test that we call the unserialise function if a serialised object is provided on init
+        """
         _ = Message(serialised_object='test', overwrite=False)
         mock_un_serialise.assert_called_once()
 
     def test_to_dict(self):
+        """
+        Test the class can be correctly converted to a dictionary
+        """
         actual = self.msg.to_dict()
         for key, value in actual.items():
             self.assertIn(key, self.key_list)
             self.assertIsNone(value)
 
     def test_serialise(self):
+        """
+        Test the class can be serialised and retain the variables values
+        """
         serialised = self.msg.serialise()
         actual = json.loads(serialised)
         for key, value in actual.items():
@@ -66,6 +86,9 @@ class TestMessage(unittest.TestCase):
             self.assertIsNone(value)
 
     def test_un_serialise_overwrite_true(self):
+        """
+        Test the class can be populated with a serialised object
+        """
         serialised = self.populated_msg.serialise()
         actual = Message()
         actual.un_serialise(serialised)

--- a/message/tests/test_job.py
+++ b/message/tests/test_job.py
@@ -22,6 +22,7 @@ class TestMessage(unittest.TestCase):
 
     @staticmethod
     def _empty():
+        """ Create and return an empty message object and corresponding dictionary"""
         empty_msg = Message()
         empty_dict = {'description': None,
                       'facility': None,
@@ -43,6 +44,7 @@ class TestMessage(unittest.TestCase):
 
     @staticmethod
     def _populated():
+        """ Create and return a populated message object and corresponding dictionary """
         run_number = 11111
         rb_number = 22222
         description = 'test message'
@@ -68,7 +70,10 @@ class TestMessage(unittest.TestCase):
         return populated_msg, populated_dict
 
     def test_init(self):
-        """ Test all the member variables are created """
+        """
+        Test: All the expected member variables are created
+        When: The class is initialised
+        """
         empty_msg, _ = self._empty()
         self.assertIsNone(empty_msg.description)
         self.assertIsNone(empty_msg.facility)
@@ -88,44 +93,62 @@ class TestMessage(unittest.TestCase):
         self.assertIsNone(empty_msg.retry_in)
 
     def test_to_dict_populated(self):
-        """ Converted to a dictionary when attribute values set """
+        """
+        Test: A dictionary with populated values in produced
+        When: attr.asdict() is called on a Message with populated values
+        """
         populated_msg, populated_dict = self._populated()
         actual = attr.asdict(populated_msg)
         self.assertEqual(actual, populated_dict)
 
     def test_serialize_populated(self):
-        """ Serialized and retain the attributes values """
+        """
+        Test: An expected JSON object is produced
+        When: The Message class is serialised
+        """
         populated_msg, populated_dict = self._populated()
         serialized = populated_msg.serialize()
         actual = json.loads(serialized)
         self.assertEqual(actual, populated_dict)
 
     def test_deserialize_populated(self):
-        """ Produce a deserialized object correctly for a populated serialized object """
+        """
+        Test: A Dictionary with all the expected value is produced
+        When: A populated serialized object is deserialized
+        """
         populated_msg, populated_dict = self._populated()
         serialized = populated_msg.serialize()
         actual = populated_msg.deserialize(serialized)
         self.assertEqual(actual, populated_dict)
 
     def test_populate_from_dict_overwrite_true(self):
-        """ Overwritten from a dictionary values """
+        """
+        Test: Values are added and overwritten in the member variables
+        When: Message.populate() is called with a non-empty dictionary and overwrite is True
+        """
         _, populated_dict = self._populated()
         actual, _ = self._empty()
-        actual.populate(populated_dict, overwrite=True)
+        actual.populate(source=populated_dict, overwrite=True)
         self.assertEqual(attr.asdict(actual), populated_dict)
 
     def test_populate_from_dict_overwrite_false(self):
-        """ Do not overwrite from dictionary """
+        """
+        Test: Values are added but NOT overwritten in the member variables
+        When: Message.populate() is called with a non-empty dictionary and overwrite is False
+        """
         populated_msg, populated_dict = self._populated()
         populated_dict['job_id'] = 123
         populated_dict['rb_number'] = 33333
         actual, _ = self._populated()
-        actual.populate(populated_dict, overwrite=False)
+        actual.populate(source=populated_dict, overwrite=False)
         self.assertEqual(actual.rb_number, populated_msg.rb_number)
         self.assertEqual(actual.job_id, 123)
 
     def test_populate_from_serialized_overwrite_true(self):
-        """ Overwrite with a serialized object """
+        """
+        Test: Values are added and overwritten in the member variables
+        When: Message.populate() called with a non-empty serialized object and overwrite is True
+        """
         populated_msg, populated_dict = self._populated()
         serialized = populated_msg.serialize()
         actual, _ = self._empty()
@@ -133,7 +156,10 @@ class TestMessage(unittest.TestCase):
         self.assertEqual(attr.asdict(actual), populated_dict)
 
     def test_populate_from_serialized_overwrite_false(self):
-        """ Do not overwrite from a serialized object """
+        """
+        Test: Values are added but NOT overwritten in the member variables
+        When: Message.populate() called with a non-empty serialized object and overwrite is False
+        """
         new_msg, _ = self._populated()
         new_msg.job_id = 123
         new_msg.rb_number = 33333
@@ -145,7 +171,10 @@ class TestMessage(unittest.TestCase):
         self.assertEqual(actual.job_id, 123)
 
     def test_invalid_serialized(self):
-        """ Test raise exception for invalid serialized object """
+        """
+        Test: A ValueError is raised
+        When: An invalid serialized object is supplied to Message.populate()
+        """
         serialized = 'test'
-        empty_msg, _ = self._populated()
+        empty_msg, _ = self._empty()
         self.assertRaises(ValueError, empty_msg.populate, serialized)

--- a/message/tests/test_job.py
+++ b/message/tests/test_job.py
@@ -9,8 +9,7 @@ Test the Message class
 """
 import unittest
 import json
-
-from mock import patch
+import attr
 
 from message.job import Message
 
@@ -21,7 +20,7 @@ class TestMessage(unittest.TestCase):
     """
 
     def setUp(self):
-        self.msg = Message()
+        self.empty_msg = Message()
         # Ensure the list below is up to date if member variables are added/removed/renamed
         self.key_list = ['description', 'facility', 'run_number', 'instrument',
                          'rb_number', 'started_by', 'file_path', 'overwrite',
@@ -33,44 +32,33 @@ class TestMessage(unittest.TestCase):
         self.populated_msg.rb_number = 22222
         self.populated_msg.description = 'test message'
 
-    @patch('message.job.Message.un_serialise')
-    def test_init(self, mock_un_serialise):
+    def test_init(self):
         """
         Test all the member variables are created and we do not call
         un-serialise if no object is provided
         """
-        self.assertIsNone(self.msg.description)
-        self.assertIsNone(self.msg.facility)
-        self.assertIsNone(self.msg.run_number)
-        self.assertIsNone(self.msg.instrument)
-        self.assertIsNone(self.msg.rb_number)
-        self.assertIsNone(self.msg.started_by)
-        self.assertIsNone(self.msg.file_path)
-        self.assertIsNone(self.msg.overwrite)
-        self.assertIsNone(self.msg.run_version)
-        self.assertIsNone(self.msg.job_id)
-        self.assertIsNone(self.msg.reduction_script)
-        self.assertIsNone(self.msg.reduction_arguments)
-        self.assertIsNone(self.msg.reduction_log)
-        self.assertIsNone(self.msg.admin_log)
-        self.assertIsNone(self.msg.return_message)
-        self.assertIsNone(self.msg.retry_in)
-        self.assertFalse(mock_un_serialise.called)
-
-    # pylint:disable=no-self-use
-    @patch('message.job.Message.un_serialise')
-    def test_init_with_serialised_obj(self, mock_un_serialise):
-        """
-        Test that we call the unserialise function if a serialised object is provided on init
-        """
-        _ = Message(serialised_object='test', overwrite=False)
-        mock_un_serialise.assert_called_once()
+        self.assertIsNone(self.empty_msg.description)
+        self.assertIsNone(self.empty_msg.facility)
+        self.assertIsNone(self.empty_msg.run_number)
+        self.assertIsNone(self.empty_msg.instrument)
+        self.assertIsNone(self.empty_msg.rb_number)
+        self.assertIsNone(self.empty_msg.started_by)
+        self.assertIsNone(self.empty_msg.file_path)
+        self.assertIsNone(self.empty_msg.overwrite)
+        self.assertIsNone(self.empty_msg.run_version)
+        self.assertIsNone(self.empty_msg.job_id)
+        self.assertIsNone(self.empty_msg.reduction_script)
+        self.assertIsNone(self.empty_msg.reduction_arguments)
+        self.assertIsNone(self.empty_msg.reduction_log)
+        self.assertIsNone(self.empty_msg.admin_log)
+        self.assertIsNone(self.empty_msg.return_message)
+        self.assertIsNone(self.empty_msg.retry_in)
 
     def test_to_dict(self):
         """
         Test the class can be correctly converted to a dictionary
         """
-        actual = self.msg.to_dict()
+        actual = attr.asdict(self.empty_msg)
         for key, value in actual.items():
             self.assertIn(key, self.key_list)
             self.assertIsNone(value)
@@ -79,7 +67,7 @@ class TestMessage(unittest.TestCase):
         """
         Test the class can be serialised and retain the variables values
         """
-        serialised = self.msg.serialise()
+        serialised = self.empty_msg.serialise()
         actual = json.loads(serialised)
         for key, value in actual.items():
             self.assertIn(key, self.key_list)
@@ -90,7 +78,7 @@ class TestMessage(unittest.TestCase):
         Test the class can be populated with a serialised object
         """
         serialised = self.populated_msg.serialise()
-        actual = Message()
+        actual = self.empty_msg
         actual.un_serialise(serialised)
         self.assertEqual(actual.run_number, self.populated_msg.run_number)
         self.assertEqual(actual.rb_number, self.populated_msg.rb_number)

--- a/message/tests/test_job.py
+++ b/message/tests/test_job.py
@@ -1,0 +1,74 @@
+# ############################################################################### #
+# Autoreduction Repository : https://github.com/ISISScientificComputing/autoreduce
+#
+# Copyright &copy; 2020 ISIS Rutherford Appleton Laboratory UKRI
+# SPDX - License - Identifier: GPL-3.0-or-later
+# ############################################################################### #
+import unittest
+import json
+
+from mock import patch
+
+from message.job import Message
+
+
+class TestMessage(unittest.TestCase):
+
+    def setUp(self):
+        self.msg = Message()
+        # Ensure the list below is up to date if member variables are added/removed/renamed
+        self.key_list = ['description', 'facility', 'run_number', 'instrument',
+                         'rb_number', 'started_by', 'file_path', 'overwrite',
+                         'run_version', 'job_id', 'reduction_script',
+                         'reduction_arguments', 'reduction_log', 'admin_log',
+                         'return_message', 'retry_in']
+        self.populated_msg = Message()
+        self.populated_msg.run_number = 11111
+        self.populated_msg.rb_number = 22222
+        self.populated_msg.description = 'test message'
+
+    @patch('message.job.Message.un_serialise')
+    def test_init(self, mock_un_serialise):
+        self.assertIsNone(self.msg.description)
+        self.assertIsNone(self.msg.facility)
+        self.assertIsNone(self.msg.run_number)
+        self.assertIsNone(self.msg.instrument)
+        self.assertIsNone(self.msg.rb_number)
+        self.assertIsNone(self.msg.started_by)
+        self.assertIsNone(self.msg.file_path)
+        self.assertIsNone(self.msg.overwrite)
+        self.assertIsNone(self.msg.run_version)
+        self.assertIsNone(self.msg.job_id)
+        self.assertIsNone(self.msg.reduction_script)
+        self.assertIsNone(self.msg.reduction_arguments)
+        self.assertIsNone(self.msg.reduction_log)
+        self.assertIsNone(self.msg.admin_log)
+        self.assertIsNone(self.msg.return_message)
+        self.assertIsNone(self.msg.retry_in)
+        self.assertFalse(mock_un_serialise.called)
+
+    @patch('message.job.Message.un_serialise')
+    def test_init_with_serialised_obj(self, mock_un_serialise):
+        _ = Message(serialised_object='test', overwrite=False)
+        mock_un_serialise.assert_called_once()
+
+    def test_to_dict(self):
+        actual = self.msg.to_dict()
+        for key, value in actual.items():
+            self.assertIn(key, self.key_list)
+            self.assertIsNone(value)
+
+    def test_serialise(self):
+        serialised = self.msg.serialise()
+        actual = json.loads(serialised)
+        for key, value in actual.items():
+            self.assertIn(key, self.key_list)
+            self.assertIsNone(value)
+
+    def test_un_serialise_overwrite_true(self):
+        serialised = self.populated_msg.serialise()
+        actual = Message()
+        actual.un_serialise(serialised)
+        self.assertEqual(actual.run_number, self.populated_msg.run_number)
+        self.assertEqual(actual.rb_number, self.populated_msg.rb_number)
+        self.assertEqual(actual.description, self.populated_msg.description)

--- a/message/tests/test_job.py
+++ b/message/tests/test_job.py
@@ -9,8 +9,9 @@ Test the Message class
 """
 import unittest
 import json
-import attr
 import copy
+
+import attr
 
 from message.job import Message
 

--- a/message/tests/test_job.py
+++ b/message/tests/test_job.py
@@ -9,7 +9,6 @@ Test the Message class
 """
 import unittest
 import json
-import copy
 
 import attr
 
@@ -21,101 +20,132 @@ class TestMessage(unittest.TestCase):
     Test cases for the Message class used with AMQ
     """
 
-    def setUp(self):
-        self.empty_msg = Message()
-        self.empty_dict = {'description': None,
-                           'facility': None,
-                           'run_number': None,
-                           'instrument': None,
-                           'rb_number': None,
-                           'started_by': None,
-                           'file_path': None,
-                           'overwrite': None,
-                           'run_version': None,
-                           'job_id': None,
-                           'reduction_script': None,
-                           'reduction_arguments': None,
-                           'reduction_log': None,
-                           'admin_log': None,
-                           'return_message': None,
-                           'retry_in': None}
-        self.populated_msg = Message(run_number=11111, rb_number=22222, description='test message')
-        self.populated_dict = copy.deepcopy(self.empty_dict)
-        self.populated_dict['run_number'] = self.populated_msg.run_number
-        self.populated_dict['rb_number'] = self.populated_msg.rb_number
-        self.populated_dict['description'] = self.populated_msg.description
-        self.populated_keys = ['run_number', 'rb_number', 'description']
+    @staticmethod
+    def _empty():
+        empty_msg = Message()
+        empty_dict = {'description': None,
+                      'facility': None,
+                      'run_number': None,
+                      'instrument': None,
+                      'rb_number': None,
+                      'started_by': None,
+                      'file_path': None,
+                      'overwrite': None,
+                      'run_version': None,
+                      'job_id': None,
+                      'reduction_script': None,
+                      'reduction_arguments': None,
+                      'reduction_log': None,
+                      'admin_log': None,
+                      'return_message': None,
+                      'retry_in': None}
+        return empty_msg, empty_dict
+
+    @staticmethod
+    def _populated():
+        run_number = 11111
+        rb_number = 22222
+        description = 'test message'
+        populated_msg = Message(run_number=run_number,
+                                rb_number=rb_number,
+                                description=description)
+        populated_dict = {'description': description,
+                          'facility': None,
+                          'run_number': run_number,
+                          'instrument': None,
+                          'rb_number': rb_number,
+                          'started_by': None,
+                          'file_path': None,
+                          'overwrite': None,
+                          'run_version': None,
+                          'job_id': None,
+                          'reduction_script': None,
+                          'reduction_arguments': None,
+                          'reduction_log': None,
+                          'admin_log': None,
+                          'return_message': None,
+                          'retry_in': None}
+        return populated_msg, populated_dict
 
     def test_init(self):
         """ Test all the member variables are created """
-        self.assertIsNone(self.empty_msg.description)
-        self.assertIsNone(self.empty_msg.facility)
-        self.assertIsNone(self.empty_msg.run_number)
-        self.assertIsNone(self.empty_msg.instrument)
-        self.assertIsNone(self.empty_msg.rb_number)
-        self.assertIsNone(self.empty_msg.started_by)
-        self.assertIsNone(self.empty_msg.file_path)
-        self.assertIsNone(self.empty_msg.overwrite)
-        self.assertIsNone(self.empty_msg.run_version)
-        self.assertIsNone(self.empty_msg.job_id)
-        self.assertIsNone(self.empty_msg.reduction_script)
-        self.assertIsNone(self.empty_msg.reduction_arguments)
-        self.assertIsNone(self.empty_msg.reduction_log)
-        self.assertIsNone(self.empty_msg.admin_log)
-        self.assertIsNone(self.empty_msg.return_message)
-        self.assertIsNone(self.empty_msg.retry_in)
+        empty_msg, _ = self._empty()
+        self.assertIsNone(empty_msg.description)
+        self.assertIsNone(empty_msg.facility)
+        self.assertIsNone(empty_msg.run_number)
+        self.assertIsNone(empty_msg.instrument)
+        self.assertIsNone(empty_msg.rb_number)
+        self.assertIsNone(empty_msg.started_by)
+        self.assertIsNone(empty_msg.file_path)
+        self.assertIsNone(empty_msg.overwrite)
+        self.assertIsNone(empty_msg.run_version)
+        self.assertIsNone(empty_msg.job_id)
+        self.assertIsNone(empty_msg.reduction_script)
+        self.assertIsNone(empty_msg.reduction_arguments)
+        self.assertIsNone(empty_msg.reduction_log)
+        self.assertIsNone(empty_msg.admin_log)
+        self.assertIsNone(empty_msg.return_message)
+        self.assertIsNone(empty_msg.retry_in)
 
     def test_to_dict_populated(self):
         """ Converted to a dictionary when attribute values set """
-        actual = attr.asdict(self.populated_msg)
-        self.assertEqual(actual, self.populated_dict)
+        populated_msg, populated_dict = self._populated()
+        actual = attr.asdict(populated_msg)
+        self.assertEqual(actual, populated_dict)
 
     def test_serialize_populated(self):
         """ Serialized and retain the attributes values """
-        serialized = self.populated_msg.serialize()
+        populated_msg, populated_dict = self._populated()
+        serialized = populated_msg.serialize()
         actual = json.loads(serialized)
-        self.assertEqual(actual, self.populated_dict)
+        self.assertEqual(actual, populated_dict)
 
     def test_deserialize_populated(self):
         """ Produce a deserialized object correctly for a populated serialized object """
-        serialized = self.populated_msg.serialize()
-        actual = self.populated_msg.deserialize(serialized)
-        self.assertEqual(actual, self.populated_dict)
+        populated_msg, populated_dict = self._populated()
+        serialized = populated_msg.serialize()
+        actual = populated_msg.deserialize(serialized)
+        self.assertEqual(actual, populated_dict)
 
     def test_populate_from_dict_overwrite_true(self):
-        """ Overwritten from a dictionary values"""
-        actual = self.empty_msg
-        actual.populate(self.populated_dict, overwrite=True)
-        self.assertEqual(attr.asdict(actual), self.populated_dict)
+        """ Overwritten from a dictionary values """
+        _, populated_dict = self._populated()
+        actual, _ = self._empty()
+        actual.populate(populated_dict, overwrite=True)
+        self.assertEqual(attr.asdict(actual), populated_dict)
 
     def test_populate_from_dict_overwrite_false(self):
         """ Do not overwrite from dictionary """
-        self.populated_dict['job_id'] = 123
-        self.populated_dict['rb_number'] = 33333
-        actual = copy.deepcopy(self.populated_msg)
-        actual.populate(self.populated_dict, overwrite=False)
-        self.assertEqual(actual.rb_number, self.populated_msg.rb_number)
+        populated_msg, populated_dict = self._populated()
+        populated_dict['job_id'] = 123
+        populated_dict['rb_number'] = 33333
+        actual, _ = self._populated()
+        actual.populate(populated_dict, overwrite=False)
+        self.assertEqual(actual.rb_number, populated_msg.rb_number)
         self.assertEqual(actual.job_id, 123)
 
     def test_populate_from_serialized_overwrite_true(self):
         """ Overwrite with a serialized object """
-        serialized = self.populated_msg.serialize()
-        actual = self.empty_msg
+        populated_msg, populated_dict = self._populated()
+        serialized = populated_msg.serialize()
+        actual, _ = self._empty()
         actual.populate(source=serialized, overwrite=True)
-        self.assertEqual(attr.asdict(actual), self.populated_dict)
+        self.assertEqual(attr.asdict(actual), populated_dict)
 
     def test_populate_from_serialized_overwrite_false(self):
         """ Do not overwrite from a serialized object """
-        new_msg = copy.deepcopy(self.populated_msg)
+        new_msg, _ = self._populated()
         new_msg.job_id = 123
         new_msg.rb_number = 33333
         serialized = new_msg.serialize()
-        actual = copy.deepcopy(self.populated_msg)
+        actual, _ = self._populated()
+        original, _ = self._populated()
         actual.populate(source=serialized, overwrite=False)
-        self.assertEqual(actual.rb_number, self.populated_msg.rb_number)
+        self.assertEqual(actual.rb_number, original.rb_number)
         self.assertEqual(actual.job_id, 123)
 
     def test_invalid_serialized(self):
         """ Test raise exception for invalid serialized object """
         serialized = 'test'
-        self.assertRaises(ValueError, self.empty_msg.populate, serialized)
+        empty_msg, _ = self._populated()
+        self.assertRaises(ValueError, empty_msg.populate, serialized)

--- a/message/tests/test_job.py
+++ b/message/tests/test_job.py
@@ -10,6 +10,7 @@ Test the Message class
 import unittest
 import json
 import attr
+import copy
 
 from message.job import Message
 
@@ -21,22 +22,31 @@ class TestMessage(unittest.TestCase):
 
     def setUp(self):
         self.empty_msg = Message()
-        # Ensure the list below is up to date if member variables are added/removed/renamed
-        self.key_list = ['description', 'facility', 'run_number', 'instrument',
-                         'rb_number', 'started_by', 'file_path', 'overwrite',
-                         'run_version', 'job_id', 'reduction_script',
-                         'reduction_arguments', 'reduction_log', 'admin_log',
-                         'return_message', 'retry_in']
-        self.populated_msg = Message()
-        self.populated_msg.run_number = 11111
-        self.populated_msg.rb_number = 22222
-        self.populated_msg.description = 'test message'
+        self.empty_dict = {'description': None,
+                           'facility': None,
+                           'run_number': None,
+                           'instrument': None,
+                           'rb_number': None,
+                           'started_by': None,
+                           'file_path': None,
+                           'overwrite': None,
+                           'run_version': None,
+                           'job_id': None,
+                           'reduction_script': None,
+                           'reduction_arguments': None,
+                           'reduction_log': None,
+                           'admin_log': None,
+                           'return_message': None,
+                           'retry_in': None}
+        self.populated_msg = Message(run_number=11111, rb_number=22222, description='test message')
+        self.populated_dict = copy.deepcopy(self.empty_dict)
+        self.populated_dict['run_number'] = self.populated_msg.run_number
+        self.populated_dict['rb_number'] = self.populated_msg.rb_number
+        self.populated_dict['description'] = self.populated_msg.description
+        self.populated_keys = ['run_number', 'rb_number', 'description']
 
     def test_init(self):
-        """
-        Test all the member variables are created and we do not call
-        un-serialise if no object is provided
-        """
+        """ Test all the member variables are created """
         self.assertIsNone(self.empty_msg.description)
         self.assertIsNone(self.empty_msg.facility)
         self.assertIsNone(self.empty_msg.run_number)
@@ -54,32 +64,57 @@ class TestMessage(unittest.TestCase):
         self.assertIsNone(self.empty_msg.return_message)
         self.assertIsNone(self.empty_msg.retry_in)
 
-    def test_to_dict(self):
-        """
-        Test the class can be correctly converted to a dictionary
-        """
-        actual = attr.asdict(self.empty_msg)
-        for key, value in actual.items():
-            self.assertIn(key, self.key_list)
-            self.assertIsNone(value)
+    def test_to_dict_populated(self):
+        """ Converted to a dictionary when attribute values set """
+        actual = attr.asdict(self.populated_msg)
+        self.assertEqual(actual, self.populated_dict)
 
-    def test_serialise(self):
-        """
-        Test the class can be serialised and retain the variables values
-        """
-        serialised = self.empty_msg.serialise()
-        actual = json.loads(serialised)
-        for key, value in actual.items():
-            self.assertIn(key, self.key_list)
-            self.assertIsNone(value)
+    def test_serialize_populated(self):
+        """ Serialized and retain the attributes values """
+        serialized = self.populated_msg.serialize()
+        actual = json.loads(serialized)
+        self.assertEqual(actual, self.populated_dict)
 
-    def test_un_serialise_overwrite_true(self):
-        """
-        Test the class can be populated with a serialised object
-        """
-        serialised = self.populated_msg.serialise()
+    def test_deserialize_populated(self):
+        """ Produce a deserialized object correctly for a populated serialized object """
+        serialized = self.populated_msg.serialize()
+        actual = self.populated_msg.deserialize(serialized)
+        self.assertEqual(actual, self.populated_dict)
+
+    def test_populate_from_dict_overwrite_true(self):
+        """ Overwritten from a dictionary values"""
         actual = self.empty_msg
-        actual.un_serialise(serialised)
-        self.assertEqual(actual.run_number, self.populated_msg.run_number)
+        actual.populate(self.populated_dict, overwrite=True)
+        self.assertEqual(attr.asdict(actual), self.populated_dict)
+
+    def test_populate_from_dict_overwrite_false(self):
+        """ Do not overwrite from dictionary """
+        self.populated_dict['job_id'] = 123
+        self.populated_dict['rb_number'] = 33333
+        actual = copy.deepcopy(self.populated_msg)
+        actual.populate(self.populated_dict, overwrite=False)
         self.assertEqual(actual.rb_number, self.populated_msg.rb_number)
-        self.assertEqual(actual.description, self.populated_msg.description)
+        self.assertEqual(actual.job_id, 123)
+
+    def test_populate_from_serialized_overwrite_true(self):
+        """ Overwrite with a serialized object """
+        serialized = self.populated_msg.serialize()
+        actual = self.empty_msg
+        actual.populate(source=serialized, overwrite=True)
+        self.assertEqual(attr.asdict(actual), self.populated_dict)
+
+    def test_populate_from_serialized_overwrite_false(self):
+        """ Do not overwrite from a serialized object """
+        new_msg = copy.deepcopy(self.populated_msg)
+        new_msg.job_id = 123
+        new_msg.rb_number = 33333
+        serialized = new_msg.serialize()
+        actual = copy.deepcopy(self.populated_msg)
+        actual.populate(source=serialized, overwrite=False)
+        self.assertEqual(actual.rb_number, self.populated_msg.rb_number)
+        self.assertEqual(actual.job_id, 123)
+
+    def test_invalid_serialized(self):
+        """ Test raise exception for invalid serialized object """
+        serialized = 'test'
+        self.assertRaises(ValueError, self.empty_msg.populate, serialized)

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,8 @@ from build.commands.migrate_settings import MigrateTestSettings
 from build.commands.start import Start
 
 
-setup_requires = ['dash',
+setup_requires = ['attrs',
+                  'dash',
                   'dash_html_components',
                   'dash_core_components',
                   'docker',


### PR DESCRIPTION
### Summary of work
Added a class that can handle the containment of an AMQ message and act as a wrapper to the meta data stored within. The class can also be serialised and un-serialised (whcich must be done before sending.

### How to test your work
* Code review
* Assess quality of unit tests

### Additional comments
Note: this is not current implemented in the places it will be used in the code base. This is ONLY a review of the containing class for AMQ messages. Integration will be done in a  separate PR and most likely done one area at a time.

Fixes #507 


**Before merging ensure the release notes have been updated**