### PR TITLE
[DNM] Integrate Message class to post_process_admin

### DIFF
--- a/queue_processors/autoreduction_processor/post_process_admin.py
+++ b/queue_processors/autoreduction_processor/post_process_admin.py
@@ -112,6 +112,7 @@ class PostProcessAdmin:
     # pylint: disable=too-many-instance-attributes
     def __init__(self, data, client):
         logger.debug("json data: %s", prettify(data))
+        # Note: "information" isn't a Message attribute so is not accepted by Message
         data["information"] = socket.gethostname()
         self.data = data
         self.client = client
@@ -198,8 +199,6 @@ class PostProcessAdmin:
                          prettify(self.data))
             message = Message()
             message.populate(self.data)
-            # Note: I don't believe tests cover this, but making tests for such a large method
-            #   would be a sizable, separate issue
             self.client.send(ACTIVEMQ_SETTINGS.reduction_started, message)
 
             # Specify instrument directory
@@ -288,6 +287,7 @@ class PostProcessAdmin:
                 logger.error(traceback.format_exc())
                 raise exp
 
+            # Note: "reduction_data" isn't a Message attribute so is not accepted by Message
             self.data['reduction_data'] = []
             if "message" not in self.data:
                 self.data["message"] = ""
@@ -420,6 +420,7 @@ class PostProcessAdmin:
                 and self.instrument not in MISC["excitation_instruments"]:
             self._remove_directory(copy_destination)
 
+        # Note: "reduction_data" isn't a Message attribute so is not accepted by Message
         self.data['reduction_data'].append(copy_destination)
         logger.info("Moving %s to %s", temp_result_dir, copy_destination)
         try:
@@ -439,6 +440,9 @@ class PostProcessAdmin:
     def log_and_message(self, msg):
         """ Helper function to add text to the outgoing activemq message and to the info logs """
         logger.info(msg)
+        # Note: "message" isn't a Message attribute so is not accepted by Message
+        #   This key is used extensively through this code to store error data and ultimately
+        #   check whether an error has occurred
         if self.data["message"] == "":
             # Only send back first message as there is a char limit
             self.data["message"] = msg
@@ -524,7 +528,7 @@ def main():
                 post_proc.reduce()
 
         except ValueError as exp:
-            # Note: "error" key added here won't be ingested by Message class
+            # Note: "error" isn't a Message attribute so is not accepted by Message
             json_data["error"] = str(exp)
             logger.info("JSON data error: %s", prettify(json_data))
             raise

--- a/queue_processors/autoreduction_processor/tests/test_post_process_admin.py
+++ b/queue_processors/autoreduction_processor/tests/test_post_process_admin.py
@@ -41,6 +41,8 @@ class TestPostProcessAdminHelpers(unittest.TestCase):
 
 
 class TestPostProcessAdmin(unittest.TestCase):
+    # pylint:disable=too-many-public-methods
+    DIR = "queue_processors.autoreduction_processor"
 
     def setUp(self):
         # Note: I've seen 'data' being used as a key for the data file path in
@@ -81,11 +83,11 @@ class TestPostProcessAdmin(unittest.TestCase):
         location = PostProcessAdmin._reduction_script_location('WISH')
         self.assertEqual(location, MISC['scripts_directory'] % 'WISH')
 
-    @patch('queue_processors.autoreduction_processor.post_process_admin.'
+    @patch(DIR+'.post_process_admin.'
            'PostProcessAdmin._remove_directory')
-    @patch('queue_processors.autoreduction_processor.post_process_admin.'
+    @patch(DIR+'.post_process_admin.'
            'PostProcessAdmin._copy_tree')
-    @patch('queue_processors.autoreduction_processor.autoreduction_logging_setup.logger.info')
+    @patch(DIR+'.autoreduction_logging_setup.logger.info')
     def test_copy_temp_dir(self, mock_logger, mock_copy, mock_remove):
         result_dir = mkdtemp()
         copy_dir = mkdtemp()
@@ -99,9 +101,9 @@ class TestPostProcessAdmin(unittest.TestCase):
         shutil.rmtree(result_dir)
         shutil.rmtree(copy_dir)
 
-    @patch('queue_processors.autoreduction_processor.post_process_admin.'
+    @patch(DIR+'.post_process_admin.'
            'PostProcessAdmin._copy_tree')
-    @patch('queue_processors.autoreduction_processor.autoreduction_logging_setup.logger.info')
+    @patch(DIR+'.autoreduction_logging_setup.logger.info')
     def test_copy_temp_dir_with_excitation(self, _, mock_copy):
         result_dir = mkdtemp()
         ppa = PostProcessAdmin(self.data, None)
@@ -111,11 +113,11 @@ class TestPostProcessAdmin(unittest.TestCase):
         mock_copy.assert_called_once_with(result_dir, 'copy-dir')
         shutil.rmtree(result_dir)
 
-    @patch('queue_processors.autoreduction_processor.post_process_admin.'
+    @patch(DIR+'.post_process_admin.'
            'PostProcessAdmin._copy_tree')
-    @patch('queue_processors.autoreduction_processor.post_process_admin.PostProcessAdmin.'
+    @patch(DIR+'.post_process_admin.PostProcessAdmin.'
            'log_and_message')
-    @patch('queue_processors.autoreduction_processor.autoreduction_logging_setup.logger.info')
+    @patch(DIR+'.autoreduction_logging_setup.logger.info')
     def test_copy_temp_dir_with_error(self, _, mock_log_and_msg, mock_copy):
         # pylint:disable=unused-argument
         def raise_runtime(arg1, arg2):  # pragma : no cover
@@ -130,7 +132,7 @@ class TestPostProcessAdmin(unittest.TestCase):
                                                                                 'test'))
         shutil.rmtree(result_dir)
 
-    @patch('queue_processors.autoreduction_processor.autoreduction_logging_setup.logger.info')
+    @patch(DIR+'.autoreduction_logging_setup.logger.info')
     def test_send_error_and_log(self, mock_logger):
         activemq_client_mock = Mock()
         ppa = PostProcessAdmin(self.data, activemq_client_mock)
@@ -143,7 +145,7 @@ class TestPostProcessAdmin(unittest.TestCase):
                                                           message)
 
     @patch('shutil.rmtree')
-    @patch('queue_processors.autoreduction_processor.autoreduction_logging_setup.logger.info')
+    @patch(DIR+'.autoreduction_logging_setup.logger.info')
     def test_delete_temp_dir_valid(self, mock_logger, mock_remove_dir):
         temp_dir = mkdtemp()
         PostProcessAdmin.delete_temp_directory(temp_dir)
@@ -153,7 +155,7 @@ class TestPostProcessAdmin(unittest.TestCase):
         shutil.rmtree(temp_dir)
 
     @patch('shutil.rmtree')
-    @patch('queue_processors.autoreduction_processor.autoreduction_logging_setup.logger.info')
+    @patch(DIR+'.autoreduction_logging_setup.logger.info')
     def test_delete_temp_dir_invalid(self, mock_logger, mock_remove_dir):
         def raise_runtime():  # pragma: no cover
             raise RuntimeError('test')
@@ -163,7 +165,7 @@ class TestPostProcessAdmin(unittest.TestCase):
                                       call('Unable to remove temporary directory - %s',
                                            'not-a-file-path.test')])
 
-    @patch('queue_processors.autoreduction_processor.autoreduction_logging_setup.logger.info')
+    @patch(DIR+'.autoreduction_logging_setup.logger.info')
     def test_empty_log_and_message(self, mock_logger):
         ppa = PostProcessAdmin(self.data, None)
         ppa.data['message'] = ''
@@ -171,7 +173,7 @@ class TestPostProcessAdmin(unittest.TestCase):
         self.assertEqual(ppa.data['message'], 'test')
         mock_logger.assert_called_once_with('test')
 
-    @patch('queue_processors.autoreduction_processor.autoreduction_logging_setup.logger.info')
+    @patch(DIR+'.autoreduction_logging_setup.logger.info')
     def test_load_and_message_with_preexisting_message(self, mock_logger):
         ppa = PostProcessAdmin(self.data, None)
         ppa.data['message'] = 'Old message'
@@ -214,9 +216,9 @@ class TestPostProcessAdmin(unittest.TestCase):
         ppa._remove_directory(directory_to_remove)
         self.assertFalse(os.path.exists(directory_to_remove))
 
-    @patch('queue_processors.autoreduction_processor.post_process_admin.windows_to_linux_path',
+    @patch(DIR+'.post_process_admin.windows_to_linux_path',
            return_value='path')
-    @patch('queue_processors.autoreduction_processor.post_process_admin.PostProcessAdmin.reduce')
+    @patch(DIR+'.post_process_admin.PostProcessAdmin.reduce')
     @patch('utils.clients.queue_client.QueueClient.connect')
     @patch('utils.clients.queue_client.QueueClient.__init__', return_value=None)
     def test_main(self, mock_init, mock_connect, mock_reduce, _):
@@ -230,7 +232,7 @@ class TestPostProcessAdmin(unittest.TestCase):
         mock_connect.assert_called_once()
         mock_reduce.assert_called_once()
 
-    @patch('queue_processors.autoreduction_processor.post_process_admin.windows_to_linux_path',
+    @patch(DIR+'.post_process_admin.windows_to_linux_path',
            return_value='path')
     @patch('utils.clients.queue_client.QueueClient.connect')
     @patch('utils.clients.queue_client.QueueClient.__init__', return_value=None)
@@ -250,13 +252,13 @@ class TestPostProcessAdmin(unittest.TestCase):
 
     @patch('os.makedirs')
     @patch('os.access', return_value=True)
-    @patch('queue_processors.autoreduction_processor.post_process_admin.channels_redirected')
+    @patch(DIR+'.post_process_admin.channels_redirected')
     @patch('importlib.util.spec_from_file_location')
-    @patch('queue_processors.autoreduction_processor.timeout.TimeOut.__enter__', return_value=None)
-    @patch('queue_processors.autoreduction_processor.timeout.TimeOut.__exit__', return_value=None)
-    @patch('queue_processors.autoreduction_processor.post_process_admin.PostProcessAdmin.copy_temp_directory')
-    @patch('queue_processors.autoreduction_processor.post_process_admin.PostProcessAdmin.log_and_message')
-    @patch('queue_processors.autoreduction_processor.post_process_admin.windows_to_linux_path',
+    @patch(DIR+'.timeout.TimeOut.__enter__', return_value=None)
+    @patch(DIR+'.timeout.TimeOut.__exit__', return_value=None)
+    @patch(DIR+'.post_process_admin.PostProcessAdmin.copy_temp_directory')
+    @patch(DIR+'.post_process_admin.PostProcessAdmin.log_and_message')
+    @patch(DIR+'.post_process_admin.windows_to_linux_path',
            return_value='path')
     @patch('utils.clients.queue_client.QueueClient.connect')
     @patch('utils.clients.queue_client.QueueClient.__init__', return_value=None)
@@ -281,11 +283,11 @@ class TestPostProcessAdmin(unittest.TestCase):
         self.assertEqual(ACTIVEMQ_SETTINGS.reduction_complete, args[0])
         self.assertEqual(message, actual_message_without_logs)
 
-    @patch('queue_processors.autoreduction_processor.post_process_admin.prettify',
+    @patch(DIR+'.post_process_admin.prettify',
            return_value='test')
     @patch('sys.exit')
-    @patch('queue_processors.autoreduction_processor.autoreduction_logging_setup.logger.info')
-    @patch('queue_processors.autoreduction_processor.post_process_admin.PostProcessAdmin.__init__',
+    @patch(DIR+'.autoreduction_logging_setup.logger.info')
+    @patch(DIR+'.post_process_admin.PostProcessAdmin.__init__',
            return_value=None)
     @patch('utils.clients.queue_client.QueueClient.send')
     @patch('utils.clients.queue_client.QueueClient.connect')
@@ -313,8 +315,8 @@ class TestPostProcessAdmin(unittest.TestCase):
                                           message)
 
     @patch('sys.exit')
-    @patch('queue_processors.autoreduction_processor.autoreduction_logging_setup.logger.info')
-    @patch('queue_processors.autoreduction_processor.post_process_admin.PostProcessAdmin.__init__',
+    @patch(DIR+'.autoreduction_logging_setup.logger.info')
+    @patch(DIR+'.post_process_admin.PostProcessAdmin.__init__',
            return_value=None)
     @patch('utils.clients.queue_client.QueueClient.send')
     @patch('utils.clients.queue_client.QueueClient.connect')

--- a/queue_processors/autoreduction_processor/tests/test_post_process_admin.py
+++ b/queue_processors/autoreduction_processor/tests/test_post_process_admin.py
@@ -230,6 +230,57 @@ class TestPostProcessAdmin(unittest.TestCase):
         mock_connect.assert_called_once()
         mock_reduce.assert_called_once()
 
+    @patch('queue_processors.autoreduction_processor.post_process_admin.windows_to_linux_path',
+           return_value='path')
+    @patch('utils.clients.queue_client.QueueClient.connect')
+    @patch('utils.clients.queue_client.QueueClient.__init__', return_value=None)
+    @patch('utils.clients.queue_client.QueueClient.send')
+    def test_reduce_sends_reduction_started_message(self, mock_send, *_):
+        """
+        Test: A message is sent to the reduction started queue
+        When: The reduce method is called
+        """
+        sys.argv = ['', '/queue/ReductionPending', json.dumps(self.data)]
+        main()
+
+        message = Message()
+        message.populate(self.data)
+        print(f"call args list: {mock_send.call_args_list}")
+        mock_send.assert_any_call(ACTIVEMQ_SETTINGS.reduction_started, message)
+
+    @patch('os.makedirs')
+    @patch('os.access', return_value=True)
+    @patch('queue_processors.autoreduction_processor.post_process_admin.channels_redirected')
+    @patch('importlib.util.spec_from_file_location')
+    @patch('queue_processors.autoreduction_processor.timeout.TimeOut.__enter__', return_value=None)
+    @patch('queue_processors.autoreduction_processor.timeout.TimeOut.__exit__', return_value=None)
+    @patch('queue_processors.autoreduction_processor.post_process_admin.PostProcessAdmin.copy_temp_directory')
+    @patch('queue_processors.autoreduction_processor.post_process_admin.PostProcessAdmin.log_and_message')
+    @patch('queue_processors.autoreduction_processor.post_process_admin.windows_to_linux_path',
+           return_value='path')
+    @patch('utils.clients.queue_client.QueueClient.connect')
+    @patch('utils.clients.queue_client.QueueClient.__init__', return_value=None)
+    @patch('utils.clients.queue_client.QueueClient.send')
+    def test_reduce_sends_reduction_complete_message(self, mock_send, *_):
+        """
+        Test: A message is sent to the reduction complete queue
+        When: No errors occur during the reduce method
+        Note: This test does not cover the contents of the admin_log or reduction_logs
+        """
+        sys.argv = ['', '/queue/ReductionPending', json.dumps(self.data)]
+        main()
+
+        (args, _) = mock_send.call_args
+        actual_message_without_logs = args[1]
+        actual_message_without_logs.admin_log = None
+        actual_message_without_logs.reduction_log = None
+
+        message = Message()
+        message.populate(self.data)
+
+        self.assertEqual(ACTIVEMQ_SETTINGS.reduction_complete, args[0])
+        self.assertEqual(message, actual_message_without_logs)
+
     @patch('queue_processors.autoreduction_processor.post_process_admin.prettify',
            return_value='test')
     @patch('sys.exit')

--- a/systemtests/test_end_to_end.py
+++ b/systemtests/test_end_to_end.py
@@ -15,7 +15,7 @@ import json
 import time
 import shutil
 
-
+from message.job import Message
 from scripts.manual_operations import manual_remove as remove
 
 from utils import service_handling as external
@@ -75,13 +75,13 @@ if os.name != 'nt':
                                                         vars_script='')
 
             # Create and send json message to ActiveMQ
-            data_ready_message = self.queue_client.serialise_data(rb_number=self.rb_number,
-                                                                  instrument=self.instrument,
-                                                                  location=file_location,
-                                                                  run_number=self.run_number,
-                                                                  started_by=0)
+            data_ready_message = Message(rb_number=self.rb_number,
+                                         instrument=self.instrument,
+                                         file_path=file_location,
+                                         run_number=self.run_number,
+                                         started_by=0)
             self.queue_client.send('/queue/DataReady',
-                                   json.dumps(data_ready_message))
+                                   data_ready_message)
 
             # Get Result from database
             results = self._find_run_in_database()
@@ -106,13 +106,13 @@ if os.name != 'nt':
                                                         vars_script='')
 
             # Create and send json message to ActiveMQ
-            data_ready_message = self.queue_client.serialise_data(instrument=self.instrument,
-                                                                  rb_number=self.rb_number,
-                                                                  run_number=self.run_number,
-                                                                  location=file_location,
-                                                                  started_by=0)
+            data_ready_message = Message(rb_number=self.rb_number,
+                                         instrument=self.instrument,
+                                         file_path=file_location,
+                                         run_number=self.run_number,
+                                         started_by=0)
             self.queue_client.send('/queue/DataReady',
-                                   json.dumps(data_ready_message))
+                                   data_ready_message)
 
             # Get Result from database
             results = self._find_run_in_database()

--- a/utils/clients/queue_client.py
+++ b/utils/clients/queue_client.py
@@ -141,7 +141,7 @@ class QueueClient(AbstractClient):
         """
         return {'rb_number': rb_number,
                 'instrument': instrument,
-                'data': location,
+                'file_path': location,
                 'run_number': run_number,
                 'facility': 'ISIS',
                 'started_by': started_by}


### PR DESCRIPTION
### Summary of work
> - This PR continues integrates the Message class  into `run_detection`
> - This is done by replacing the data dictionary used to pass run data with a Message instance
> - Tests are refactored to accommodate the change

### How to test your work
- Address `Note` comments
- Ensure all tests pass
- Code review

### Additional comments
- I noticed that not all of instances of `QueueClient` are fully tested, due in this case to the complexity of certain methods.
  * Before merging, I'd like to look into improving this test coverage

Part of #512

**Before merging ensure the release notes have been updated**