### PR TITLE
Standardise test-docstrings to 'Test/When' for Plotting

### DIFF
--- a/plotting/plot_meta_language/tests/test_interpreter.py
+++ b/plotting/plot_meta_language/tests/test_interpreter.py
@@ -35,35 +35,48 @@ class TestInterpreter(unittest.TestCase):
         return inter
 
     def test_valid_figure_dict(self):
-        """ Test the interpret method outputs the inner dictionary when given
-        a dictionary exclusively containing a key="figure" entry """
+        """
+        Test: interpret() outputs the dictionary value of the "figure" key
+        When: The method is given a dictionary containing a key="figure" entry
+        """
         inter = self.create_interpreter_with_mocked_read(self.valid_figure_dict)
         output = inter.interpret("")
         self.assertEqual(output, self.valid_figure_dict["figure"])
 
     def test_valid_dict(self):
-        """ Test the interpret method outputs the same (valid) dictionary that is read """
+        """
+        Test: interpret() outputs the same (valid) dictionary that is read
+        When: The method is given a dictionary which does NOT exclusively contain a key="figure" entry
+        """
         inter = self.create_interpreter_with_mocked_read(self.valid_minimal_dict)
         output = inter.interpret("")
         self.assertEqual(output, self.valid_minimal_dict)
 
     def test_invalid_input(self):
-        """ Test the interpret method raises an error if the data provided is not a dictionary """
+        """
+        Test: interpret() raises an error
+        When: The argument provided is not a dictionary
+        """
         inter = self.create_interpreter_with_mocked_read(self.invalid_text)
         with self.assertRaises(RuntimeError):
             inter.interpret("")
 
     @patch('yaml.full_load')
     def test_invalid_file_location(self, mocked_load):
-        """ Test the read method raises an error
-        if the plot type file location does not point to a file """
+        """
+        Test: read() raises an error
+        When: The plot-type file location does not point to a file
+        """
         inter = Interpreter()
         mocked_load.side_effect = FileNotFoundError
         with self.assertRaises(RuntimeError):
             inter.read("")
 
     def test_empty_input(self):
-        """ Test the interpret method raises an error if the plot type file is empty """
+        """
+        Test: interpret() raises an error
+        When: The plot-type file is empty
+        """
         inter = self.create_interpreter_with_mocked_read("")
         with self.assertRaises(RuntimeError):
             inter.interpret("")

--- a/plotting/plot_meta_language/tests/test_interpreter.py
+++ b/plotting/plot_meta_language/tests/test_interpreter.py
@@ -46,7 +46,8 @@ class TestInterpreter(unittest.TestCase):
     def test_valid_dict(self):
         """
         Test: interpret() outputs the same (valid) dictionary that is read
-        When: The method is given a dictionary which does NOT exclusively contain a key="figure" entry
+        When: The method is given a dictionary which does NOT
+        exclusively contain a key="figure" entry
         """
         inter = self.create_interpreter_with_mocked_read(self.valid_minimal_dict)
         output = inter.interpret("")

--- a/plotting/tests/test_prepare_data.py
+++ b/plotting/tests/test_prepare_data.py
@@ -36,14 +36,19 @@ class TestPrepareData(unittest.TestCase):
         os.remove(self.test_file_name)
 
     def test_default_init(self):
-        """ Test initialisation values are set """
+        """
+        Test: Class variables are created and set
+        When: PrepareData is initialised
+        """
         prep = PrepareData()
         self.assertIsNotNone(prep.expected_first_row)
         self.assertIsNotNone(prep.columns)
 
     def test_invalid_first_row(self):
-        """ Test _check_first_row raises a RuntimeError if the given data
-         does not match the expected_first_row """
+        """
+        Test: _check_first_row() raises a RuntimeError
+        When: The argument given does not match PrepareData.expected_first_row
+        """
         prep = PrepareData()
         valid_string = "0"
         prep.expected_first_row = valid_string
@@ -52,23 +57,29 @@ class TestPrepareData(unittest.TestCase):
             prep._check_first_row(invalid_first_row)
 
     def test_valid_first_row(self):
-        """ Test _check_first_row removes appended whitespace
-        and returns True if it matches expected_first_row """
+        """
+        Test: _check_first_row() returns True
+        When: The argument given matches PrepareData.expected_first_row,
+        despite the argument containing additional appended whitespace.
+        """
         prep = PrepareData()
         prep.expected_first_row = self.valid_first_row
         first_row = self.valid_data.split("\n")[0]
         self.assertTrue(prep._check_first_row(first_row))
 
     def test_invalid_second_row(self):
-        """ Test _check_second_row raises a RuntimeError if the given data
-        cannot be cast to an integer """
+        """
+        Test: _check_second_row() raises a RuntimeError
+        When : The argument given cannot be cast to an integer
+        """
         prep = PrepareData()
         with self.assertRaises(RuntimeError):
             prep._check_second_row("invalid")
 
     def test_valid_second_row(self):
-        """ Test _check_second_row returns a the given data as an integer
-        when the given data can be cast as such """
+        """
+        Test: _check_second_row() returns the argument given as an integer type
+        When: The argument given is a string representation of an integer """
         prep = PrepareData()
         second_row = self.valid_data.split("\n")[1]
         expected_return = int(second_row)
@@ -76,7 +87,10 @@ class TestPrepareData(unittest.TestCase):
                          expected_return)
 
     def test_invalid_path(self):
-        """ Test a FileNotFoundError is raised if an invalid path is given """
+        """
+        Test: prepare_data raises a FileNotFoundError
+        When: An invalid path is given
+        """
         prep = PrepareData()
         with self.assertRaises(FileNotFoundError):
             prep.prepare_data("invalid_path")
@@ -84,9 +98,11 @@ class TestPrepareData(unittest.TestCase):
     @patch('plotting.prepare_data.PrepareData._check_second_row')
     @patch('plotting.prepare_data.PrepareData._check_first_row', return_value=True)
     def test_valid_path(self, mocked_check_first_row, mocked_check_second_row):
-        """ Test that where a valid path is given, prepare_data validates the
-        full first and second rows, and returns a panda.DataFrame of the same
-        length as the input (minus the first two rows) """
+        """
+        Test: prepare_data() validates the first and second rows of the data pointed to,
+        and returns a panda.DataFrame 2 rows less than the data
+        When: A valid path to valid data is given
+        """
         split_data = self.valid_data.split("\n")
         first_row_with_newline = split_data[0] + "\n"
         second_row_with_newline = split_data[1] + "\n"

--- a/plotting/tests/test_prepare_data.py
+++ b/plotting/tests/test_prepare_data.py
@@ -79,7 +79,8 @@ class TestPrepareData(unittest.TestCase):
     def test_valid_second_row(self):
         """
         Test: _check_second_row() returns the argument given as an integer type
-        When: The argument given is a string representation of an integer """
+        When: The argument given is a string representation of an integer
+        """
         prep = PrepareData()
         second_row = self.valid_data.split("\n")[1]
         expected_return = int(second_row)


### PR DESCRIPTION
### Summary of work
Part of #514
- Docstrings within the test files of the Plotting directory standardised to meet the Test/When format

### How to test your work
- Review the updated docstring

**Before merging ensure the release notes have been updated**