### PR TITLE
Manual Submission to check DB before calling ICAT

### DIFF
--- a/scripts/manual_operations/manual_submission.py
+++ b/scripts/manual_operations/manual_submission.py
@@ -32,6 +32,10 @@ def submit_run(active_mq_client, rb_number, instrument, data_file_location, run_
     :param data_file_location: location of the data file
     :param run_number: run number fo the experiment
     """
+    if active_mq_client is None:
+        print("ActiveMQ not connected, cannot submit runs")
+        return
+
     data_dict = active_mq_client.serialise_data(rb_number=rb_number,
                                                 instrument=instrument,
                                                 location=data_file_location,
@@ -180,7 +184,11 @@ def main():
 
     print("Logging into ActiveMQ")
     activemq_client = QueueClient()
-    activemq_client.connect()
+    try:
+        activemq_client.connect()
+    except (ConnectionException, ValueError):
+        print("Couldn't connect to ActiveMQ. Continuing without ActiveMQ connection.")
+        activemq_client = None
 
     instrument = args.instrument.upper()
 

--- a/scripts/manual_operations/manual_submission.py
+++ b/scripts/manual_operations/manual_submission.py
@@ -40,7 +40,7 @@ def submit_run(active_mq_client, rb_number, instrument, data_file_location, run_
 
 
 def get_location_and_rb_from_database(database_client, run_number): # TODO: Add new docstrings
-    db_connection = database_client.get_connection()
+    db_connection = database_client.connect()
     location_query = f"""
                     SELECT file_path
                     FROM reduction_viewer_reductionlocation
@@ -97,15 +97,18 @@ def get_location_and_rb(database_client, icat_client, instrument, run_number, fi
     :param file_ext: expected file extension
     :return The resulting data_file
     """
-
+    try:
+        run_number = int(run_number)
+    except ValueError:
+        print(f"Cannot cast run_number as an integer. Run number given: '{run_number}'")
+        return None
     result = get_location_and_rb_from_database(database_client, run_number)
     if result:
         return result
     print(f"Cannot find datafile for run_number {run_number} in Auto-reduction database. "
           f"Will try ICAT...")
 
-    result = get_location_and_rb_from_icat(icat_client, instrument, run_number, file_ext)
-    return result
+    return get_location_and_rb_from_icat(icat_client, instrument, run_number, file_ext)
 
 def main():
     """

--- a/scripts/manual_operations/manual_submission.py
+++ b/scripts/manual_operations/manual_submission.py
@@ -17,6 +17,7 @@ import argparse
 # pylint: disable=import-error, no-name-in-module
 from utils.clients.icat_client import ICATClient
 from utils.clients.queue_client import QueueClient
+from utils.clients.database_client import DatabaseClient
 
 
 def submit_run(active_mq_client, rb_number, instrument, data_file_location, run_number):
@@ -37,16 +38,25 @@ def submit_run(active_mq_client, rb_number, instrument, data_file_location, run_
     active_mq_client.send('/queue/DataReady', json.dumps(data_dict), priority=1)
     print("Submitted run: \r\n" + json.dumps(data_dict, indent=1))
 
+def get_location_and_rb_from_database(database_client, run_number):
+    db_connection = database_client.get_connection()
+    location_query = f"SELECT file_path " \
+                     f"FROM reduction_viewer_reductionlocation " \
+                     f"WHERE reduction_run_id = {run_number}"
+    location_result = db_connection.execute(location_query).fetchall()
+    if len(location_result) == 0:
+        return None
 
-def get_data_file(icat_client, instrument, run_number, file_ext):
-    """
-    Gets the datafile from ICAT which contains the location and investigation of the datafile.
-    :param icat_client: client to access ICAT service
-    :param instrument: name of instrument
-    :param run_number: run number to be processed
-    :param file_ext: expected file extension
-    :return The resulting data_file
-    """
+    # NOTE: where is RB number stored?
+    rb_query = f"SELECT r " \
+                     f"FROM reduction_viewer_reductionrun " \
+                     f"WHERE reduction_run_id = {run_number}"
+
+
+
+
+
+def get_location_and_rb_from_icat(icat_client, instrument, run_number, file_ext):
     file_name = instrument + str(run_number).zfill(5) + "." + file_ext
     datafile = icat_client.execute_query("SELECT df FROM Datafile df WHERE df.name = '"
                                          + file_name +
@@ -54,17 +64,38 @@ def get_data_file(icat_client, instrument, run_number, file_ext):
 
     if not datafile:
         print("Cannot find datafile '" + file_name +
-              "'. Will try with zeros in front of run number.")
+              "' in ICAT. Will try with zeros in front of run number.")
         file_name = instrument + str(run_number).zfill(8) + "." + file_ext
         datafile = icat_client.execute_query("SELECT df FROM Datafile df WHERE df.name = '"
                                              + file_name +
                                              "' INCLUDE df.dataset AS ds, ds.investigation")
 
     if not datafile:
-        print("Cannot find datafile '" + file_name + "'. Exiting...")
+        print("Cannot find datafile '" + file_name + "' in ICAT. Exiting...")
         sys.exit(1)
-    return datafile[0]
+    return datafile[0].location, datafile[0].dataset.investigation.name
 
+def get_location_and_rb(database_client, icat_client, instrument, run_number, file_ext):
+    """
+    TODO: update this properly
+    Attempts to retrieve the datafile from the auto-reduction database.
+    If the datafile does not exist within the database, attempts to retrieve it's
+    location and investigation from ICAT.
+    :param icat_client: client to access ICAT service
+    :param instrument: name of instrument
+    :param run_number: run number to be processed
+    :param file_ext: expected file extension
+    :return The resulting data_file
+    """
+
+    result = get_location_and_rb_from_database(database_client, run_number)
+    if result:
+        return result
+    print(f"Cannot find datafile for run_number {run_number} in Auto-reduction database."
+          f"Will try ICAT...")
+
+    result = get_location_and_rb_from_icat(icat_client, instrument, run_number, file_ext)
+    return result
 
 def main():
     """
@@ -99,13 +130,14 @@ def main():
     activemq_client = QueueClient()
     activemq_client.connect()
 
+    print("Logging into Database")
+    database_client = DatabaseClient()
+    database_client.connect()
+
     instrument = args.instrument.upper()
 
     for run in run_numbers:
-        datafile = get_data_file(icat_client, instrument, run, "nxs")
-
-        location = datafile.location
-        rb_num = datafile.dataset.investigation.name
+        location, rb_num = get_location_and_rb(database_client, icat_client, instrument, run, "nxs")
         submit_run(activemq_client, rb_num, instrument, location, run)
 
 

--- a/scripts/manual_operations/tests/test_manual_submission.py
+++ b/scripts/manual_operations/tests/test_manual_submission.py
@@ -37,7 +37,7 @@ def get_json_object(rb_number, instrument, data_file_location, run_number, start
 
 
 # pylint:disable=no-self-use
-class TestManualSubmission(unittest.TestCase):
+class TestManualSubmission(unittest.TestCase):  # TODO: Update the tests
     """
     Test manual_submission.py
     """

--- a/scripts/manual_operations/tests/test_manual_submission.py
+++ b/scripts/manual_operations/tests/test_manual_submission.py
@@ -7,10 +7,14 @@
 """
 Test cases for the manual job submission script
 """
+import re
 import unittest
 import json
-from mock import Mock, patch
+from mock import Mock, patch, MagicMock
 import scripts.manual_operations.manual_submission as ms
+from scripts.manual_operations import manual_submission
+from utils.clients.database_client import DatabaseClient
+from utils.clients.icat_client import ICATClient
 from utils.clients.queue_client import QueueClient
 
 
@@ -41,30 +45,93 @@ class TestManualSubmission(unittest.TestCase):  # TODO: Update the tests
     """
     Test manual_submission.py
     """
-    def test_get_existing_data_file(self):
-        """
-        Get an existing data file name from ICAT
-        """
-        icat_client = Mock()
-        icat_client.execute_query = Mock(return_value=[DataFile("GEM84823.nxs")])
-        data_file = ms.get_data_file(icat_client, "GEM", "84823", "nxs")
-        self.assertEqual(data_file.name, "GEM84823.nxs")
+    def setUp(self):
+        # self.valid_value = "valid"
+        self.location_and_rb_args = [DatabaseClient(), ICATClient(),
+                                     "instrument", -1, "file_ext"]
+        self.submit_run_args = [QueueClient(), -1, "instrument",
+                                "data_file_location", -1]
+        self.valid_return = ("location", "rb")
 
-    def test_get_invalid_data_file(self):
+    def make_mock_return_object(self, return_from):
+        ret_obj = [MagicMock()]
+        if return_from == "icat":
+            ret_obj[0].location = self.valid_return[0]
+            ret_obj[0].dataset.investigation.name = self.valid_return[1]
+        elif return_from == "db_location":
+            ret_obj[0].file_path = self.valid_return[0]
+        elif return_from == "db_rb":
+            ret_obj[0].reference_number = self.valid_return[1]
+        return ret_obj
+
+    # TODO: test/whens
+
+    # TODO: tests
+    #   - test_get_calls_icat_then_database
+    #   - test_get_from_database
+    #   - test_get_from_icat_when_file_exists_without_zeroes
+    #   - test_get_from_icat_when_file_exists_with_zeroes
+    #   - test_get_when_file_does_not_exist
+
+    @patch('scripts.manual_operations.manual_submission.get_location_and_rb_from_database', return_value=None)
+    @patch('scripts.manual_operations.manual_submission.get_location_and_rb_from_icat')
+    def test_get_checks_database_then_icat(self, mock_from_icat, mock_from_database):
         """
-        Attempt to get an invalid file name from ICAT
+        Test: A datafile is sought for in the database before icat
+        When: get_location_and_rb is called and the datafile isn't in the database
         """
-        icat_client = Mock()
-        icat_client.execute_query = Mock(return_value=None)
+        mock_from_icat.return_value = self.valid_return
+        result = ms.get_location_and_rb(*self.location_and_rb_args)
+        self.assertEqual(self.valid_return, result)
+        mock_from_database.assert_called_once()
+
+    @patch('sqlalchemy.engine.result.ResultProxy.fetchall')
+    def test_get_from_database(self, mock_fetchall):
+        mock_fetchall.side_effect = ["_test_connection_return",
+                                     self.make_mock_return_object("db_location"),
+                                     self.make_mock_return_object("db_rb")]
+        location_and_rb = ms.get_location_and_rb_from_database(self.location_and_rb_args[0], self.location_and_rb_args[3])
+        self.assertEqual(location_and_rb, self.valid_return)
+
+    @patch('utils.clients.icat_client.ICATClient.execute_query')
+    def test_get_from_icat_when_file_exists_without_zeroes(self, mock_query):
+        mock_query.return_value = self.make_mock_return_object("icat")
+        location_and_rb = ms.get_location_and_rb_from_icat(*self.location_and_rb_args[1:])
+        mock_query.assert_called_once()
+        self.assertEqual(location_and_rb, self.valid_return)
+
+    @patch('utils.clients.icat_client.ICATClient.execute_query')
+    def test_get_from_icat_when_file_exists_with_zeroes(self, mock_query):
+        # The below sets a sequence of return values (1st call -> ret=None ; 2nd call -> ret=Mock)
+        mock_query.side_effect = [None, self.make_mock_return_object("icat")]
+        location_and_rb = ms.get_location_and_rb_from_icat(*self.location_and_rb_args[1:])
+        self.assertEqual(mock_query.call_count, 2)
+        self.assertEqual(location_and_rb, self.valid_return)
+
+    @patch('utils.clients.icat_client.ICATClient.execute_query', return_value=None)
+    @patch('sqlalchemy.engine.result.ResultProxy.fetchall', return_value=[])
+    def test_get_when_file_does_not_exist(self, mock_db_fetchall, mock_icat_query):
         with self.assertRaises(SystemExit):
-            ms.get_data_file(icat_client, "GEM", "84823", "jpg")
+            ms.get_location_and_rb(*self.location_and_rb_args)
+        # Below: '>=2' factors in DatabaseClient._test_connection but doesn't require it
+        self.assertTrue(mock_db_fetchall.call_count >= 2)
+        self.assertTrue(mock_icat_query.call_count == 2)
+
+    @patch('scripts.manual_operations.manual_submission.get_location_and_rb_from_database')
+    @patch('scripts.manual_operations.manual_submission.get_location_and_rb_from_icat')
+    def test_get_when_run_number_not_int(self, mock_from_icat, mock_from_database):
+        args = self.location_and_rb_args
+        args[3] = "string_rb_number"
+        result = ms.get_location_and_rb(*args)
+        self.assertIsNone(result)
+        mock_from_icat.assert_not_called()
+        mock_from_database.assert_not_called()
 
     @patch('utils.clients.queue_client.QueueClient.send', return_value=None)
-    def test_submit_run(self, send):
+    def test_submit_run(self, mock_send):
         """
         Check that a run is submitted successfully
         """
-        active_mq_client = QueueClient()
-        ms.submit_run(active_mq_client, "1812345", "GEM", "5454", "nxs")
-        json_obj = get_json_object("1812345", "GEM", "5454", "nxs", -1)
-        send.assert_called_with('/queue/DataReady', json_obj, priority=1)
+        ms.submit_run(*self.submit_run_args)
+        json_obj = get_json_object(*self.submit_run_args[1:], -1)
+        mock_send.assert_called_with('/queue/DataReady', json_obj, priority=1)

--- a/scripts/manual_operations/tests/test_manual_submission.py
+++ b/scripts/manual_operations/tests/test_manual_submission.py
@@ -18,35 +18,13 @@ from utils.clients.icat_client import ICATClient
 from utils.clients.queue_client import QueueClient
 
 
-# pylint:disable=too-few-public-methods
-class DataFile:
-    """
-    Basic data file representation for testing
-    """
-    def __init__(self, df_name):
-        self.name = df_name
-
-
-def get_json_object(rb_number, instrument, data_file_location, run_number, started_by):
-    """
-    Return the JSON object that should be sent to DataReady
-    """
-    data_dict = {"rb_number": rb_number,
-                 "instrument": instrument,
-                 "data": data_file_location,
-                 "run_number": run_number,
-                 "facility": "ISIS",
-                 "started_by": started_by}
-    return json.dumps(data_dict)
-
-
 # pylint:disable=no-self-use
 class TestManualSubmission(unittest.TestCase):  # TODO: Update the tests
     """
     Test manual_submission.py
     """
     def setUp(self):
-        # self.valid_value = "valid"
+        """ Creates test variables used throughout the test suite """
         self.location_and_rb_args = [DatabaseClient(), ICATClient(),
                                      "instrument", -1, "file_ext"]
         self.submit_run_args = [QueueClient(), -1, "instrument",
@@ -54,6 +32,11 @@ class TestManualSubmission(unittest.TestCase):  # TODO: Update the tests
         self.valid_return = ("location", "rb")
 
     def make_mock_return_object(self, return_from):
+        """ Creates a MagicMock object in a format which mimics the format of
+        an object returned from ICAT or the auto-reduction database
+        :param return_from: A string representing what type of return object
+        to be mocked
+        :return: The formatted MagicMock object """
         ret_obj = [MagicMock()]
         if return_from == "icat":
             ret_obj[0].location = self.valid_return[0]
@@ -64,29 +47,35 @@ class TestManualSubmission(unittest.TestCase):  # TODO: Update the tests
             ret_obj[0].reference_number = self.valid_return[1]
         return ret_obj
 
-    # TODO: test/whens
-
-    # TODO: tests
-    #   - test_get_calls_icat_then_database
-    #   - test_get_from_database
-    #   - test_get_from_icat_when_file_exists_without_zeroes
-    #   - test_get_from_icat_when_file_exists_with_zeroes
-    #   - test_get_when_file_does_not_exist
+    @staticmethod
+    def get_json_object(rb_number, instrument, data_file_location, run_number, started_by):
+        """ :return: The JSON object which should be sent to DataReady """
+        data_dict = {"rb_number": rb_number,
+                     "instrument": instrument,
+                     "data": data_file_location,
+                     "run_number": run_number,
+                     "facility": "ISIS",
+                     "started_by": started_by}
+        return json.dumps(data_dict)
 
     @patch('scripts.manual_operations.manual_submission.get_location_and_rb_from_database', return_value=None)
     @patch('scripts.manual_operations.manual_submission.get_location_and_rb_from_icat')
     def test_get_checks_database_then_icat(self, mock_from_icat, mock_from_database):
         """
-        Test: A datafile is sought for in the database before icat
-        When: get_location_and_rb is called and the datafile isn't in the database
+        Test: Data for a given run is searched for in the database before calling ICAT
+        When: get_location_and_rb is called for a datafile which isn't in the database
         """
-        mock_from_icat.return_value = self.valid_return
-        result = ms.get_location_and_rb(*self.location_and_rb_args)
-        self.assertEqual(self.valid_return, result)
+        ms.get_location_and_rb(*self.location_and_rb_args)
         mock_from_database.assert_called_once()
+        mock_from_icat.assert_called_once()
 
     @patch('sqlalchemy.engine.result.ResultProxy.fetchall')
     def test_get_from_database(self, mock_fetchall):
+        """
+        Test: Data for a given run can be retrieved from the database in the expected format
+        When: get_location_and_rb_from_database is called and the data is present
+        in the database
+        """
         mock_fetchall.side_effect = ["_test_connection_return",
                                      self.make_mock_return_object("db_location"),
                                      self.make_mock_return_object("db_rb")]
@@ -95,6 +84,10 @@ class TestManualSubmission(unittest.TestCase):  # TODO: Update the tests
 
     @patch('utils.clients.icat_client.ICATClient.execute_query')
     def test_get_from_icat_when_file_exists_without_zeroes(self, mock_query):
+        """
+        Test: Data for a given run can be retrieved from ICAT in the expected format
+        When: get_location_and_rb_from_icat is called and the data is present in ICAT
+        """
         mock_query.return_value = self.make_mock_return_object("icat")
         location_and_rb = ms.get_location_and_rb_from_icat(*self.location_and_rb_args[1:])
         mock_query.assert_called_once()
@@ -102,6 +95,11 @@ class TestManualSubmission(unittest.TestCase):  # TODO: Update the tests
 
     @patch('utils.clients.icat_client.ICATClient.execute_query')
     def test_get_from_icat_when_file_exists_with_zeroes(self, mock_query):
+        """
+        Test: Data for a given run can be retrieved from ICAT in the expected format
+        When: get_location_and_rb_from_icat is called and the data is present in ICAT
+        but named with prepended zeroes
+        """
         # The below sets a sequence of return values (1st call -> ret=None ; 2nd call -> ret=Mock)
         mock_query.side_effect = [None, self.make_mock_return_object("icat")]
         location_and_rb = ms.get_location_and_rb_from_icat(*self.location_and_rb_args[1:])
@@ -110,7 +108,11 @@ class TestManualSubmission(unittest.TestCase):  # TODO: Update the tests
 
     @patch('utils.clients.icat_client.ICATClient.execute_query', return_value=None)
     @patch('sqlalchemy.engine.result.ResultProxy.fetchall', return_value=[])
-    def test_get_when_file_does_not_exist(self, mock_db_fetchall, mock_icat_query):
+    def test_get_when_does_not_exist(self, mock_db_fetchall, mock_icat_query):
+        """
+        Test: A SystemExit is raised
+        When: get_location_and_rb is called but the data requested doesn't exist
+        """
         with self.assertRaises(SystemExit):
             ms.get_location_and_rb(*self.location_and_rb_args)
         # Below: '>=2' factors in DatabaseClient._test_connection but doesn't require it
@@ -120,6 +122,10 @@ class TestManualSubmission(unittest.TestCase):  # TODO: Update the tests
     @patch('scripts.manual_operations.manual_submission.get_location_and_rb_from_database')
     @patch('scripts.manual_operations.manual_submission.get_location_and_rb_from_icat')
     def test_get_when_run_number_not_int(self, mock_from_icat, mock_from_database):
+        """
+        Test: None is return and neither the database nor ICAT is checked for data
+        When: get_location_and_rb is called with a run_number which cannot be cast as an int
+        """
         args = self.location_and_rb_args
         args[3] = "string_rb_number"
         result = ms.get_location_and_rb(*args)
@@ -130,8 +136,9 @@ class TestManualSubmission(unittest.TestCase):  # TODO: Update the tests
     @patch('utils.clients.queue_client.QueueClient.send', return_value=None)
     def test_submit_run(self, mock_send):
         """
-        Check that a run is submitted successfully
+        Test: A given run is submitted to the DataReady queue
+        When: submit_run is called with valid arguments
         """
         ms.submit_run(*self.submit_run_args)
-        json_obj = get_json_object(*self.submit_run_args[1:], -1)
+        json_obj = self.get_json_object(*self.submit_run_args[1:], -1)
         mock_send.assert_called_with('/queue/DataReady', json_obj, priority=1)

--- a/scripts/manual_operations/tests/test_manual_submission.py
+++ b/scripts/manual_operations/tests/test_manual_submission.py
@@ -123,13 +123,13 @@ class TestManualSubmission(unittest.TestCase):  # TODO: Update the tests
     @patch('scripts.manual_operations.manual_submission.get_location_and_rb_from_icat')
     def test_get_when_run_number_not_int(self, mock_from_icat, mock_from_database):
         """
-        Test: None is return and neither the database nor ICAT is checked for data
+        Test: A SystemExit is raised and neither the database nor ICAT are checked for data
         When: get_location_and_rb is called with a run_number which cannot be cast as an int
         """
         args = self.location_and_rb_args
         args[3] = "string_rb_number"
-        result = ms.get_location_and_rb(*args)
-        self.assertIsNone(result)
+        with self.assertRaises(SystemExit):
+            ms.get_location_and_rb(*args)
         mock_from_icat.assert_not_called()
         mock_from_database.assert_not_called()
 

--- a/scripts/manual_operations/tests/test_manual_submission.py
+++ b/scripts/manual_operations/tests/test_manual_submission.py
@@ -7,15 +7,10 @@
 """
 Test cases for the manual job submission script
 """
-import re
 import unittest
 import json
-from mock import Mock, patch, MagicMock
+from mock import patch, MagicMock
 import scripts.manual_operations.manual_submission as ms
-from scripts.manual_operations import manual_submission
-from utils.clients.database_client import DatabaseClient
-from utils.clients.icat_client import ICATClient
-from utils.clients.queue_client import QueueClient
 
 
 # pylint:disable=no-self-use
@@ -25,11 +20,10 @@ class TestManualSubmission(unittest.TestCase):
     """
     def setUp(self):
         """ Creates test variables used throughout the test suite """
-        self.location_and_rb_args = [MagicMock(name="DatabaseClient"),
-                                     MagicMock(name="ICATClient"),
-                                     "instrument", -1, "file_ext"]
-        self.submit_run_args = [MagicMock(name="QueueClient"), -1, "instrument",
-                                "data_file_location", -1]
+        self.loc_and_rb_args = [MagicMock(name="DatabaseClient"), MagicMock(name="ICATClient"),
+                                "instrument", -1, "file_ext"]
+        self.sub_run_args = [MagicMock(name="QueueClient"),
+                             -1, "instrument", "data_file_location", -1]
         self.valid_return = ("location", "rb")
 
     def mock_database_query_result(self, side_effects):
@@ -41,9 +35,9 @@ class TestManualSubmission(unittest.TestCase):
         mock_query_result.fetchall.side_effect = side_effects
         mock_connection = MagicMock(name="mock_connection")
         mock_connection.execute.return_value = mock_query_result
-        self.location_and_rb_args[0].connect.return_value = mock_connection
+        self.loc_and_rb_args[0].connect.return_value = mock_connection
 
-    def make_valid_query_return_object(self, return_from):
+    def make_query_return_object(self, return_from):
         """ Creates a MagicMock object in a format which mimics the format of
         an object returned from a query to ICAT or the auto-reduction database
         :param return_from: A string representing what type of return object
@@ -70,14 +64,15 @@ class TestManualSubmission(unittest.TestCase):
                      "started_by": started_by}
         return json.dumps(data_dict)
 
-    @patch('scripts.manual_operations.manual_submission.get_location_and_rb_from_database', return_value=None)
+    @patch('scripts.manual_operations.manual_submission.get_location_and_rb_from_database',
+           return_value=None)
     @patch('scripts.manual_operations.manual_submission.get_location_and_rb_from_icat')
     def test_get_checks_database_then_icat(self, mock_from_icat, mock_from_database):
         """
         Test: Data for a given run is searched for in the database before calling ICAT
         When: get_location_and_rb is called for a datafile which isn't in the database
         """
-        ms.get_location_and_rb(*self.location_and_rb_args)
+        ms.get_location_and_rb(*self.loc_and_rb_args)
         mock_from_database.assert_called_once()
         mock_from_icat.assert_called_once()
 
@@ -87,12 +82,12 @@ class TestManualSubmission(unittest.TestCase):
         When: get_location_and_rb_from_database is called and the data is present
         in the database
         """
-        side_effects = [self.make_valid_query_return_object("db_location"),
-                        self.make_valid_query_return_object("db_rb")]
+        side_effects = [self.make_query_return_object("db_location"),
+                        self.make_query_return_object("db_rb")]
         self.mock_database_query_result(side_effects)
 
-        location_and_rb = ms.get_location_and_rb_from_database(self.location_and_rb_args[0],
-                                                               self.location_and_rb_args[3])
+        location_and_rb = ms.get_location_and_rb_from_database(self.loc_and_rb_args[0],
+                                                               self.loc_and_rb_args[3])
         self.assertEqual(location_and_rb, self.valid_return)
 
     def test_get_from_icat_when_file_exists_without_zeroes(self):
@@ -100,9 +95,9 @@ class TestManualSubmission(unittest.TestCase):
         Test: Data for a given run can be retrieved from ICAT in the expected format
         When: get_location_and_rb_from_icat is called and the data is present in ICAT
         """
-        self.location_and_rb_args[1].execute_query.return_value = self.make_valid_query_return_object("icat")
-        location_and_rb = ms.get_location_and_rb_from_icat(*self.location_and_rb_args[1:])
-        self.location_and_rb_args[1].execute_query.assert_called_once()
+        self.loc_and_rb_args[1].execute_query.return_value = self.make_query_return_object("icat")
+        location_and_rb = ms.get_location_and_rb_from_icat(*self.loc_and_rb_args[1:])
+        self.loc_and_rb_args[1].execute_query.assert_called_once()
         self.assertEqual(location_and_rb, self.valid_return)
 
     def test_get_from_icat_when_file_exists_with_zeroes(self):
@@ -111,9 +106,10 @@ class TestManualSubmission(unittest.TestCase):
         When: get_location_and_rb_from_icat is called and the data is present in ICAT
         but named with prepended zeroes
         """
-        self.location_and_rb_args[1].execute_query.side_effect = [None, self.make_valid_query_return_object("icat")]
-        location_and_rb = ms.get_location_and_rb_from_icat(*self.location_and_rb_args[1:])
-        self.assertEqual(self.location_and_rb_args[1].execute_query.call_count, 2)
+        self.loc_and_rb_args[1].execute_query.side_effect =\
+            [None, self.make_query_return_object("icat")]
+        location_and_rb = ms.get_location_and_rb_from_icat(*self.loc_and_rb_args[1:])
+        self.assertEqual(self.loc_and_rb_args[1].execute_query.call_count, 2)
         self.assertEqual(location_and_rb, self.valid_return)
 
     def test_get_when_does_not_exist(self):
@@ -122,13 +118,13 @@ class TestManualSubmission(unittest.TestCase):
         When: get_location_and_rb is called but the data requested doesn't exist
         """
         mock_db_connection = MagicMock(name="mock_connection")
-        self.location_and_rb_args[0].connect.return_value = mock_db_connection
-        self.location_and_rb_args[1].execute_query.return_value = None
+        self.loc_and_rb_args[0].connect.return_value = mock_db_connection
+        self.loc_and_rb_args[1].execute_query.return_value = None
 
         with self.assertRaises(SystemExit):
-            ms.get_location_and_rb(*self.location_and_rb_args)
+            ms.get_location_and_rb(*self.loc_and_rb_args)
         self.assertTrue(mock_db_connection.execute.call_count == 1)
-        self.assertTrue(self.location_and_rb_args[1].execute_query.call_count == 2)
+        self.assertTrue(self.loc_and_rb_args[1].execute_query.call_count == 2)
 
     @patch('scripts.manual_operations.manual_submission.get_location_and_rb_from_database')
     @patch('scripts.manual_operations.manual_submission.get_location_and_rb_from_icat')
@@ -137,9 +133,9 @@ class TestManualSubmission(unittest.TestCase):
         Test: A SystemExit is raised and neither the database nor ICAT are checked for data
         When: get_location_and_rb is called with a run_number which cannot be cast as an int
         """
-        self.location_and_rb_args[3] = "string_rb_number"
+        self.loc_and_rb_args[3] = "string_rb_number"
         with self.assertRaises(SystemExit):
-            ms.get_location_and_rb(*self.location_and_rb_args)
+            ms.get_location_and_rb(*self.loc_and_rb_args)
         mock_from_icat.assert_not_called()
         mock_from_database.assert_not_called()
 
@@ -149,5 +145,7 @@ class TestManualSubmission(unittest.TestCase):
         Test: A given run is submitted to the DataReady queue
         When: submit_run is called with valid arguments
         """
-        ms.submit_run(*self.submit_run_args)
-        self.submit_run_args[0].send.assert_called_with('/queue/DataReady', mock_json_dump.return_value, priority=1)
+        ms.submit_run(*self.sub_run_args)
+        self.sub_run_args[0].send.assert_called_with('/queue/DataReady',
+                                                     mock_json_dump.return_value,
+                                                     priority=1)


### PR DESCRIPTION
### Summary of work
- This PR changes the _data file location & RB-number retrieval_ functionality (fka `get_data_file`) of the `manual_submission` script (MSS) to first check the Auto-reduction database (i.e. check whether the file has already been reduced) before resorting to calling ICAT for this information.
- This avoids unnecessary ICAT calls and enhances autoreduction's (AR) independence from ICAT

### How to test your work
- Ensure the following cases are true (which can be checked by the print statements produced):
1. When a file exists in AR, MSS retrieves the necessary data from there
2. When a file does not exists in AR, MSS calls ICAT
3. When a file exists in neither AR or ICAT, MSS exits gracefully as usual

### Additional comments
- I've used raw SQL because we plan to change our ORM soon.
  * It is easier to transition from raw SQL to a new ORM than from an existing ORM.

Fixes #526 


**Before merging ensure the release notes have been updated**