### PR TITLE
Identify instances of AMQ interaction

### DIFF
--- a/WebApp/autoreduce_webapp/autoreduce_webapp/queue_processor.py
+++ b/WebApp/autoreduce_webapp/autoreduce_webapp/queue_processor.py
@@ -14,7 +14,7 @@ import logging
 import logging.config
 
 import django
-import stomp
+import stomp    # <stomp>
 
 # The below is a template on the repository
 # pylint: disable=relative-import
@@ -53,7 +53,7 @@ class Client(object):
         """
         LOGGER.info("[%s] Connecting to %s", self._consumer_name, str(self._brokers))
 
-        connection = stomp.Connection(host_and_ports=self._brokers,     # <AMQ[S] 3 - NO TEST>
+        connection = stomp.Connection(host_and_ports=self._brokers,
                                       use_ssl=self._use_ssl, ssl_version=3)
         connection.connect(self._user, self._password, wait=False)
 

--- a/WebApp/autoreduce_webapp/autoreduce_webapp/queue_processor.py
+++ b/WebApp/autoreduce_webapp/autoreduce_webapp/queue_processor.py
@@ -53,7 +53,7 @@ class Client(object):
         """
         LOGGER.info("[%s] Connecting to %s", self._consumer_name, str(self._brokers))
 
-        connection = stomp.Connection(host_and_ports=self._brokers,     # <AMQ[S] 3>
+        connection = stomp.Connection(host_and_ports=self._brokers,     # <AMQ[S] 3 - NO TEST>
                                       use_ssl=self._use_ssl, ssl_version=3)
         connection.connect(self._user, self._password, wait=False)
 

--- a/WebApp/autoreduce_webapp/autoreduce_webapp/queue_processor.py
+++ b/WebApp/autoreduce_webapp/autoreduce_webapp/queue_processor.py
@@ -53,7 +53,7 @@ class Client(object):
         """
         LOGGER.info("[%s] Connecting to %s", self._consumer_name, str(self._brokers))
 
-        connection = stomp.Connection(host_and_ports=self._brokers,
+        connection = stomp.Connection(host_and_ports=self._brokers,     # <AMQ[S] 3>
                                       use_ssl=self._use_ssl, ssl_version=3)
         connection.connect(self._user, self._password, wait=False)
 

--- a/WebApp/autoreduce_webapp/reduction_variables/utils.py
+++ b/WebApp/autoreduce_webapp/reduction_variables/utils.py
@@ -680,5 +680,5 @@ class MessagingUtils(object):
                                         False, ACTIVEMQ['SSL'])
         message_client.connect()
         message_client.send('/queue/ReductionPending', json.dumps(data_dict),
-                            priority='0', delay=delay)  # <AMQ[QC] 1>
+                            priority='0', delay=delay)  # <AMQ[QC] 1 - NO TEST>
         message_client.stop()

--- a/WebApp/autoreduce_webapp/reduction_variables/utils.py
+++ b/WebApp/autoreduce_webapp/reduction_variables/utils.py
@@ -680,5 +680,5 @@ class MessagingUtils(object):
                                         False, ACTIVEMQ['SSL'])
         message_client.connect()
         message_client.send('/queue/ReductionPending', json.dumps(data_dict),
-                            priority='0', delay=delay)  # <AMQ[QC] 1 - NO TEST>
+                            priority='0', delay=delay)  # <AMQ[C] 1 - NO TEST (!)Note: This uses a different QC>
         message_client.stop()

--- a/WebApp/autoreduce_webapp/reduction_variables/utils.py
+++ b/WebApp/autoreduce_webapp/reduction_variables/utils.py
@@ -680,5 +680,5 @@ class MessagingUtils(object):
                                         False, ACTIVEMQ['SSL'])
         message_client.connect()
         message_client.send('/queue/ReductionPending', json.dumps(data_dict),
-                            priority='0', delay=delay)
+                            priority='0', delay=delay)  # <AMQ[QC] 1>
         message_client.stop()

--- a/monitors/run_detection.py
+++ b/monitors/run_detection.py
@@ -144,7 +144,7 @@ class InstrumentMonitor:
                 rb_number = summary_rb_number
             EORM_LOG.info("Submitting '%s' with RB number '%s'", file_name, rb_number)
             data_dict = self.build_dict(rb_number, run_number, file_path)
-            self.client.send('/queue/DataReady', json.dumps(data_dict), priority='9')  # <AMQ[QC] 2>
+            self.client.send('/queue/DataReady', json.dumps(data_dict), priority='9')  # <AMQ[QC] 2 - TESTED>
         else:
             raise FileNotFoundError("File does not exist '{}'".format(file_path))
 

--- a/monitors/run_detection.py
+++ b/monitors/run_detection.py
@@ -144,7 +144,7 @@ class InstrumentMonitor:
                 rb_number = summary_rb_number
             EORM_LOG.info("Submitting '%s' with RB number '%s'", file_name, rb_number)
             data_dict = self.build_dict(rb_number, run_number, file_path)
-            self.client.send('/queue/DataReady', json.dumps(data_dict), priority='9')
+            self.client.send('/queue/DataReady', json.dumps(data_dict), priority='9')  # <AMQ[QC] 2>
         else:
             raise FileNotFoundError("File does not exist '{}'".format(file_path))
 

--- a/monitors/tests/test_run_detection.py
+++ b/monitors/tests/test_run_detection.py
@@ -61,7 +61,7 @@ NXLOAD_MOCK_EMPTY.items = Mock(return_value=[('raw_data_1', DataHolder(['']))])
 
 
 # pylint:disable=missing-docstring,no-self-use,too-many-public-methods
-class TestRunDetection(unittest.TestCase):    # <AMQ[QC] 3 - Several tests for (AMQ 2)>
+class TestRunDetection(unittest.TestCase):    # <AMQ[QC] 3 - QC *mocked* rather than used for several (AMQ[QC] 2) tests >>
     def tearDown(self):
         if os.path.isfile('test_lastrun.txt'):
             os.remove('test_lastrun.txt')

--- a/monitors/tests/test_run_detection.py
+++ b/monitors/tests/test_run_detection.py
@@ -61,7 +61,7 @@ NXLOAD_MOCK_EMPTY.items = Mock(return_value=[('raw_data_1', DataHolder(['']))])
 
 
 # pylint:disable=missing-docstring,no-self-use,too-many-public-methods
-class TestRunDetection(unittest.TestCase):
+class TestRunDetection(unittest.TestCase):    # <AMQ[QC] 3 - Several tests for (AMQ 1)>
     def tearDown(self):
         if os.path.isfile('test_lastrun.txt'):
             os.remove('test_lastrun.txt')

--- a/monitors/tests/test_run_detection.py
+++ b/monitors/tests/test_run_detection.py
@@ -61,7 +61,7 @@ NXLOAD_MOCK_EMPTY.items = Mock(return_value=[('raw_data_1', DataHolder(['']))])
 
 
 # pylint:disable=missing-docstring,no-self-use,too-many-public-methods
-class TestRunDetection(unittest.TestCase):    # <AMQ[QC] 3 - Several tests for (AMQ 1)>
+class TestRunDetection(unittest.TestCase):    # <AMQ[QC] 3 - Several tests for (AMQ 2)>
     def tearDown(self):
         if os.path.isfile('test_lastrun.txt'):
             os.remove('test_lastrun.txt')

--- a/queue_processors/autoreduction_processor/autoreduction_logging_setup.py
+++ b/queue_processors/autoreduction_processor/autoreduction_logging_setup.py
@@ -21,4 +21,4 @@ formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(messag
 handler.setFormatter(formatter)
 logger.addHandler(handler)
 # Quiet the Stomp logs as they are quite chatty
-logging.getLogger('stomp').setLevel(logging.INFO)
+logging.getLogger('stomp').setLevel(logging.INFO)    # <stomp>

--- a/queue_processors/autoreduction_processor/autoreduction_processor.py
+++ b/queue_processors/autoreduction_processor/autoreduction_processor.py
@@ -14,7 +14,7 @@ import sys
 
 from twisted.internet import reactor
 
-import stomp
+import stomp    # <stomp>
 
 from queue_processors.autoreduction_processor.autoreduction_logging_setup import logger
 # pylint:disable=no-name-in-module,import-error
@@ -142,7 +142,7 @@ class Consumer:
         Connect to ActiveMQ and listen to the queue for messages.
         """
         brokers = [(ACTIVEMQ['brokers'].split(':')[0], int(ACTIVEMQ['brokers'].split(':')[1]))]
-        connection = stomp.Connection(host_and_ports=brokers, use_ssl=False)    # <AMQ[S] 1 - TESTED>
+        connection = stomp.Connection(host_and_ports=brokers, use_ssl=False)
         connection.set_listener(self.consumer_name, Listener(connection))
         logger.info("Starting ActiveMQ Connection to %s", ACTIVEMQ['brokers'])
         logger.info("Completed ActiveMQ Connection")

--- a/queue_processors/autoreduction_processor/autoreduction_processor.py
+++ b/queue_processors/autoreduction_processor/autoreduction_processor.py
@@ -142,7 +142,7 @@ class Consumer:
         Connect to ActiveMQ and listen to the queue for messages.
         """
         brokers = [(ACTIVEMQ['brokers'].split(':')[0], int(ACTIVEMQ['brokers'].split(':')[1]))]
-        connection = stomp.Connection(host_and_ports=brokers, use_ssl=False)    # <AMQ[S] 1>
+        connection = stomp.Connection(host_and_ports=brokers, use_ssl=False)    # <AMQ[S] 1 - TESTED>
         connection.set_listener(self.consumer_name, Listener(connection))
         logger.info("Starting ActiveMQ Connection to %s", ACTIVEMQ['brokers'])
         logger.info("Completed ActiveMQ Connection")

--- a/queue_processors/autoreduction_processor/autoreduction_processor.py
+++ b/queue_processors/autoreduction_processor/autoreduction_processor.py
@@ -142,7 +142,7 @@ class Consumer:
         Connect to ActiveMQ and listen to the queue for messages.
         """
         brokers = [(ACTIVEMQ['brokers'].split(':')[0], int(ACTIVEMQ['brokers'].split(':')[1]))]
-        connection = stomp.Connection(host_and_ports=brokers, use_ssl=False)
+        connection = stomp.Connection(host_and_ports=brokers, use_ssl=False)    # <AMQ[S] 1>
         connection.set_listener(self.consumer_name, Listener(connection))
         logger.info("Starting ActiveMQ Connection to %s", ACTIVEMQ['brokers'])
         logger.info("Completed ActiveMQ Connection")

--- a/queue_processors/autoreduction_processor/post_process_admin.py
+++ b/queue_processors/autoreduction_processor/post_process_admin.py
@@ -492,7 +492,7 @@ def main():
     """ Main method. """
     brokers = []
     brokers.append((ACTIVEMQ['brokers'].split(':')[0], int(ACTIVEMQ['brokers'].split(':')[1])))
-    stomp_connection = stomp.Connection(host_and_ports=brokers, use_ssl=False)  # <AMQ[S] 2>
+    stomp_connection = stomp.Connection(host_and_ports=brokers, use_ssl=False)  # <AMQ[S] 2 - TESTED>
     json_data = None
     try:
         logger.info("PostProcessAdmin Connecting to ActiveMQ")
@@ -532,7 +532,7 @@ def main():
     except Exception as exp:
         logger.info("Something went wrong: %s", str(exp))
         try:
-            stomp_connection.send(ACTIVEMQ['postprocess_error'], json.dumps(json_data))     # <AMQ[QC] 4>
+            stomp_connection.send(ACTIVEMQ['postprocess_error'], json.dumps(json_data))     # <AMQ[QC] 4 - TESTED>
             logger.info("Called %s ---- %s", ACTIVEMQ['postprocess_error'], prettify(json_data))
         finally:
             sys.exit()

--- a/queue_processors/autoreduction_processor/post_process_admin.py
+++ b/queue_processors/autoreduction_processor/post_process_admin.py
@@ -30,7 +30,7 @@ import importlib.util as imp
 
 from sentry_sdk import init
 
-import stomp
+import stomp    # <stomp>
 # pylint:disable=no-name-in-module,import-error
 from queue_processors.autoreduction_processor.settings import ACTIVEMQ, MISC
 from queue_processors.autoreduction_processor.autoreduction_logging_setup import logger
@@ -492,7 +492,7 @@ def main():
     """ Main method. """
     brokers = []
     brokers.append((ACTIVEMQ['brokers'].split(':')[0], int(ACTIVEMQ['brokers'].split(':')[1])))
-    stomp_connection = stomp.Connection(host_and_ports=brokers, use_ssl=False)  # <AMQ[S] 2 - TESTED>
+    stomp_connection = stomp.Connection(host_and_ports=brokers, use_ssl=False)
     json_data = None
     try:
         logger.info("PostProcessAdmin Connecting to ActiveMQ")

--- a/queue_processors/autoreduction_processor/post_process_admin.py
+++ b/queue_processors/autoreduction_processor/post_process_admin.py
@@ -492,7 +492,7 @@ def main():
     """ Main method. """
     brokers = []
     brokers.append((ACTIVEMQ['brokers'].split(':')[0], int(ACTIVEMQ['brokers'].split(':')[1])))
-    stomp_connection = stomp.Connection(host_and_ports=brokers, use_ssl=False)
+    stomp_connection = stomp.Connection(host_and_ports=brokers, use_ssl=False)  # <AMQ[S] 2>
     json_data = None
     try:
         logger.info("PostProcessAdmin Connecting to ActiveMQ")
@@ -532,7 +532,7 @@ def main():
     except Exception as exp:
         logger.info("Something went wrong: %s", str(exp))
         try:
-            stomp_connection.send(ACTIVEMQ['postprocess_error'], json.dumps(json_data))
+            stomp_connection.send(ACTIVEMQ['postprocess_error'], json.dumps(json_data))     # <AMQ[QC] 4>
             logger.info("Called %s ---- %s", ACTIVEMQ['postprocess_error'], prettify(json_data))
         finally:
             sys.exit()

--- a/queue_processors/autoreduction_processor/tests/test_autoreduction_processor.py
+++ b/queue_processors/autoreduction_processor/tests/test_autoreduction_processor.py
@@ -163,7 +163,7 @@ class TestAutoreductionProcessorListener(unittest.TestCase):
 
 
 # pylint:disable=missing-docstring
-class TestAutoReductionProcessorConsumer(unittest.TestCase):
+class TestAutoReductionProcessorConsumer(unittest.TestCase):    # <stomp>
 
     def setUp(self):
         self.consumer = Consumer()

--- a/queue_processors/autoreduction_processor/tests/test_post_process_admin.py
+++ b/queue_processors/autoreduction_processor/tests/test_post_process_admin.py
@@ -39,7 +39,7 @@ class TestPostProcessAdminHelpers(unittest.TestCase):
         self.assertEqual(actual, '/temp/data/some/more/path.nxs')
 
 
-class TestPostProcessAdmin(unittest.TestCase):    # <AMQ[QC] 5 - Several tests for (AMQ[QC] 4)>
+class TestPostProcessAdmin(unittest.TestCase):  # <stomp> <AMQ[QC] 5 - QC *mocked* rather than used for several (AMQ[QC] 4) tests >
 
     def setUp(self):
         self.data = {'data': '\\\\isis\\inst$\\data.nxs',

--- a/queue_processors/autoreduction_processor/tests/test_post_process_admin.py
+++ b/queue_processors/autoreduction_processor/tests/test_post_process_admin.py
@@ -39,7 +39,7 @@ class TestPostProcessAdminHelpers(unittest.TestCase):
         self.assertEqual(actual, '/temp/data/some/more/path.nxs')
 
 
-class TestPostProcessAdmin(unittest.TestCase):
+class TestPostProcessAdmin(unittest.TestCase):    # <AMQ[QC] 5 - Several tests for (AMQ[QC] 4)>
 
     def setUp(self):
         self.data = {'data': '\\\\isis\\inst$\\data.nxs',

--- a/queue_processors/queue_processor/queue_processor.py
+++ b/queue_processors/queue_processor/queue_processor.py
@@ -215,7 +215,7 @@ class Listener:
         if instrument.is_paused:
             logger.info("Run %s has been skipped", self._data_dict['run_number'])
         else:
-            self._client.send('/queue/ReductionPending', json.dumps(self._data_dict),      # <AMQ[QC] 6a>
+            self._client.send('/queue/ReductionPending', json.dumps(self._data_dict),      # <AMQ[QC] 6a - NO TEST>
                               priority=self._priority)
             logger.info("Run %s ready for reduction", self._data_dict['run_number'])
 
@@ -229,7 +229,7 @@ class Listener:
         self._data_dict['message'] = 'Reduction Skipped: {}. Assuming run number to be ' \
                                      'a calibration run.'.format(reason)
         skipped_queue = ACTIVEMQ_SETTINGS.reduction_skipped
-        self._client.send(skipped_queue, json.dumps(self._data_dict),   # <AMQ[QC] 6b>
+        self._client.send(skipped_queue, json.dumps(self._data_dict),   # <AMQ[QC] 6b - NO TEST>
                           priority=self._priority)
 
     def reduction_started(self):

--- a/queue_processors/queue_processor/queue_processor.py
+++ b/queue_processors/queue_processor/queue_processor.py
@@ -215,7 +215,7 @@ class Listener:
         if instrument.is_paused:
             logger.info("Run %s has been skipped", self._data_dict['run_number'])
         else:
-            self._client.send('/queue/ReductionPending', json.dumps(self._data_dict),
+            self._client.send('/queue/ReductionPending', json.dumps(self._data_dict),      # <AMQ[QC] 6a>
                               priority=self._priority)
             logger.info("Run %s ready for reduction", self._data_dict['run_number'])
 
@@ -229,7 +229,7 @@ class Listener:
         self._data_dict['message'] = 'Reduction Skipped: {}. Assuming run number to be ' \
                                      'a calibration run.'.format(reason)
         skipped_queue = ACTIVEMQ_SETTINGS.reduction_skipped
-        self._client.send(skipped_queue, json.dumps(self._data_dict),
+        self._client.send(skipped_queue, json.dumps(self._data_dict),   # <AMQ[QC] 6b>
                           priority=self._priority)
 
     def reduction_started(self):

--- a/queue_processors/queue_processor/queueproc_utils/messaging_utils.py
+++ b/queue_processors/queue_processor/queueproc_utils/messaging_utils.py
@@ -69,7 +69,7 @@ class MessagingUtils:
         # To prevent circular dependencies
         message_client = QueueClient()
         message_client.connect()
-        message_client.send('/queue/ReductionPending',  # <AMQ[QC] 7>
+        message_client.send('/queue/ReductionPending',  # <AMQ[QC] 7 - NO TEST>
                             json.dumps(data_dict),
                             priority='0',
                             delay=delay)

--- a/queue_processors/queue_processor/queueproc_utils/messaging_utils.py
+++ b/queue_processors/queue_processor/queueproc_utils/messaging_utils.py
@@ -69,7 +69,7 @@ class MessagingUtils:
         # To prevent circular dependencies
         message_client = QueueClient()
         message_client.connect()
-        message_client.send('/queue/ReductionPending',
+        message_client.send('/queue/ReductionPending',  # <AMQ[QC] 7>
                             json.dumps(data_dict),
                             priority='0',
                             delay=delay)

--- a/scripts/manual_operations/manual_submission.py
+++ b/scripts/manual_operations/manual_submission.py
@@ -34,7 +34,7 @@ def submit_run(active_mq_client, rb_number, instrument, data_file_location, run_
                                                 run_number=run_number,
                                                 started_by=-1)
 
-    active_mq_client.send('/queue/DataReady', json.dumps(data_dict), priority=1)
+    active_mq_client.send('/queue/DataReady', json.dumps(data_dict), priority=1)    # <AMQ[QC] 8>
     print("Submitted run: \r\n" + json.dumps(data_dict, indent=1))
 
 

--- a/scripts/manual_operations/manual_submission.py
+++ b/scripts/manual_operations/manual_submission.py
@@ -34,7 +34,7 @@ def submit_run(active_mq_client, rb_number, instrument, data_file_location, run_
                                                 run_number=run_number,
                                                 started_by=-1)
 
-    active_mq_client.send('/queue/DataReady', json.dumps(data_dict), priority=1)    # <AMQ[QC] 8>
+    active_mq_client.send('/queue/DataReady', json.dumps(data_dict), priority=1)    # <AMQ[QC] 8 - TESTED>
     print("Submitted run: \r\n" + json.dumps(data_dict, indent=1))
 
 

--- a/systemtests/test_end_to_end.py
+++ b/systemtests/test_end_to_end.py
@@ -81,7 +81,7 @@ if os.name != 'nt':
                                                                   run_number=self.run_number,
                                                                   started_by=0)
             self.queue_client.send('/queue/DataReady',
-                                   json.dumps(data_ready_message))  # <AMQ[QC] 9>
+                                   json.dumps(data_ready_message))  # <AMQ[QC] 9 - NO TEST>
 
             # Get Result from database
             results = self._find_run_in_database()

--- a/systemtests/test_end_to_end.py
+++ b/systemtests/test_end_to_end.py
@@ -81,7 +81,7 @@ if os.name != 'nt':
                                                                   run_number=self.run_number,
                                                                   started_by=0)
             self.queue_client.send('/queue/DataReady',
-                                   json.dumps(data_ready_message))
+                                   json.dumps(data_ready_message))  # <AMQ[QC] 9>
 
             # Get Result from database
             results = self._find_run_in_database()

--- a/utils/clients/queue_client.py
+++ b/utils/clients/queue_client.py
@@ -143,7 +143,7 @@ class QueueClient(AbstractClient):
         :param delay: time to wait before send
         """
         self.connect()
-        self._connection.send(destination, message,     # <AMQ[QC] 11>
+        self._connection.send(destination, message,     # <AMQ[QC] 11 - TESTED>
                               persistent=persistent,
                               priority=priority,
                               delay=delay)

--- a/utils/clients/queue_client.py
+++ b/utils/clients/queue_client.py
@@ -10,7 +10,7 @@ Client class for accessing queuing service
 import logging
 import time
 
-import stomp
+import stomp    # <stomp>
 from stomp.exception import ConnectFailedException
 
 from utils.clients.abstract_client import AbstractClient

--- a/utils/clients/queue_client.py
+++ b/utils/clients/queue_client.py
@@ -143,7 +143,7 @@ class QueueClient(AbstractClient):
         :param delay: time to wait before send
         """
         self.connect()
-        self._connection.send(destination, message,
+        self._connection.send(destination, message,     # <AMQ[QC] 11>
                               persistent=persistent,
                               priority=priority,
                               delay=delay)

--- a/utils/clients/tests/test_queue_client.py
+++ b/utils/clients/tests/test_queue_client.py
@@ -85,7 +85,7 @@ class TestQueueClient(unittest.TestCase):
     def test_send_data(self, mock_send):
         """ Test data can be sent without error """
         client = QueueClient()
-        client.send('dataready', 'test-message')
+        client.send('dataready', 'test-message')    # <AMQ[QC] 10 - but AMQ interaction patched over>
         mock_send.assert_called_once()
 
     @patch('stomp.connect.StompConnection11.ack')

--- a/utils/clients/tests/test_queue_client.py
+++ b/utils/clients/tests/test_queue_client.py
@@ -17,7 +17,7 @@ from utils.clients.settings.client_settings_factory import ClientSettingsFactory
 
 
 # pylint:disable=protected-access,invalid-name,missing-docstring
-class TestQueueClient(unittest.TestCase):
+class TestQueueClient(unittest.TestCase):    # <stomp>
     """
     Exercises the queue client
     """


### PR DESCRIPTION
# DO NOT MERGE please

### Summary of work
- Part of #512
- This issue _attempts_ to identify all interactions with ActiveMQ (AMQ).
- For each interaction, it labels whether it occurs via:
    1. QueueClient
    2. autoreduce_webapp.queue_processor.Client 
    3. Directly via stomp
- If via (1), it also labels whether the interaction is tested.
___

### Findings
#### 1) via `QueueClient`:
- run_detection
  * test_run_detection
- **queue_processor [NOT tested]**
- **messaging_utils [NOT tested]**
- manual_submission
  * test_manual_submission
- test_end_to_end _[NOT tested - ignore]_
- queue_client(self)
  * test_queue_client (self-tests)

#### 2) via `autoreduce_webapp.queue_processor.Client`:
- reduction_variables\utils

#### 3) `stomp` directly
- queue_client (ok)
  * test_queue_client (ok)
- **autoreduce_webapp\queue_processor**
- **autoreduction_processor**
  * **test_autoreduction_processor**
- autoreduction_logging_setup _(as a string)_
- **post_process_admin**
  * **test_post_process_admin**
___

### Next Steps (make new issues for each)

1. Tests should be made for the _'NOT tested'_ usages of QueueClient. - #520
2. The usage of (2) `autoreduce_webapp.queue_processor.Client` should be **replaced with** `QueueClient`.
3. All direct usages of `stomp` should be **replaced with** going via `QueueClient`. - #517


# DO NOT MERGE please