### PR TITLE
Remove use of raw stomp in autoreduction_processor.py

### DIFF
--- a/queue_processors/autoreduction_processor/autoreduction_processor.py
+++ b/queue_processors/autoreduction_processor/autoreduction_processor.py
@@ -19,6 +19,7 @@ import stomp
 from queue_processors.autoreduction_processor.autoreduction_logging_setup import logger
 # pylint:disable=no-name-in-module,import-error
 from queue_processors.autoreduction_processor.settings import MISC, ACTIVEMQ
+from utils.clients.queue_client import QueueClient
 
 
 class Listener:
@@ -141,29 +142,33 @@ class Consumer:
         """
         Connect to ActiveMQ and listen to the queue for messages.
         """
-        brokers = [(ACTIVEMQ['brokers'].split(':')[0], int(ACTIVEMQ['brokers'].split(':')[1]))]
-        connection = stomp.Connection(host_and_ports=brokers, use_ssl=False)
-        connection.set_listener(self.consumer_name, Listener(connection))
-        logger.info("Starting ActiveMQ Connection to %s", ACTIVEMQ['brokers'])
-        logger.info("Completed ActiveMQ Connection")
-        connection.connect(ACTIVEMQ['amq_user'],
-                           ACTIVEMQ['amq_pwd'],
-                           wait=False,
-                           header={'activemq.prefetchSize': '1'})
-        for queue in ACTIVEMQ['amq_queues']:
-            connection.subscribe(destination=queue,
-                                 id='1',
-                                 ack='client-individual',
-                                 header={'activemq.prefetchSize': '1'})
-            logger.info("[%s] Subscribing to %s", self.consumer_name, queue)
-        logger.info("Successfully subscribed to all of the queues")
+        # brokers = [(ACTIVEMQ['brokers'].split(':')[0], int(ACTIVEMQ['brokers'].split(':')[1]))]
+        # connection = stomp.Connection(host_and_ports=brokers, use_ssl=False)
+        # connection.set_listener(self.consumer_name, Listener(connection))
+        # logger.info("Starting ActiveMQ Connection to %s", ACTIVEMQ['brokers'])
+        # logger.info("Completed ActiveMQ Connection")
+        # connection.connect(ACTIVEMQ['amq_user'],
+        #                    ACTIVEMQ['amq_pwd'],
+        #                    wait=False,
+        #                    header={'activemq.prefetchSize': '1'})
+        # for queue in ACTIVEMQ['amq_queues']:
+        #     connection.subscribe(destination=queue,
+        #                          id='1',
+        #                          ack='client-individual',
+        #                          header={'activemq.prefetchSize': '1'})
+        #     logger.info("[%s] Subscribing to %s", self.consumer_name, queue)
+        # logger.info("Successfully subscribed to all of the queues")
 
-        # activemq_client = QueueClient()
-        # activemq_client.connect()
+        activemq_client = QueueClient()
+        connection = activemq_client.connect()
 
         # Create event listener
-        # listener = Listener(activemq_client)
-        # activemq_client.subscribe_amq(self.consumer_name, listener, ack='client-individual')
+        listener = Listener(connection)
+        connection.set_listener('Autoreduction', listener)
+        connection.subscribe(destination='/queue/ReductionPending',
+                             id='1',
+                             ack='client-individual',
+                             header={'activemq.prefetchSize': '1'})
 
 
 def main():  # pragma: no cover

--- a/queue_processors/autoreduction_processor/autoreduction_processor.py
+++ b/queue_processors/autoreduction_processor/autoreduction_processor.py
@@ -14,11 +14,9 @@ import sys
 
 from twisted.internet import reactor
 
-import stomp
-
 from queue_processors.autoreduction_processor.autoreduction_logging_setup import logger
 # pylint:disable=no-name-in-module,import-error
-from queue_processors.autoreduction_processor.settings import MISC, ACTIVEMQ
+from queue_processors.autoreduction_processor.settings import MISC
 from utils.clients.queue_client import QueueClient
 
 
@@ -138,27 +136,12 @@ class Consumer:
         """ Initialise consumer. """
         self.consumer_name = "queueProcessor"
 
-    def run(self):
+    @staticmethod
+    def run():
         """
-        Connect to ActiveMQ and listen to the queue for messages.
+        Connect to ActiveMQ via the QueueClient and listen to the
+        /ReductionPending queue for messages.
         """
-        # brokers = [(ACTIVEMQ['brokers'].split(':')[0], int(ACTIVEMQ['brokers'].split(':')[1]))]
-        # connection = stomp.Connection(host_and_ports=brokers, use_ssl=False)
-        # connection.set_listener(self.consumer_name, Listener(connection))
-        # logger.info("Starting ActiveMQ Connection to %s", ACTIVEMQ['brokers'])
-        # logger.info("Completed ActiveMQ Connection")
-        # connection.connect(ACTIVEMQ['amq_user'],
-        #                    ACTIVEMQ['amq_pwd'],
-        #                    wait=False,
-        #                    header={'activemq.prefetchSize': '1'})
-        # for queue in ACTIVEMQ['amq_queues']:
-        #     connection.subscribe(destination=queue,
-        #                          id='1',
-        #                          ack='client-individual',
-        #                          header={'activemq.prefetchSize': '1'})
-        #     logger.info("[%s] Subscribing to %s", self.consumer_name, queue)
-        # logger.info("Successfully subscribed to all of the queues")
-
         activemq_client = QueueClient()
         connection = activemq_client.connect()
 

--- a/queue_processors/autoreduction_processor/tests/test_autoreduction_processor.py
+++ b/queue_processors/autoreduction_processor/tests/test_autoreduction_processor.py
@@ -13,12 +13,12 @@ import json
 import os
 import sys
 
-from mock import patch, Mock, call
+from mock import patch, Mock
 
 from queue_processors.autoreduction_processor.autoreduction_processor import (Listener,
                                                                               Consumer,
                                                                               main)
-from queue_processors.autoreduction_processor.settings import MISC, ACTIVEMQ
+from queue_processors.autoreduction_processor.settings import MISC
 
 
 # pylint:disable=missing-docstring,too-many-arguments,no-self-use,protected-access
@@ -171,34 +171,23 @@ class TestAutoReductionProcessorConsumer(unittest.TestCase):
     def test_init(self):
         self.assertEqual(self.consumer.consumer_name, 'queueProcessor')
 
-    @patch('stomp.Connection.subscribe')
-    @patch('stomp.Connection.connect')
-    @patch('stomp.Connection.set_listener')
-    @patch('stomp.Connection.__init__', return_value=None)
-    def test_run(self, mock_connection, mock_set_listener,
-                 mock_connect, mock_subscribe):
+    @patch('utils.clients.queue_client.QueueClient.connect')
+    def test_run(self, mock_connect):
+        """
+        Test: That the QueueClient is connected and subscribed to the /ReductionPending queue
+        When: Consumer.run() is called
+        """
+        mock_connection = Mock()
+        mock_connect.return_value = mock_connection
         self.consumer.run()
-        init_args = {'host_and_ports': [(ACTIVEMQ['brokers'].split(':')[0],
-                                         int(ACTIVEMQ['brokers'].split(':')[1]))],
-                     'use_ssl': False}
-        mock_connection.assert_called_once_with(**init_args)
-        mock_set_listener.assert_called_once()
-        connect_args = {
-            'username': ACTIVEMQ['amq_user'],
-            'passcode': ACTIVEMQ['amq_pwd'],
-            'wait': False,
-            'header': {'activemq.prefetchSize': '1'}
-        }
-        mock_connect.assert_called_once_with(**connect_args)
-        subcription_calls = []
-        for queue in ACTIVEMQ['amq_queues']:
-            subscribe_args = {'destination': queue,
-                              'id': '1',
-                              'ack': 'client-individual',
-                              'header': {'activemq.prefetchSize': '1'}
-                             }
-            subcription_calls.append(call(**subscribe_args))
-        mock_subscribe.assert_has_calls(subcription_calls)
+        mock_connect.assert_called_once()
+        mock_connection.set_listener.assert_called_once()
+        subscribe_args = {'destination': '/queue/ReductionPending',
+                          'id': '1',
+                          'ack': 'client-individual',
+                          'header': {'activemq.prefetchSize': '1'}
+                         }
+        mock_connection.subscribe.assert_called_once_with(**subscribe_args)
 
 
 if os.name != 'nt':  # pragma: no cover

--- a/queue_processors/autoreduction_processor/tests/test_autoreduction_processor.py
+++ b/queue_processors/autoreduction_processor/tests/test_autoreduction_processor.py
@@ -183,11 +183,13 @@ class TestAutoReductionProcessorConsumer(unittest.TestCase):
                      'use_ssl': False}
         mock_connection.assert_called_once_with(**init_args)
         mock_set_listener.assert_called_once()
-        connect_args = {'wait': False,
-                        'header': {'activemq.prefetchSize': '1'}}
-        mock_connect.assert_called_once_with(ACTIVEMQ['amq_user'],
-                                             ACTIVEMQ['amq_pwd'],
-                                             **connect_args)
+        connect_args = {
+            'username': ACTIVEMQ['amq_user'],
+            'passcode': ACTIVEMQ['amq_pwd'],
+            'wait': False,
+            'header': {'activemq.prefetchSize': '1'}
+        }
+        mock_connect.assert_called_once_with(**connect_args)
         subcription_calls = []
         for queue in ACTIVEMQ['amq_queues']:
             subscribe_args = {'destination': queue,


### PR DESCRIPTION
### Summary of work
* Changed the AMQ subscription in the autoreduction_processor to be done via the QueueClient. 

### How to test your work
* Perform a manual submission on the development environment (this code is currently on there but might be worth checking before you do this).
* Ensure that the job does not get stuck in the queued state.

### Additional comments
* Before merging I might look into cleaning this up a little. There is currently functionality in the QueueClient for subscription but I wasn't able to get this to work initially in this code. As such I will look into if I can get it to work or remove it. 

EDIT: Will wait till I have done the rest of the stomp removing until I make any decisions about this.

Part of #517 


**Before merging ensure the release notes have been updated**