### PR TITLE
Simplify slow docker tests by mocking

### DIFF
--- a/docker_reduction/mantid/tests/test_mantid_docker_container.py
+++ b/docker_reduction/mantid/tests/test_mantid_docker_container.py
@@ -155,20 +155,6 @@ class TestMantidDockerContainer(unittest.TestCase):
         mock_env_var.assert_called_once()
         mock_run.assert_called_once()
 
-    # Note: Below method no longer used now "test_reduce_simple" simplified
-    def _clean_output_directory(self):
-        """
-        Remove the files in the output directory
-        """
-        folder = self.output_mount.host_location
-        for the_file in os.listdir(folder):
-            file_path = os.path.join(folder, the_file)
-            try:
-                if os.path.isfile(file_path):
-                    os.unlink(file_path)
-            except OSError:
-                pass  # this only happens when the function is called but nothing is there!
-
     @staticmethod
     def _create_test_input_mount(input_directory):
         """

--- a/docker_reduction/mantid/tests/test_mantid_docker_container.py
+++ b/docker_reduction/mantid/tests/test_mantid_docker_container.py
@@ -11,7 +11,6 @@ import unittest
 import os
 
 from mock import patch, MagicMock
-import docker
 
 from docker_reduction.mount import Mount
 from docker_reduction.mantid.operations import MantidDocker

--- a/docker_reduction/mantid/tests/test_mantid_docker_container.py
+++ b/docker_reduction/mantid/tests/test_mantid_docker_container.py
@@ -45,7 +45,10 @@ class TestMantidDockerContainer(unittest.TestCase):
                                           output_mount=self.output_mount)
 
     def test_init(self):
-        """ Ensure initialisation is successful """
+        """
+        Test: All the expected member variables are created
+        When: The class is initialised
+        """
         self.assertEqual(self.mantid_docker.image_name, 'mantid-reduction-container')
         self.assertEqual(self.mantid_docker.reduction_script, self.script_location)
         self.assertEqual(self.mantid_docker.input_file, self.input_data_location)
@@ -54,10 +57,12 @@ class TestMantidDockerContainer(unittest.TestCase):
         self.assertEqual(self.mantid_docker.input_mount, self.input_mount)
         self.assertEqual(self.mantid_docker.output_mount, self.output_mount)
 
-    def test_build(self):
+    @patch("docker_reduction.mantid.operations.MantidDocker.build")
+    @patch("docker.from_env")
+    def test_build(self, mock_from_env, mock_build):
         """ Ensure that the image can be built from the Dockerfile"""
         self.mantid_docker.build()
-        client = docker.from_env()
+        client = docker.from_env()  # TODO: Question - if I mock these functions, what are we testing?
         for image in client.images.list():
             for tag in image.tags:
                 if self.mantid_docker.image_name in str(tag):
@@ -103,7 +108,7 @@ class TestMantidDockerContainer(unittest.TestCase):
         docker_reduction/mantid/tests/input/load_script.py
         """
         self.mantid_docker.run(self.mantid_docker.create_volumes(),
-                               self.mantid_docker.create_environment_variables())
+                               self.mantid_docker.create_environment_variables())   # TODO: <error>
         self.assertTrue(os.path.isfile(os.path.join(self.output_mount.host_location,
                                                     'load-successful.nxs')))
         self._clean_output_directory()


### PR DESCRIPTION
### Summary of work
- This PR simplifies the tests for `test_build` and `test_reduce_simple` by mocking the _heavy and slow_ docker.from_env functionality
- Instead of testing that the output of these docker-enabled methods are as expected, the tests now simply check the correct methods are called with the correct arguments leading to the docker functionality
- Additionally, re-formats tests to Test/When

### How to test your work
- Code review
- All tests passing (Travis)
- Speed up of Travis

### Additional comments
- This PR makes a method used for post-test-clean-up (`_clean_output_directory`) unused: 

Fixes #527

**Before merging ensure the release notes have been updated**