### PR TITLE
Replace storage and use of ._connection outside of QueueClient

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ script:
   - py.test systemtests --cov-append
   - cat logs/queue_processor.log
   - cat logs/queue_client.log
-  - cat logs/autoreduction_processor.log
+  - cat logs/autoreductionProcessor.log
 
   # ================ Static Analysis ================= #
   # ToDo: These should all be collapsed into one once autoreduction gets a single code package

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,6 +36,9 @@ script:
 
   - echo "Running System Tests"
   - py.test systemtests --cov-append
+  - echo logs/queue_processor.log
+  - echo logs/queue_client.log
+  - echo logs/autoreduction_processor.log
 
   # ================ Static Analysis ================= #
   # ToDo: These should all be collapsed into one once autoreduction gets a single code package

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,9 +36,9 @@ script:
 
   - echo "Running System Tests"
   - py.test systemtests --cov-append
-  - echo logs/queue_processor.log
-  - echo logs/queue_client.log
-  - echo logs/autoreduction_processor.log
+  - cat logs/queue_processor.log
+  - cat logs/queue_client.log
+  - cat logs/autoreduction_processor.log
 
   # ================ Static Analysis ================= #
   # ToDo: These should all be collapsed into one once autoreduction gets a single code package

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,9 +36,6 @@ script:
 
   - echo "Running System Tests"
   - py.test systemtests --cov-append
-  - cat logs/queue_processor.log
-  - cat logs/queue_client.log
-  - cat logs/autoreductionProcessor.log
 
   # ================ Static Analysis ================= #
   # ToDo: These should all be collapsed into one once autoreduction gets a single code package

--- a/queue_processors/autoreduction_processor/autoreduction_processor.py
+++ b/queue_processors/autoreduction_processor/autoreduction_processor.py
@@ -152,12 +152,12 @@ class Consumer:
         activemq_client = QueueClient()
         activemq_client.connect()
 
-        # activemq_client.subscribe_amq(consumer_name=self.consumer_name,
-        #                               listener=Listener())
-        activemq_client._connection.subscribe(destination='/queue/ReductionPending',
-                                              id='1',
-                                              ack='auto',
-                                              header={'activemq.prefetchSize': '1'})
+        activemq_client.subscribe_amq(consumer_name=self.consumer_name,
+                                      listener=Listener())
+        # activemq_client._connection.subscribe(destination='/queue/ReductionPending',
+        #                                       id='1',
+        #                                       ack='auto',
+        #                                       header={'activemq.prefetchSize': '1'})
 
 
 def main():  # pragma: no cover

--- a/queue_processors/autoreduction_processor/autoreduction_processor.py
+++ b/queue_processors/autoreduction_processor/autoreduction_processor.py
@@ -136,28 +136,17 @@ class Consumer:
     """ Class used to setup the queue listener. """
     def __init__(self):
         """ Initialise consumer. """
-        # Note: The consumer name of autoreduction_processor.py is "queueProcessor"
-        #   while the consumer name of queue_processor.py is "Autoreduction_QueueProcessor".
-        #   This seems like it needs changing...
-        self.consumer_name = "queueProcessor"
+        self.consumer_name = "autoreduction_processor"
 
     def run(self):
         """
         Connect to ActiveMQ via the QueueClient and listen to the
         /ReductionPending queue for messages.
         """
-        # Note: To reviewer - I'm not very similar with subscriptions, consumers, etc.
-        #   I'm not 100% confident I've changed the code below
-        #   (from connection to client) correctly
         activemq_client = QueueClient()
         activemq_client.connect()
-
         activemq_client.subscribe_amq(consumer_name=self.consumer_name,
                                       listener=Listener())
-        # activemq_client._connection.subscribe(destination='/queue/ReductionPending',
-        #                                       id='1',
-        #                                       ack='auto',
-        #                                       header={'activemq.prefetchSize': '1'})
 
 
 def main():  # pragma: no cover

--- a/queue_processors/autoreduction_processor/autoreduction_processor.py
+++ b/queue_processors/autoreduction_processor/autoreduction_processor.py
@@ -147,12 +147,17 @@ class Consumer:
         /ReductionPending queue for messages.
         """
         # Note: To reviewer - I'm not very similar with subscriptions, consumers, etc.
-        #   I'm not confident I've changed the code below (from connection to client) correctly
+        #   I'm not 100% confident I've changed the code below
+        #   (from connection to client) correctly
         activemq_client = QueueClient()
         activemq_client.connect()
 
-        activemq_client.subscribe_amq(consumer_name=self.consumer_name,
-                                      listener=Listener())
+        # activemq_client.subscribe_amq(consumer_name=self.consumer_name,
+        #                               listener=Listener())
+        activemq_client._connection.subscribe(destination='/queue/ReductionPending',
+                                              id='1',
+                                              ack='auto',
+                                              header={'activemq.prefetchSize': '1'})
 
 
 def main():  # pragma: no cover

--- a/queue_processors/autoreduction_processor/autoreduction_processor.py
+++ b/queue_processors/autoreduction_processor/autoreduction_processor.py
@@ -136,24 +136,23 @@ class Consumer:
     """ Class used to setup the queue listener. """
     def __init__(self):
         """ Initialise consumer. """
+        # Note: The consumer name of autoreduction_processor.py is "queueProcessor"
+        #   while the consumer name of queue_processor.py is "Autoreduction_QueueProcessor".
+        #   This seems like it needs changing...
         self.consumer_name = "queueProcessor"
 
-    @staticmethod
-    def run():
+    def run(self):
         """
         Connect to ActiveMQ via the QueueClient and listen to the
         /ReductionPending queue for messages.
         """
+        # Note: To reviewer - I'm not very similar with subscriptions, consumers, etc.
+        #   I'm not confident I've changed the code below (from connection to client) correctly
         activemq_client = QueueClient()
-        connection = activemq_client.connect(listener=Listener())
+        activemq_client.connect()
 
-        # Create event listener
-
-        # connection.set_listener('Autoreduction', listener)
-        connection.subscribe(destination='/queue/ReductionPending',
-                             id='1',
-                             ack='auto',
-                             header={'activemq.prefetchSize': '1'})
+        activemq_client.subscribe_amq(consumer_name=self.consumer_name,
+                                      listener=Listener())
 
 
 def main():  # pragma: no cover

--- a/queue_processors/autoreduction_processor/tests/test_autoreduction_processor.py
+++ b/queue_processors/autoreduction_processor/tests/test_autoreduction_processor.py
@@ -165,7 +165,7 @@ class TestAutoReductionProcessorConsumer(unittest.TestCase):
         self.consumer = Consumer()
 
     def test_init(self):
-        self.assertEqual(self.consumer.consumer_name, 'queueProcessor')
+        self.assertEqual(self.consumer.consumer_name, 'autoreduction_processor')
 
     @patch('utils.clients.queue_client.QueueClient.subscribe_amq')
     @patch('utils.clients.queue_client.QueueClient.connect')

--- a/queue_processors/queue_processor/queue_processor.py
+++ b/queue_processors/queue_processor/queue_processor.py
@@ -470,7 +470,7 @@ def setup_connection(consumer_name):
 
 def main():
     """ Main method. """
-    setup_connection('Autoreduction_QueueProcessor')
+    setup_connection('queue_processor')
 
 
 if __name__ == '__main__':

--- a/utils/clients/queue_client.py
+++ b/utils/clients/queue_client.py
@@ -90,6 +90,8 @@ class QueueClient(AbstractClient):
         """
         Subscribe a listener to the provided queues
         """
+        if not isinstance(queue_list, list):     # TODO: test this
+            queue_list = [queue_list]
         self._connection.set_listener(consumer_name, listener)
         for queue in queue_list:
             self._connection.subscribe(destination=queue,

--- a/utils/clients/queue_client.py
+++ b/utils/clients/queue_client.py
@@ -44,6 +44,8 @@ class QueueClient(AbstractClient):
         if self._connection is None or not self._connection.is_connected():
             self.disconnect()
             return self._create_connection(listener)
+        # TODO: To avoid stomp being used directly in future, I think we should no longer return _connection
+        #   i.e. connection and _create_connection to return void
         return self._connection
 
     def _test_connection(self):

--- a/utils/clients/queue_client.py
+++ b/utils/clients/queue_client.py
@@ -44,9 +44,6 @@ class QueueClient(AbstractClient):
         if self._connection is None or not self._connection.is_connected():
             self.disconnect()
             return self._create_connection(listener)
-        # pylint:disable=fixme
-        # TODO: To avoid stomp being used directly in future, I think we should no longer
-        #  return _connection; i.e. connection and _create_connection should return nothing
         return self._connection
 
     def _test_connection(self):

--- a/utils/clients/queue_client.py
+++ b/utils/clients/queue_client.py
@@ -44,8 +44,9 @@ class QueueClient(AbstractClient):
         if self._connection is None or not self._connection.is_connected():
             self.disconnect()
             return self._create_connection(listener)
-        # TODO: To avoid stomp being used directly in future, I think we should no longer return _connection
-        #   i.e. connection and _create_connection to return void
+        # pylint:disable=fixme
+        # TODO: To avoid stomp being used directly in future, I think we should no longer
+        #  return _connection; i.e. connection and _create_connection should return nothing
         return self._connection
 
     def _test_connection(self):
@@ -90,7 +91,7 @@ class QueueClient(AbstractClient):
         """
         Subscribe a listener to the provided queues
         """
-        if not isinstance(queue_list, list):     # TODO: test this
+        if not isinstance(queue_list, list):
             queue_list = [queue_list]
         self._connection.set_listener(consumer_name, listener)
         for queue in queue_list:

--- a/utils/clients/tests/test_queue_client.py
+++ b/utils/clients/tests/test_queue_client.py
@@ -161,7 +161,7 @@ class TestQueueClient(unittest.TestCase):
 
     @patch('stomp.connect.StompConnection11.set_listener')
     @patch('stomp.connect.StompConnection11.subscribe')
-    def test_subscribe_to_queue(self, mock_stomp_subscribe, mock_stomp_set_listener):
+    def test_subscribe_to_queue_list(self, mock_stomp_subscribe, mock_stomp_set_listener):
         """
         Test: subscribe_queues calls stomp.subscribe_queues twice, once for each queue given
         When: subscribe_queues is called with a queue_list length of 2
@@ -180,3 +180,21 @@ class TestQueueClient(unittest.TestCase):
                                'header': {'activemq.prefetchSize': '1'}}
         mock_stomp_subscribe.assert_has_calls([call(**test_expected_args),
                                                call(**queue_expected_args)])
+
+    @patch('stomp.connect.StompConnection11.set_listener')
+    @patch('stomp.connect.StompConnection11.subscribe')
+    def test_subscribe_to_single_queue(self, mock_stomp_subscribe, mock_stomp_set_listener):
+        """
+        Test: subscribe_queues handles a single queue (non-list)
+        and calls stomp.subscribe_queues for it
+        When: subscribe_queues is called a single queue passed as queue_list
+        """
+        client = QueueClient()
+        client.connect()
+        client.subscribe_queues('single-queue', 'consumer', None, 'auto')
+        mock_stomp_set_listener.assert_called_once_with('consumer', None)
+        test_expected_args = {'destination': 'single-queue',
+                              'id': '1',
+                              'ack': 'auto',
+                              'header': {'activemq.prefetchSize': '1'}}
+        mock_stomp_subscribe.assert_called_once_with(**test_expected_args)


### PR DESCRIPTION
### Summary of work
- This PR adjusts `post_process_admin.py` and `autoreduction_processor.py` to only use QueueClient methods, and not save and use the underlying stomp connection.
- It contains several notes questions of how to develop this PR further.

### How to test your work
- Review and respond to `Note:` comments
- Review code thus far

Fixes #543

**Before merging ensure the release notes have been updated**