### PR TITLE
Standardise test-docstrings to 'Test/When' for Clients

### DIFF
--- a/utils/clients/tests/test_abstract_client.py
+++ b/utils/clients/tests/test_abstract_client.py
@@ -17,6 +17,10 @@ from utils.clients.settings.client_settings import ClientSettings
 class TestAbstractClient(unittest.TestCase):
 
     def test_client_settings_init(self):
+        """
+        Test: A client is created
+        When: A class which implements AbstractClient is initiated with a ClientSettings argument
+        """
         valid_settings = ClientSettings(username='user',
                                         password='pass',
                                         host='host',
@@ -25,6 +29,11 @@ class TestAbstractClient(unittest.TestCase):
         self.assertIsNotNone(interface)
 
     def test_derived_settings_init(self):
+        """
+        Test: A client is created
+        When: A class which implements AbstractClient is initiated with an argument that
+        extends ClientSettings
+        """
         # pylint:disable=too-few-public-methods
         class DerivedSettings(ClientSettings):
             pass

--- a/utils/clients/tests/test_cycle_ingestion_client.py
+++ b/utils/clients/tests/test_cycle_ingestion_client.py
@@ -53,44 +53,58 @@ class TestCycleIngestionClient(unittest.TestCase):
         return client
 
     def test_invalid_init(self):
-        """ Test initialisation raises TypeError when given invalid credentials """
+        """
+        Test: A TypeError is raised
+        When: CycleIngestionClient is initialised with invalid credentials
+        """
         with self.assertRaises(TypeError):
             CycleIngestionClient("invalid")
 
     def test_default_init(self):
-        """ Test initialisation values are set """
+        """
+        Test: Class variables are created and set
+        When: CycleIngestionClient is initialised with default credentials
+        """
         client = CycleIngestionClient()
         self.assertIsNone(client._uows_client)
         self.assertIsNone(client._scheduler_client)
         self.assertIsNone(client._session_id)
 
-    @patch('suds.client.Client.__init__')
-    def test_create_uows_client_with_valid_credentials(self, mocked_suds_client):
-        """ Test the User Office Web Service client is initialised with the uows_url """
-        mocked_suds_client.return_value = None  # Avoids Client.__init__() being called
+    @patch('suds.client.Client.__init__', return_value=None)
+    def test_create_uows_client_with_valid_credentials(self, mock_suds_client):
+        """
+        Test: The User Office Web Service (UOWS) client is initialised with credentials.uows_url
+        When: create_uows_client is called while a valid uows_url is held
+        """
         client = self.create_client()
         client.create_uows_client()
-        mocked_suds_client.assert_called_with(self.test_credentials.uows_url)
+        mock_suds_client.assert_called_with(self.test_credentials.uows_url)
 
     def test_create_uows_client_with_invalid_credentials(self):
-        """ Test a URLError is raised if the User Office Web Service client
-        is initialised with an invalid uows_url """
+        """
+        Test: A URLError is raised
+        When: create_uows_client is called while an invalid uows_url is held
+        """
         client = CycleIngestionClient()
         client.credentials.uows_url = "https://api.invalid.com/?wsdl"
         with self.assertRaises(URLError):
             client.create_uows_client()
 
-    @patch('suds.client.Client.__init__')
-    def test_create_scheduler_client_with_valid_credentials(self, mocked_suds_client):
-        """ Test the Scheduler client is initialised with the scheduler_url """
-        mocked_suds_client.return_value = None  # Avoids Client.__init__() being called
+    @patch('suds.client.Client.__init__', return_value=None)
+    def test_create_scheduler_client_with_valid_credentials(self, mock_suds_client):
+        """
+        Test: The Scheduler client is initialised with credentials.scheduler_url
+        When: create_scheduler_client is called while a valid scheduler_url is held
+        """
         client = self.create_client()
         client.create_scheduler_client()
-        mocked_suds_client.assert_called_with(self.test_credentials.scheduler_url)
+        mock_suds_client.assert_called_with(self.test_credentials.scheduler_url)
 
     def test_create_scheduler_client_with_invalid_credentials(self):
-        """ Test a URLError is raised if the Scheduler client
-        is initialised with an invalid scheduler_url """
+        """
+        Test: A URLError is raised
+        When: create_scheduler_client is called while an invalid scheduler_url is held
+        """
         client = CycleIngestionClient()
         client.credentials.scheduler_url = "https://api.invalid.com/?wsdl"
         with self.assertRaises(URLError):
@@ -98,7 +112,11 @@ class TestCycleIngestionClient(unittest.TestCase):
 
     def test_connect_with_valid_credentials(self):
         # pylint: disable=line-too-long
-        """ Test UOWS login with valid credentials populates _session_id  """
+        """
+        Test: The CycleIngestionClient connects to the UOWS Client using the
+        credentials held, and a valid session_id is stored
+        When: connect is called while a valid username and password is held
+        """
         client = self.create_client(["_uows_client", "_scheduler_client"])
         client._uows_client.service.login.return_value = self.valid_value
         client.connect()
@@ -108,7 +126,10 @@ class TestCycleIngestionClient(unittest.TestCase):
 
     def test_connect_with_invalid_credentials(self):
         # pylint: disable=line-too-long
-        """ Test UOWS login with invalid credentials raises a ConnectionException """
+        """
+        Test: A ConnectionException is raised
+        When: connect is called while an invalid username and password is held
+        """
         client = self.create_client(["_uows_client"])
         client._uows_client.service.login.side_effect = suds.WebFault(fault=None, document=None)
 
@@ -119,14 +140,20 @@ class TestCycleIngestionClient(unittest.TestCase):
 
     def test_disconnect(self):
         """ Test disconnection from a session sets _session_id = None"""
+        """
+        Test: _session_id is set to None
+        When: disconnect is called after a connection has been established
+        """
         client = self.create_client(["_uows_client", "_scheduler_client"])
         client.connect()
         client.disconnect()
         self.assertEqual(None, client._session_id)
 
     def test_test_connection_no_uows_client(self):
-        """ Test the connection test throws the TypeError: "invalid_uows_client"
-        When the _uows_client is invalid """
+        """
+        Test: The TypeError: "invalid_uows_client" is raised
+        When: test_connection is called with an invalid _uows_client
+        """
         client = self.create_client(["_uows_client", "_scheduler_client"])
         client.connect()
         client._uows_client = None
@@ -135,8 +162,10 @@ class TestCycleIngestionClient(unittest.TestCase):
             self.assertEqual(error, client._errors["invalid_uows_client"])
 
     def test_test_connection_no_scheduler_client(self):
-        """ Test the connection test throws the TypeError: "invalid_scheduler_client"
-        When the _scheduler_client is invalid """
+        """
+        Test: The TypeError: "invalid_scheduler_client" is raised
+        When: test_connection is called with an invalid _scheduler_client
+        """
         client = self.create_client(["_uows_client", "_scheduler_client"])
         client.connect()
         client._scheduler_client = None
@@ -146,8 +175,10 @@ class TestCycleIngestionClient(unittest.TestCase):
 
     def test_test_connection_no_invalid_session_id(self):
         # pylint: disable=line-too-long
-        """ Test the connection test throws the ConnectionException: "invalid_session_id"
-        When the _session_id is invalid """
+        """
+        Test: The ConnectionException: "invalid_session_id" is raised
+        When: test_connection is called with an invalid _session_id
+        """
         client = self.create_client(["_uows_client", "_scheduler_client"])
         client._scheduler_client.service.getFacilityList.side_effect = suds.WebFault(fault=None, document=None)
         client.connect()
@@ -158,8 +189,10 @@ class TestCycleIngestionClient(unittest.TestCase):
 
     def test_ingest_cycle_dates(self):
         # pylint: disable=line-too-long
-        """ Test the cycle ingestion returns the output received from the Scheduler Client
-        and uses the _session_id to do so"""
+        """
+        Test: _session_id is used to retrieve cycle-dates data from the _scheduler_client
+        When: ingest_cycle_dates is called while a valid _session_id is held
+        """
         client = self.create_client(["_uows_client", "_scheduler_client"])
         client.connect()
         client._scheduler_client.service.getCycles.return_value = self.valid_value
@@ -169,8 +202,10 @@ class TestCycleIngestionClient(unittest.TestCase):
 
     def test_ingest_maintenance_days(self):
         # pylint: disable=line-too-long
-        """ Test the maintenance-days ingestion returns the output received
-        from the Scheduler Client and uses the _session_id to do so"""
+        """
+        Test: _session_id is used to retrieve maintenance-day-dates data from the _scheduler_client
+        When: ingest_maintenance_days is called while a valid _session_id is held
+        """
         client = self.create_client(["_uows_client", "_scheduler_client"])
         client.connect()
         client._scheduler_client.service.getOfflinePeriods.return_value = self.valid_value

--- a/utils/clients/tests/test_cycle_ingestion_client.py
+++ b/utils/clients/tests/test_cycle_ingestion_client.py
@@ -139,7 +139,6 @@ class TestCycleIngestionClient(unittest.TestCase):
                                                              Password=self.test_credentials.password)
 
     def test_disconnect(self):
-        """ Test disconnection from a session sets _session_id = None"""
         """
         Test: _session_id is set to None
         When: disconnect is called after a connection has been established

--- a/utils/clients/tests/test_database_client.py
+++ b/utils/clients/tests/test_database_client.py
@@ -23,7 +23,6 @@ class TestDatabaseClient(unittest.TestCase):
     """
     Exercises the database client
     """
-
     def setUp(self):
         self.incorrect_credentials = ClientSettingsFactory().create('database',
                                                                     username='not-user-name',
@@ -33,7 +32,10 @@ class TestDatabaseClient(unittest.TestCase):
                                                                     database_name='not-db')
 
     def test_default_init(self):
-        """ Test default values for initialisation """
+        """
+        Test: Class variables are created and set
+        When: DatabaseClient is initialised with default credentials
+        """
         client = DatabaseClient()
         self.assertIsNotNone(client.credentials)
         self.assertIsNone(client._connection)
@@ -41,16 +43,27 @@ class TestDatabaseClient(unittest.TestCase):
         self.assertIsNone(client._engine)
 
     def test_invalid_init(self):
-        """ Test invalid values for initialisation """
+        """
+        Test: A TypeError is raised
+        When: DatabaseClient is initialised with invalid credentials
+        """
         self.assertRaises(TypeError, DatabaseClient, 'string')
 
     def test_valid_connection(self):
-        """ Test access is established with valid connection """
+        """
+        Test: Access is established with a valid connection
+        When: connect is called while valid credentials are held
+        """
         client = DatabaseClient()
         client.connect()
         self.assertTrue(client._test_connection())
 
     def test_get_connection(self):
+        """
+        Test: get_connection returns the a connect Session or None
+        (depending on whether connect has been called)
+        When: get_connection is called
+        """
         client = DatabaseClient()
         self.assertIsNone(client.get_connection())
         client.connect()
@@ -58,21 +71,30 @@ class TestDatabaseClient(unittest.TestCase):
 
     @patch('utils.clients.database_client.DatabaseClient._test_connection')
     def test_double_connect(self, mock_test_connection):
+        """
+        Test: The existing (rather than a new) connection is returned
+        When: connect is called while a valid connection is currently established
+        """
         client = DatabaseClient()
         connection_1 = client.connect()
         connection_2 = client.connect()
-        # Test that we do not attempt to reconnect if a valid connection is already established
         mock_test_connection.assert_called_once()
         self.assertEqual(connection_1, connection_2)
 
     def test_invalid_connection(self):
-        """ Test access is rejected with invalid credentials """
+        """
+        Test: A ConnectionException is raised
+        When: connect is called while invalid connection are held
+        """
         client = DatabaseClient(self.incorrect_credentials)
         with self.assertRaises(ConnectionException):
             client.connect()
 
     def test_stop_connection(self):
-        """ Test connection can be successfully stopped gracefully """
+        """
+        Test: Connection is stopped and connection variables are set to None
+        When: disconnect is called while a valid connection is currently established
+        """
         client = DatabaseClient()
         client.connect()
         self.assertTrue(client._test_connection())
@@ -80,9 +102,11 @@ class TestDatabaseClient(unittest.TestCase):
         self.assertIsNone(client._connection)
         self.assertIsNone(client._engine)
         self.assertIsNone(client._meta_data)
+        self.assertRaises(AttributeError, client._test_connection)
 
     @patch('sqlalchemy.engine.result.ResultProxy.fetchall')
     def test_re_raise_unexpected_exception(self, mock_execute):
+        # NOTE: Question - what is being tested here?
         client = DatabaseClient()
         client.connect()
 
@@ -92,6 +116,10 @@ class TestDatabaseClient(unittest.TestCase):
         self.assertRaises(RuntimeError, client._test_connection)
 
     def test_instrument_table(self):
+        """
+        Test: An Instrument object is created and returned with a Table object stored within
+        When: instrument is called
+        """
         client = DatabaseClient()
         client.connect()
         instrument_table = client.instrument()
@@ -99,6 +127,10 @@ class TestDatabaseClient(unittest.TestCase):
         self.assertIsNotNone(instrument_table.__table__)
 
     def test_reduction_run_table(self):
+        """
+        Test: A ReductionRun object is created and returned with a Table object stored within
+        When: reduction_run is called
+        """
         client = DatabaseClient()
         client.connect()
         reduction_run_table = client.reduction_run()

--- a/utils/clients/tests/test_database_client.py
+++ b/utils/clients/tests/test_database_client.py
@@ -106,7 +106,11 @@ class TestDatabaseClient(unittest.TestCase):
 
     @patch('sqlalchemy.engine.result.ResultProxy.fetchall')
     def test_re_raise_unexpected_exception(self, mock_execute):
-        # NOTE: Question - what is being tested here?
+        """
+        Test: _test_connection re-raises an exception 'as is'
+        When: The connection raises an exception that is not a connection related error
+        (which is handled as a special case)
+        """
         client = DatabaseClient()
         client.connect()
 

--- a/utils/clients/tests/test_icat_client.py
+++ b/utils/clients/tests/test_icat_client.py
@@ -30,6 +30,10 @@ class TestICATClient(unittest.TestCase):
 
     @patch('icat.Client.__init__', return_value=None)
     def test_default_init(self, mock_icat,):
+        """
+        Test: Class variables are created and set
+        When: ICATClient is initialised with default credentials
+        """
         client = ICATClient()
         self.assertEqual(client.credentials.username, 'YOUR-ICAT-USERNAME')
         self.assertEqual(client.credentials.password, 'YOUR-PASSWORD')
@@ -41,15 +45,22 @@ class TestICATClient(unittest.TestCase):
     @patch('icat.Client.__init__', return_value=None)
     @patch('icat.Client.login')
     def test_valid_connection(self, mock_icat_login, mock_icat):
+        """
+        Test: login is called on the stored client
+        When: connect is called while valid credentials are held
+        """
         client = ICATClient()
         mock_icat.assert_called_once()
         client.connect()
-        mock_icat_login.assert_called_once()
         mock_icat_login.assert_called_once_with(auth='simple',
                                                 credentials={'username': 'YOUR-ICAT-USERNAME',
                                                              'password': 'YOUR-PASSWORD'})
 
     def test_invalid_connection(self):
+        """
+        Test: A ValueError is raised
+        When: connect is called while invalid credentials are held
+        """
         invalid_settings = ClientSettingsFactory().create('icat',
                                                           username='user',
                                                           password='pass',
@@ -61,6 +72,10 @@ class TestICATClient(unittest.TestCase):
     @patch('icat.Client.__init__', return_value=None)
     @patch('icat.Client.logout')
     def test_disconnect(self, mock_logout, _):
+        """
+        Test: logout is called on the stored client
+        When: disconnect is called
+        """
         client = ICATClient()
         client.disconnect()
         mock_logout.assert_called_once()
@@ -68,6 +83,10 @@ class TestICATClient(unittest.TestCase):
     @patch('icat.Client.__init__', return_value=None)
     @patch('icat.Client.refresh')
     def test_refresh(self, mock_autorefresh, _):
+        """
+        Test: refresh is called on the stored client
+        When: refresh is called
+        """
         client = ICATClient()
         client.refresh()
         mock_autorefresh.assert_called_once()
@@ -75,6 +94,10 @@ class TestICATClient(unittest.TestCase):
     @patch('icat.Client.__init__', return_value=None)
     @patch('icat.Client.refresh')
     def test_valid_test_connection(self, mock_refresh, _):
+        """
+        Test: refresh is called on the stored client
+        When: _test_connection is called
+        """
         client = ICATClient()
         # pylint:disable=protected-access
         self.assertTrue(client._test_connection())
@@ -83,6 +106,10 @@ class TestICATClient(unittest.TestCase):
     @patch('icat.Client.__init__', return_value=None)
     @patch('icat.Client.refresh')
     def test_failing_test_connection(self, mock_refresh, _):
+        """
+        Test: A ConnectionException is raised
+        When: _test_connection is called while an invalid connection is held
+        """
         mock_refresh.side_effect = raise_icat_session_error
         client = ICATClient()
         # pylint:disable=protected-access
@@ -94,6 +121,10 @@ class TestICATClient(unittest.TestCase):
     @patch('icat.Client.refresh')
     @patch('icat.Client.search')
     def test_query_without_conn(self, mock_search, mock_refresh, mock_connect, mock_set_attr, _):
+        """
+        Test: A query is executed
+        When: execute_query is called without a connection having been established
+        """
         # Add side effect to raise exception with icat.refresh
         mock_refresh.side_effect = raise_icat_session_error
         client = ICATClient()
@@ -107,6 +138,10 @@ class TestICATClient(unittest.TestCase):
     @patch('icat.Client.search')
     @patch('icat.Client.refresh', return_value=None)
     def test_query_icat(self, mock_refresh, mock_search, _):
+        """
+        Test: A query is executed
+        When: execute_query is called with a connection having been established
+        """
         client = ICATClient()
         client.execute_query('icat query')
         mock_refresh.assert_called_once()

--- a/utils/clients/tests/test_queue_client.py
+++ b/utils/clients/tests/test_queue_client.py
@@ -111,7 +111,7 @@ class TestQueueClient(unittest.TestCase):
         client.send('dataready', 'test-message')
         (args, _) = mock_stomp_send.call_args
         self.assertEqual(args[0], 'dataready')
-        self.assertEqual(args[1], 'message')
+        self.assertEqual(args[1], 'test-message')
 
     @patch('stomp.connect.StompConnection11.ack')
     def test_ack(self, mock_stomp_ack):
@@ -178,4 +178,5 @@ class TestQueueClient(unittest.TestCase):
                                'id': '1',
                                'ack': 'auto',
                                'header': {'activemq.prefetchSize': '1'}}
-        mock_stomp_subscribe.assert_has_calls([call(**test_expected_args), call(**queue_expected_args)])
+        mock_stomp_subscribe.assert_has_calls([call(**test_expected_args),
+                                               call(**queue_expected_args)])

--- a/utils/clients/tests/test_queue_client.py
+++ b/utils/clients/tests/test_queue_client.py
@@ -30,20 +30,27 @@ class TestQueueClient(unittest.TestCase):
                                                                     port='1234')
 
     def test_default_init(self):
-        """ Test default values for initialisation """
+        """
+        Test: Class variables are created and set
+        When: QueueClient is initialised with default credentials
+        """
         client = QueueClient()
         self.assertIsNotNone(client.credentials)
         self.assertIsNone(client._connection)
         self.assertEqual('QueueProcessor', client._consumer_name)
 
     def test_invalid_init(self):
-        """ Test invalid values for initialisation """
+        """
+        Test: A TypeError is raised
+        When: QueueClient is initialised with invalid credentials
+        """
         self.assertRaises(TypeError, QueueClient, 'string')
 
     def test_valid_connection(self):
         """
-        Test connection with valid credentials
-        This by proxy will also test the get_connection function
+        Test: Access is established with a valid connection
+        (This by proxy will also test the get_connection function)
+        When: connect is called while valid credentials are held
         """
         client = QueueClient()
         client.connect()
@@ -51,18 +58,28 @@ class TestQueueClient(unittest.TestCase):
 
     @patch('stomp.connect.StompConnection11.is_connected', return_value=False)
     def test_invalid_connection_raises_on_test(self, _):
+        """
+        Test: A ConnectionException is raised
+        When: _test_connection is called while a valid connection is not held
+        """
         client = QueueClient()
         client.connect()
         self.assertRaises(ConnectionException, client._test_connection)
 
     def test_invalid_credentials(self):
-        """ Test connection with invalid credentials """
+        """
+        Test: A ConnectionException is raised
+        When: _test_connection is called while invalid credentials are held
+        """
         client = QueueClient(self.incorrect_credentials)
         with self.assertRaises(ConnectionException):
             client.connect()
 
     def test_stop_connection(self):
-        """ Test connection can be stopped gracefully """
+        """
+        Test: Connection is stopped and connection variables are set to None
+        When: disconnect is called while a valid connection is currently established
+        """
         client = QueueClient()
         client.connect()
         self.assertTrue(client._connection.is_connected())
@@ -70,7 +87,10 @@ class TestQueueClient(unittest.TestCase):
         self.assertIsNone(client._connection)
 
     def test_serialise_message(self):
-        """ Test data is correctly serialised """
+        """
+        Test: Data is correctly serialised
+        When: serialise_data is called with valid arguments
+        """
         client = QueueClient()
         data = client.serialise_data('123', 'WISH', 'file/path', '001', 0)
         self.assertEqual(data['rb_number'], '123')
@@ -82,21 +102,35 @@ class TestQueueClient(unittest.TestCase):
 
     # pylint:disable=no-self-use
     @patch('stomp.connect.StompConnection11.send')
-    def test_send_data(self, mock_send):
-        """ Test data can be sent without error """
+    def test_send_data(self, mock_stomp_send):
+        """
+        Test: send establishes a connection and sends given data using stomp.send
+        When: send is called while a valid connection is not held
+        """
         client = QueueClient()
         client.send('dataready', 'test-message')
-        mock_send.assert_called_once()
+        (args, _) = mock_stomp_send.call_args
+        self.assertEqual(args[0], 'dataready')
+        self.assertEqual(args[1], 'message')
 
     @patch('stomp.connect.StompConnection11.ack')
-    def test_ack(self, mock_ack):
+    def test_ack(self, mock_stomp_ack):
+        """
+        Test: ack sends an ack frame using stomp.ack
+        When: ack is called while a valid connection is held
+        """
         client = QueueClient()
         client.connect()
         client.ack('test')
-        mock_ack.assert_called_once_with('test')
+        mock_stomp_ack.assert_called_once_with('test')
 
     @patch('utils.clients.queue_client.QueueClient.subscribe_queues')
     def test_subscribe_to_pending(self, mock_subscribe):
+        """
+        Test: subscribe_amq calls subscribe_queues with given arguments,
+        including a single queue (ReductionPending)
+        When: subscribe_amq is called once with the arguments given
+        """
         client = QueueClient()
         client.subscribe_amq('consumer', None, 'auto')
         # due to default params these have to be supplied to the mock in a dictionary
@@ -108,6 +142,11 @@ class TestQueueClient(unittest.TestCase):
 
     @patch('utils.clients.queue_client.QueueClient.subscribe_queues')
     def test_subscribe_to_all_queues(self, mock_subscribe):
+        """
+        Test: subscribe_autoreduce calls subscribe_queues with given arguments,
+        including a list of multiple queues (all)
+        When: subscribe_autoreduce is called once with the arguments given
+        """
         client = QueueClient()
         client.subscribe_autoreduce('consumer', None, 'auto')
         expected_args = {'queue_list': ['/queue/DataReady',
@@ -122,11 +161,15 @@ class TestQueueClient(unittest.TestCase):
 
     @patch('stomp.connect.StompConnection11.set_listener')
     @patch('stomp.connect.StompConnection11.subscribe')
-    def test_subscribe_to_queue(self, mock_subscribe, mock_set_listener):
+    def test_subscribe_to_queue(self, mock_stomp_subscribe, mock_stomp_set_listener):
+        """
+        Test: subscribe_queues calls stomp.subscribe_queues twice, once for each queue given
+        When: subscribe_queues is called with a queue_list length of 2
+        """
         client = QueueClient()
         client.connect()
         client.subscribe_queues(['test', 'queues'], 'consumer', None, 'auto')
-        mock_set_listener.assert_called_once_with('consumer', None)
+        mock_stomp_set_listener.assert_called_once_with('consumer', None)
         test_expected_args = {'destination': 'test',
                               'id': '1',
                               'ack': 'auto',
@@ -135,4 +178,4 @@ class TestQueueClient(unittest.TestCase):
                                'id': '1',
                                'ack': 'auto',
                                'header': {'activemq.prefetchSize': '1'}}
-        mock_subscribe.assert_has_calls([call(**test_expected_args), call(**queue_expected_args)])
+        mock_stomp_subscribe.assert_has_calls([call(**test_expected_args), call(**queue_expected_args)])

--- a/utils/clients/tests/test_sftp_client.py
+++ b/utils/clients/tests/test_sftp_client.py
@@ -114,7 +114,7 @@ class TestSFTPClient(unittest.TestCase):
 
     def test_server_path_and_local_path_are_valid(self):
         """
-        Test: retrieve finds a file from a given server_path and puts a copy in local_path 
+        Test: retrieve finds a file from a given server_path and puts a copy in local_path
         When: retrieve is called with a valid server_path (i.e. a path which point to a real file)
         and a valid local_path (i.e. a local path which exists)
         """


### PR DESCRIPTION
### Summary of work
Part of #514
- Docstrings within the test files of the `utils/clients` directory standardised to meet the Test/When format

### How to test your work
- Review the updated docstring

**Before merging ensure the release notes have been updated**