### PR TITLE
[DNM] Update calls to QueueClient.send to use Message class instead of json dumps

### DIFF
--- a/WebApp/autoreduce_webapp/reduction_variables/utils.py
+++ b/WebApp/autoreduce_webapp/reduction_variables/utils.py
@@ -18,6 +18,8 @@ import sys
 import chardet
 import importlib.util as imp
 
+from message.job import Message
+
 sys.path.append(os.path.join("../", os.path.dirname(os.path.dirname(__file__))))
 os.environ["DJANGO_SETTINGS_MODULE"] = "autoreduce_webapp.settings"
 
@@ -685,6 +687,6 @@ class MessagingUtils(object):
 
         message_client = QueueClient()
         message_client.connect()
-        message_client.send('/queue/ReductionPending', json.dumps(data_dict),
+        message_client.send('/queue/ReductionPending', Message(data_dict),
                             priority='0', delay=delay)
         message_client.disconnect()

--- a/message/job.py
+++ b/message/job.py
@@ -34,20 +34,24 @@ class Message:
     admin_log = attr.ib(default=None)
     return_message = attr.ib(default=None)
     retry_in = attr.ib(default=None)
+    # Note: reduction location not currently stored
 
-    # Note: since most uses of a message will immediately require populate() after initialisation,
-    #   adding population_source as an init arg cuts down a step
-    #   i.e. Message().populate(DICT) --> Message(DICT)     [but the former method will still work]
-    def init(self, population_source=None):
-        if population_source:
-            self.populate(population_source)
+    # # Note: since most uses of a message will immediately require populate() after initialisation,
+    # #   adding population_source as an init arg cuts down a step
+    # #   i.e. Message().populate(DICT) --> Message(DICT)     [but the former method will still work]
+    # def init(self, population_source=None):
+    #     if population_source:
+    #         self.populate(population_source)
+
+    def as_dict(self):
+        return attr.asdict(self)
 
     def serialize(self):
         """
         Serialized member variables as a json dump
         :return: JSON dump of a dictionary representing the member variables
         """
-        return json.dumps(attr.asdict(self))
+        return json.dumps(self.as_dict())
 
     @staticmethod
     def deserialize(serialized_object):
@@ -78,3 +82,8 @@ class Message:
                 if overwrite or self_value is None:
                     # Set the value of the variable on this object accessing it by name
                     setattr(self, key, value)
+            else:
+                # NOTE: added this for debugging purposes,but may be useful to flag
+                #  unexpected, skipped keys somehow
+                print(f"Unexpected key encountered: '{key}'."   # TODO: Change this to a log at Worning
+                      f"Skipping..")

--- a/message/job.py
+++ b/message/job.py
@@ -35,6 +35,13 @@ class Message:
     return_message = attr.ib(default=None)
     retry_in = attr.ib(default=None)
 
+    # Note: since most uses of a message will immediately require populate() after initialisation,
+    #   adding population_source as an init arg cuts down a step
+    #   i.e. Message().populate(DICT) --> Message(DICT)     [but the former method will still work]
+    def init(self, population_source=None):
+        if population_source:
+            self.populate(population_source)
+
     def serialize(self):
         """
         Serialized member variables as a json dump

--- a/monitors/run_detection.py
+++ b/monitors/run_detection.py
@@ -12,6 +12,7 @@ from filelock import (FileLock, Timeout)
 
 from monitors.settings import (LAST_RUNS_CSV, CYCLE_FOLDER)
 
+from message.job import Message
 from utils.clients.queue_client import QueueClient
 from utils.project.structure import get_log_file
 from utils.project.static_content import LOG_FORMAT
@@ -144,7 +145,7 @@ class InstrumentMonitor:
                 rb_number = summary_rb_number
             EORM_LOG.info("Submitting '%s' with RB number '%s'", file_name, rb_number)
             data_dict = self.build_dict(rb_number, run_number, file_path)
-            self.client.send('/queue/DataReady', json.dumps(data_dict), priority='9')
+            self.client.send('/queue/DataReady', Message(data_dict), priority='9')
         else:
             raise FileNotFoundError("File does not exist '{}'".format(file_path))
 

--- a/queue_processors/queue_processor/queue_processor.py
+++ b/queue_processors/queue_processor/queue_processor.py
@@ -21,6 +21,7 @@ import traceback
 
 from sqlalchemy import sql
 
+from message.job import Message
 from queue_processors.queue_processor.base import session
 from queue_processors.queue_processor.orm_mapping import (ReductionRun, Instrument,
                                                           Status, Experiment,
@@ -215,7 +216,7 @@ class Listener:
         if instrument.is_paused:
             logger.info("Run %s has been skipped", self._data_dict['run_number'])
         else:
-            self._client.send('/queue/ReductionPending', json.dumps(self._data_dict),
+            self._client.send('/queue/ReductionPending', Message(self._data_dict),
                               priority=self._priority)
             logger.info("Run %s ready for reduction", self._data_dict['run_number'])
 
@@ -229,7 +230,7 @@ class Listener:
         self._data_dict['message'] = 'Reduction Skipped: {}. Assuming run number to be ' \
                                      'a calibration run.'.format(reason)
         skipped_queue = ACTIVEMQ_SETTINGS.reduction_skipped
-        self._client.send(skipped_queue, json.dumps(self._data_dict),
+        self._client.send(skipped_queue, Message(self._data_dict),
                           priority=self._priority)
 
     def reduction_started(self):

--- a/queue_processors/queue_processor/queueproc_utils/messaging_utils.py
+++ b/queue_processors/queue_processor/queueproc_utils/messaging_utils.py
@@ -9,6 +9,7 @@ import json
 import logging.config
 
 # pylint: disable=cyclic-import
+from message.job import Message
 from queue_processors.queue_processor.base import session
 from queue_processors.queue_processor.orm_mapping import DataLocation
 # pylint:disable=no-name-in-module,import-error
@@ -70,7 +71,7 @@ class MessagingUtils:
         message_client = QueueClient()
         message_client.connect()
         message_client.send('/queue/ReductionPending',
-                            json.dumps(data_dict),
+                            Message(data_dict),
                             priority='0',
                             delay=delay)
         message_client.disconnect()

--- a/queue_processors/queue_processor/queueproc_utils/tests/test_messaging_utils.py
+++ b/queue_processors/queue_processor/queueproc_utils/tests/test_messaging_utils.py
@@ -12,6 +12,7 @@ import unittest
 
 from mock import patch
 
+from message.job import Message
 from queue_processors.queue_processor.queueproc_utils.messaging_utils import MessagingUtils
 
 
@@ -43,6 +44,6 @@ class TestMessagingUtils(unittest.TestCase):
 
         (args, kwargs) = mock_send.call_args
         self.assertEqual(args[0], self.pending_queue_name)
-        self.assertEqual(args[1], json.dumps(self.test_data))
+        self.assertEqual(args[1], Message(self.test_data))
         self.assertEqual(kwargs["priority"], '0')
         self.assertEqual(kwargs["delay"], None)

--- a/queue_processors/queue_processor/tests/test_queue_processor.py
+++ b/queue_processors/queue_processor/tests/test_queue_processor.py
@@ -9,11 +9,13 @@ Test cases for the queue processor
 """
 import unittest
 
-from mock import patch
+from mock import patch, MagicMock
 
+from message.job import Message
 from queue_processors.queue_processor import queue_processor
 from queue_processors.queue_processor.queue_processor import Listener
 from utils.clients.queue_client import QueueClient
+from utils.settings import ACTIVEMQ_SETTINGS
 
 
 class TestQueueProcessor(unittest.TestCase):
@@ -23,17 +25,22 @@ class TestQueueProcessor(unittest.TestCase):
     """
     def setUp(self):
         self.test_consumer_name = "Test_Autoreduction_QueueProcessor"
+        self.rb_number = -1
+        self.reason = "test"
+        # self.logger = MagicMock()
 
+    @patch('logging.Logger.info')
     @patch('utils.clients.queue_client.QueueClient.__init__', return_value=None)
     @patch('utils.clients.queue_client.QueueClient.connect')
     @patch('utils.clients.queue_client.QueueClient.subscribe_autoreduce')
-    def test_setup_connection(self, mock_sub_ar, mock_connect, mock_client):
+    def test_setup_connection(self, mock_sub_ar, mock_connect, mock_client, mock_logger_info):
         """
         Test: Connection to ActiveMQ setup, along with subscription to queues
         When: setup_connection is called with a consumer name
         """
         queue_processor.setup_connection(self.test_consumer_name)
 
+        mock_logger_info.assert_called_once()
         mock_client.assert_called_once()
         mock_connect.assert_called_once()
         mock_sub_ar.assert_called_once()
@@ -42,3 +49,22 @@ class TestQueueProcessor(unittest.TestCase):
         self.assertEqual(args[0], self.test_consumer_name)
         self.assertIsInstance(args[1], Listener)
         self.assertIsInstance(args[1]._client, QueueClient)
+
+    @patch('logging.Logger.warning')
+    def test_construct_and_send_skipped(self, mock_logger_warning):
+        """
+        Test: _data_dict['message'] is given a value,and the _data_dict is sent via the QueueClient
+        When: _construct_and_send_skipped is called
+        """
+        mock_client = MagicMock(name="QueueClient")
+        listener = Listener(mock_client)
+        listener._construct_and_send_skipped(self.rb_number, self.reason)
+
+        mock_logger_warning.assert_called_once()
+
+        self.assertIsNotNone(listener._data_dict['message'])
+        mock_client.send.assert_called_once_with(ACTIVEMQ_SETTINGS.reduction_skipped,
+                                                 Message(listener._data_dict),
+                                                 priority=listener._priority)
+        message = mock_client.send.call_args[0][1]
+        self.assertEqual(message.description, listener._data_dict)

--- a/scripts/manual_operations/manual_submission.py
+++ b/scripts/manual_operations/manual_submission.py
@@ -15,6 +15,7 @@ import argparse
 
 # The below is only a template on the repo
 # pylint: disable=import-error, no-name-in-module
+from message.job import Message
 from utils.clients.icat_client import ICATClient
 from utils.clients.queue_client import QueueClient
 
@@ -34,7 +35,7 @@ def submit_run(active_mq_client, rb_number, instrument, data_file_location, run_
                                                 run_number=run_number,
                                                 started_by=-1)
 
-    active_mq_client.send('/queue/DataReady', json.dumps(data_dict), priority=1)
+    active_mq_client.send('/queue/DataReady', Message(data_dict), priority=1)
     print("Submitted run: \r\n" + json.dumps(data_dict, indent=1))
 
 

--- a/scripts/manual_operations/tests/test_manual_submission.py
+++ b/scripts/manual_operations/tests/test_manual_submission.py
@@ -11,6 +11,7 @@ import unittest
 import json
 from mock import Mock, patch
 import scripts.manual_operations.manual_submission as ms
+from message.job import Message
 from utils.clients.queue_client import QueueClient
 
 
@@ -23,9 +24,9 @@ class DataFile:
         self.name = df_name
 
 
-def get_json_object(rb_number, instrument, data_file_location, run_number, started_by):
+def get_message_object(rb_number, instrument, data_file_location, run_number, started_by):
     """
-    Return the JSON object that should be sent to DataReady
+    Return the Message object that should be sent to DataReady
     """
     data_dict = {"rb_number": rb_number,
                  "instrument": instrument,
@@ -33,7 +34,7 @@ def get_json_object(rb_number, instrument, data_file_location, run_number, start
                  "run_number": run_number,
                  "facility": "ISIS",
                  "started_by": started_by}
-    return json.dumps(data_dict)
+    return Message(data_dict)
 
 
 # pylint:disable=no-self-use
@@ -66,5 +67,5 @@ class TestManualSubmission(unittest.TestCase):
         """
         active_mq_client = QueueClient()
         ms.submit_run(active_mq_client, "1812345", "GEM", "5454", "nxs")
-        json_obj = get_json_object("1812345", "GEM", "5454", "nxs", -1)
-        send.assert_called_with('/queue/DataReady', json_obj, priority=1)
+        message = get_message_object("1812345", "GEM", "5454", "nxs", -1)
+        send.assert_called_with('/queue/DataReady', message, priority=1)

--- a/systemtests/test_end_to_end.py
+++ b/systemtests/test_end_to_end.py
@@ -15,7 +15,7 @@ import json
 import time
 import shutil
 
-
+from message.job import Message
 from scripts.manual_operations import manual_remove as remove
 
 from utils import service_handling as external
@@ -81,7 +81,7 @@ if os.name != 'nt':
                                                                   run_number=self.run_number,
                                                                   started_by=0)
             self.queue_client.send('/queue/DataReady',
-                                   json.dumps(data_ready_message))
+                                   Message(data_ready_message))
 
             # Get Result from database
             results = self._find_run_in_database()
@@ -112,7 +112,7 @@ if os.name != 'nt':
                                                                   location=file_location,
                                                                   started_by=0)
             self.queue_client.send('/queue/DataReady',
-                                   json.dumps(data_ready_message))
+                                   Message(data_ready_message))
 
             # Get Result from database
             results = self._find_run_in_database()

--- a/utils/clients/queue_client.py
+++ b/utils/clients/queue_client.py
@@ -139,13 +139,14 @@ class QueueClient(AbstractClient):
         """
         Send a message via the open connection to a queue
         :param destination: Queue to send to
-        :param message: contents of the message
+        :param message: Message instance holding the contents of the message
         :param persistent: should to message be persistent
         :param priority: priority rating of the message
         :param delay: time to wait before send
         """
         self.connect()
-        self._connection.send(destination, message,
+        message_content = message.serialize()
+        self._connection.send(destination, message_content,
                               persistent=persistent,
                               priority=priority,
                               delay=delay)

--- a/utils/clients/queue_client.py
+++ b/utils/clients/queue_client.py
@@ -145,8 +145,9 @@ class QueueClient(AbstractClient):
         :param delay: time to wait before send
         """
         self.connect()
-        message_content = message.serialize()
-        self._connection.send(destination, message_content,
+
+        message_as_dict = message.as_dict()
+        self._connection.send(destination, message_as_dict,
                               persistent=persistent,
                               priority=priority,
                               delay=delay)


### PR DESCRIPTION
# DO NOT MERGE please
This PR is being replaced by smaller version
___
### Summary of work
- This PR updates all calls to `QueueClient.send`, specially the `message` argument
- Previously, usages of QueueClient.send populated the message argument with a json.dump of the data to be sent
- This has been replaced with a new instance of the new Message class (#507) across all usages and tests for said usages

#### Other small additional changes:
- **post_process_admin usage of 'send'**
  * During this work I found that post_process_admin was calling send on `QueueClient._connection` (the stomp instance) rather than on QueueClient itself (which inturn calls stomp after connecting and extracting the message content).
  *As such, I updated post_process_admin to use the QueueClient rather than the conneciton
- **queue_processor tests**
  * I also found that a 2 additional usages of `QueueClient.send` which I had not spotted in previous work (#520) in `queue_processor`.
  * I updated these instances to use the Message class like the rest
  * I added a test for 1 of these (c57d6da) but the other usage is in the 100-line `data_ready` method, and so I could not elegantly create a test for this (doing so would be a large task, involving mocking out huge sections of code)

### How to test your work
- Ensure all tests pass
- Code review

### Additional comments
- This is a large PR which spans many important areas of the code base...

Fixes #512


**Before merging ensure the release notes have been updated**