### PR TITLE
Remove _connection returns

### DIFF
--- a/utils/clients/queue_client.py
+++ b/utils/clients/queue_client.py
@@ -28,7 +28,7 @@ class QueueClient(AbstractClient):
     """
     Class for client to access messaging service via python
     """
-    def __init__(self, credentials=None, consumer_name='QueueProcessor'):
+    def __init__(self, credentials=None, consumer_name='queue_client'):
         if not credentials:
             credentials = ACTIVEMQ_SETTINGS
         super(QueueClient, self).__init__(credentials)
@@ -40,12 +40,11 @@ class QueueClient(AbstractClient):
     def connect(self, listener=None):
         """
         Create the connection if the connection has not been created
-        :return: connection object
+        :param listener: A ConnectionListener object to assign to the stomp connection, optionally
         """
         if self._connection is None or not self._connection.is_connected():
             self.disconnect()
-            return self._create_connection(listener)
-        return self._connection
+            self._create_connection(listener)
 
     def _test_connection(self):
         if not self._connection.is_connected():
@@ -54,7 +53,7 @@ class QueueClient(AbstractClient):
 
     def disconnect(self):
         """
-        disconnect from queue service
+        Disconnect from queue service
         """
         logging.info("Disconnecting from activemq")
         if self._connection is not None and self._connection.is_connected():
@@ -63,8 +62,8 @@ class QueueClient(AbstractClient):
 
     def _create_connection(self, listener=None):
         """
-        Get the connection to the queuing service
-        :return: The connection to the queue
+        Create the connection to the queuing service and store as self._connection
+        :param listener: A ConnectionListener object to assign to the stomp connection, optionally
         """
         if self._connection is None or not self._connection.is_connected():
             try:
@@ -83,11 +82,14 @@ class QueueClient(AbstractClient):
             # Sleep required to avoid using the service too quickly after establishing connection
             time.sleep(0.5)
             self._connection = connection
-        return self._connection
 
     def subscribe_queues(self, queue_list, consumer_name, listener, ack='auto'):
         """
         Subscribe a listener to the provided queues
+        :param queue_list: The queue(s) to subscribe to as a string or list of strings
+        :param consumer_name: A name to assign to the consumer
+        :param listener: A ConnectionListener object to assign to the stomp connection, optionally
+        :param ack: The acknowledge type
         """
         if not isinstance(queue_list, list):
             queue_list = [queue_list]
@@ -103,6 +105,9 @@ class QueueClient(AbstractClient):
     def subscribe_autoreduce(self, consumer_name, listener, ack='auto'):
         """
         Subscribe to queues including DataReady
+        :param consumer_name: A name to assign to the consumer
+        :param listener: A ConnectionListener object to assign to the stomp connection, optionally
+        :param ack: The acknowledge type
         """
         self.subscribe_queues(queue_list=self.credentials.all_subscriptions,
                               consumer_name=consumer_name,
@@ -112,6 +117,9 @@ class QueueClient(AbstractClient):
     def subscribe_amq(self, consumer_name, listener, ack='auto'):
         """
         Subscribe to ReductionPending
+        :param consumer_name: A name to assign to the consumer
+        :param listener: A ConnectionListener object to assign to the stomp connection, optionally
+        :param ack: The acknowledge type
         """
         self.subscribe_queues(queue_list=self.credentials.reduction_pending,
                               consumer_name=consumer_name,
@@ -121,6 +129,7 @@ class QueueClient(AbstractClient):
     def ack(self, frame):
         """
         Acknowledge receipt of a message
+        :param frame: The identifier of the message
         """
         # pylint:disable=no-value-for-parameter
         self._connection.ack(frame)

--- a/utils/clients/tests/test_queue_client.py
+++ b/utils/clients/tests/test_queue_client.py
@@ -38,7 +38,7 @@ class TestQueueClient(unittest.TestCase):
         client = QueueClient()
         self.assertIsNotNone(client.credentials)
         self.assertIsNone(client._connection)
-        self.assertEqual('QueueProcessor', client._consumer_name)
+        self.assertEqual('queue_client', client._consumer_name)
 
     def test_invalid_init(self):
         """


### PR DESCRIPTION
### Summary of work
- This PR updates QueueClient (QC) to stop returning _connection (the raw stomp connection).
- This is to avoid direct interaction with stomp outside of the QC

### How to test your work
- Code review
- Ensure tests still pass

Fixes #547


**Before merging ensure the release notes have been updated**