### PR TITLE
Integrate Message class to manual_submission

### DIFF
--- a/message/job.py
+++ b/message/job.py
@@ -8,8 +8,15 @@
 Represents the messages passed between AMQ queues
 """
 import json
+import logging
+
 import attr
 
+from utils.project.static_content import LOG_FORMAT
+from utils.project.structure import get_log_file
+
+logging.basicConfig(filename=get_log_file('job.log'), level=logging.INFO,
+                    format=LOG_FORMAT)
 
 # pylint:disable=too-many-instance-attributes
 @attr.s
@@ -35,12 +42,14 @@ class Message:
     return_message = attr.ib(default=None)
     retry_in = attr.ib(default=None)
 
-    def serialize(self):
+    # Note: added indent to allow pretty-printing
+    #   Although I can work around needing this if not appropriate to have as argument
+    def serialize(self, indent=None):
         """
         Serialized member variables as a json dump
         :return: JSON dump of a dictionary representing the member variables
         """
-        return json.dumps(attr.asdict(self))
+        return json.dumps(attr.asdict(self), indent=indent)
 
     @staticmethod
     def deserialize(serialized_object):
@@ -71,3 +80,8 @@ class Message:
                 if overwrite or self_value is None:
                     # Set the value of the variable on this object accessing it by name
                     setattr(self, key, value)
+            else:
+                warning_message = (f"Unexpected key encountered during Message population: '{key}'."
+                                   f"Skipping this key...")
+                logging.warning(warning_message)
+                print(warning_message)  # Note: for debug purposes

--- a/message/job.py
+++ b/message/job.py
@@ -42,8 +42,6 @@ class Message:
     return_message = attr.ib(default=None)
     retry_in = attr.ib(default=None)
 
-    # Note: added indent to allow pretty-printing
-    #   Although I can work around needing this if not appropriate to have as argument
     def serialize(self, indent=None):
         """
         Serialized member variables as a json dump

--- a/message/job.py
+++ b/message/job.py
@@ -47,6 +47,7 @@ class Message:
     def serialize(self, indent=None):
         """
         Serialized member variables as a json dump
+        :param indent: The indent level passed to json.dumps
         :return: JSON dump of a dictionary representing the member variables
         """
         return json.dumps(attr.asdict(self), indent=indent)

--- a/queue_processors/queue_processor/tests/test_queue_processor.py
+++ b/queue_processors/queue_processor/tests/test_queue_processor.py
@@ -57,7 +57,7 @@ class TestListener(unittest.TestCase):
     def test_construct_and_send_skipped(self):
         # pylint:disable=protected-access
         """
-        Test: _data_dict['message'] is given a value,and the _data_dict is sent via the QueueClient
+        Test: _data_dict['message'] is given a value, and the _data_dict is sent via the QueueClient
         When: _construct_and_send_skipped is called
         """
         mock_client = MagicMock(name="QueueClient")

--- a/queue_processors/queue_processor/tests/test_queue_processor.py
+++ b/queue_processors/queue_processor/tests/test_queue_processor.py
@@ -55,6 +55,7 @@ class TestListener(unittest.TestCase):
         self.reason = "test"
 
     def test_construct_and_send_skipped(self):
+        # pylint:disable=protected-access
         """
         Test: _data_dict['message'] is given a value,and the _data_dict is sent via the QueueClient
         When: _construct_and_send_skipped is called

--- a/scripts/manual_operations/manual_submission.py
+++ b/scripts/manual_operations/manual_submission.py
@@ -17,6 +17,7 @@ import argparse
 # pylint: disable=import-error, no-name-in-module
 from icat import ICATSessionError
 
+from message.job import Message
 from utils.clients.connection_exception import ConnectionException
 from utils.clients.icat_client import ICATClient
 from utils.clients.queue_client import QueueClient
@@ -36,14 +37,13 @@ def submit_run(active_mq_client, rb_number, instrument, data_file_location, run_
         print("ActiveMQ not connected, cannot submit runs")
         return
 
-    data_dict = active_mq_client.serialise_data(rb_number=rb_number,
-                                                instrument=instrument,
-                                                location=data_file_location,
-                                                run_number=run_number,
-                                                started_by=-1)
-
-    active_mq_client.send('/queue/DataReady', json.dumps(data_dict), priority=1)
-    print("Submitted run: \r\n" + json.dumps(data_dict, indent=1))
+    message = Message(rb_number=rb_number,
+                      instrument=instrument,
+                      file_path=data_file_location,
+                      run_number=run_number,
+                      started_by=-1)
+    active_mq_client.send('/queue/DataReady', message, priority=1)
+    print("Submitted run: \r\n" + message.serialize(indent=1))
 
 
 def get_location_and_rb_from_database(database_client, run_number):

--- a/scripts/manual_operations/manual_submission.py
+++ b/scripts/manual_operations/manual_submission.py
@@ -9,7 +9,6 @@ A module for creating and submitting manual submissions to autoreduction
 """
 from __future__ import print_function
 
-import json
 import sys
 import argparse
 

--- a/scripts/manual_operations/tests/test_manual_submission.py
+++ b/scripts/manual_operations/tests/test_manual_submission.py
@@ -14,6 +14,9 @@ import scripts.manual_operations.manual_submission as ms
 
 
 # pylint:disable=no-self-use
+from message.job import Message
+
+
 class TestManualSubmission(unittest.TestCase):
     """
     Test manual_submission.py
@@ -139,13 +142,17 @@ class TestManualSubmission(unittest.TestCase):
         mock_from_icat.assert_not_called()
         mock_from_database.assert_not_called()
 
-    @patch('json.dumps', return_value="json_dump")
-    def test_submit_run(self, mock_json_dump):
+    def test_submit_run(self):
         """
         Test: A given run is submitted to the DataReady queue
         When: submit_run is called with valid arguments
         """
         ms.submit_run(*self.sub_run_args)
+        message = Message(rb_number=self.sub_run_args[1],
+                          instrument=self.sub_run_args[2],
+                          file_path=self.sub_run_args[3],
+                          run_number=self.sub_run_args[4],
+                          started_by=-1)
         self.sub_run_args[0].send.assert_called_with('/queue/DataReady',
-                                                     mock_json_dump.return_value,
+                                                     message,
                                                      priority=1)

--- a/utils/clients/queue_client.py
+++ b/utils/clients/queue_client.py
@@ -128,6 +128,10 @@ class QueueClient(AbstractClient):
         """
         Packs the specified data into a dictionary ready to send to a processor queue
         """
+        # TODO: This probably ought to be removed once we've fully integrated the Message class.
+        #   The danger with this is that we will need to make sure the keys match the
+        #   attribute names in the Message class.
+        #   Better to just give to Message these directly.
         return {'rb_number': rb_number,
                 'instrument': instrument,
                 'data': location,

--- a/utils/clients/queue_client.py
+++ b/utils/clients/queue_client.py
@@ -128,6 +128,7 @@ class QueueClient(AbstractClient):
         """
         Packs the specified data into a dictionary ready to send to a processor queue
         """
+        # pylint:disable=fixme
         # TODO: This probably ought to be removed once we've fully integrated the Message class.
         #   The danger with this is that we will need to make sure the keys match the
         #   attribute names in the Message class.

--- a/utils/clients/queue_client.py
+++ b/utils/clients/queue_client.py
@@ -128,11 +128,6 @@ class QueueClient(AbstractClient):
         """
         Packs the specified data into a dictionary ready to send to a processor queue
         """
-        # pylint:disable=fixme
-        # TODO: This probably ought to be removed once we've fully integrated the Message class.
-        #   The danger with this is that we will need to make sure the keys match the
-        #   attribute names in the Message class.
-        #   Better to just give to Message these directly.
         return {'rb_number': rb_number,
                 'instrument': instrument,
                 'data': location,

--- a/utils/clients/queue_client.py
+++ b/utils/clients/queue_client.py
@@ -13,6 +13,7 @@ import time
 import stomp
 from stomp.exception import ConnectFailedException
 
+from message.job import Message
 from utils.clients.abstract_client import AbstractClient
 from utils.clients.connection_exception import ConnectionException
 from utils.settings import ACTIVEMQ_SETTINGS
@@ -139,13 +140,19 @@ class QueueClient(AbstractClient):
         """
         Send a message via the open connection to a queue
         :param destination: Queue to send to
-        :param message: contents of the message
+        :param message: Message instance OR json dump of dict containing message payload
         :param persistent: should to message be persistent
         :param priority: priority rating of the message
         :param delay: time to wait before send
         """
         self.connect()
-        self._connection.send(destination, message,
+
+        if isinstance(message, Message):
+            message_json_dump = message.serialize()
+        else:
+            message_json_dump = message
+
+        self._connection.send(destination, message_json_dump,
                               persistent=persistent,
                               priority=priority,
                               delay=delay)

--- a/utils/clients/tests/test_queue_client.py
+++ b/utils/clients/tests/test_queue_client.py
@@ -11,6 +11,7 @@ import unittest
 
 from mock import patch, call
 
+from message.job import Message
 from utils.clients.connection_exception import ConnectionException
 from utils.clients.queue_client import QueueClient
 from utils.clients.settings.client_settings_factory import ClientSettingsFactory
@@ -102,16 +103,29 @@ class TestQueueClient(unittest.TestCase):
 
     # pylint:disable=no-self-use
     @patch('stomp.connect.StompConnection11.send')
-    def test_send_data(self, mock_stomp_send):
+    def test_send_with_raw_string(self, mock_stomp_send):
         """
-        Test: send establishes a connection and sends given data using stomp.send
-        When: send is called while a valid connection is not held
+        Test: send sends the given data using stomp.send
+        When: send is called with a string argument for message
         """
         client = QueueClient()
-        client.send('dataready', 'test-message')
+        client.send('dataready', 'raw_json_dump')
         (args, _) = mock_stomp_send.call_args
         self.assertEqual(args[0], 'dataready')
-        self.assertEqual(args[1], 'test-message')
+        self.assertEqual(args[1], 'raw_json_dump')
+
+    @patch('stomp.connect.StompConnection11.send')
+    def test_send_with_message_instance(self, mock_stomp_send):
+        """
+        Test: send sends the given data using stomp.send
+        When: send is called with a Message instance argument for message
+        """
+        client = QueueClient()
+        message = Message(description="test-message")
+        client.send('dataready', message)
+        (args, _) = mock_stomp_send.call_args
+        self.assertEqual(args[0], 'dataready')
+        self.assertEqual(args[1], message.serialize())
 
     @patch('stomp.connect.StompConnection11.ack')
     def test_ack(self, mock_stomp_ack):


### PR DESCRIPTION
### Summary of work
- This PR begins the task of Integrating the Message class into the code base (#512)
- Specifically, this PR does the following:
  * Updates `QueueClient.send` to accommodate Message instances being received as the message argument (as well as json dumps which have been use up until now)
  * Adds logging to the Message class such that when `populate` encountered a key which does not match an attribute, a warning is logged
  * Refactors the `manual_submission` call to `QueueClient.send` to use the Message class instead of a json dump (+ tests)
  * Adds a test for a usage of `QueueClient.send` that was missed.
    * note: there is another usage in the same class but it is within the 100-line `data-ready` method.  Due to it's size, adding tests to this method should be separate chunk of work.

### How to test your work
- Ensure all tests pass
- Code review

Part of #512

**Before merging ensure the release notes have been updated**