### PR TITLE
Replace json.dump with Message in test_end_to_end

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,6 +36,9 @@ script:
 
   - echo "Running System Tests"
   - py.test systemtests --cov-append
+  - cat logs/queue_processor.log
+  - cat logs/queue_client.log
+  - cat logs/autoreduction_processor.log
 
   # ================ Static Analysis ================= #
   # ToDo: These should all be collapsed into one once autoreduction gets a single code package

--- a/monitors/tests/test_run_detection.py
+++ b/monitors/tests/test_run_detection.py
@@ -159,7 +159,6 @@ class TestRunDetection(unittest.TestCase):
     def test_submit_run_invalid_nexus(self, read_rb_mock, isfile_mock):
         client = Mock()
         client.send = Mock(return_value=None)
-        client.serialise_data = Mock(return_value=RUN_DATA['summary_rb_number'])
 
         inst_mon = InstrumentMonitor(client, 'WISH')
         inst_mon.data_dir = '/my/data/dir'

--- a/queue_processors/autoreduction_processor/autoreduction_logging_setup.py
+++ b/queue_processors/autoreduction_processor/autoreduction_logging_setup.py
@@ -11,7 +11,7 @@ import os
 from utils.project.structure import get_project_root
 
 LOGGING_LEVEL = logging.INFO
-LOGGING_LOC = os.path.join(get_project_root(), 'logs', 'autoreductionProcessor.log')
+LOGGING_LOC = os.path.join(get_project_root(), 'logs', 'autoreduction_processor.log')
 
 logger = logging.getLogger('AutoreductionProcessor')
 logger.setLevel(LOGGING_LEVEL)

--- a/queue_processors/autoreduction_processor/post_process_admin.py
+++ b/queue_processors/autoreduction_processor/post_process_admin.py
@@ -119,7 +119,7 @@ class PostProcessAdmin:
         self.admin_log_stream = io.StringIO()
 
         try:
-            self.data_file = windows_to_linux_path(self.validate_input('data'),
+            self.data_file = windows_to_linux_path(self.validate_input('file_path'),
                                                    MISC["temp_root_directory"])
             self.facility = self.validate_input('facility')
             self.instrument = self.validate_input('instrument').upper()

--- a/queue_processors/autoreduction_processor/tests/test_post_process_admin.py
+++ b/queue_processors/autoreduction_processor/tests/test_post_process_admin.py
@@ -42,7 +42,7 @@ class TestPostProcessAdminHelpers(unittest.TestCase):
 class TestPostProcessAdmin(unittest.TestCase):
 
     def setUp(self):
-        self.data = {'data': '\\\\isis\\inst$\\data.nxs',
+        self.data = {'file_path': '\\\\isis\\inst$\\data.nxs',
                      'facility': 'ISIS',
                      'instrument': 'GEM',
                      'rb_number': '1234',

--- a/queue_processors/queue_processor/queue_processor.py
+++ b/queue_processors/queue_processor/queue_processor.py
@@ -187,7 +187,7 @@ class Listener:
         # Create a new data location entry which has a foreign key linking it to the current
         # reduction run. The file path itself will point to a datafile
         # (e.g. "\isis\inst$\NDXWISH\Instrument\data\cycle_17_1\WISH00038774.nxs")
-        data_location = DataLocation(file_path=self._data_dict['data'],
+        data_location = DataLocation(file_path=self._data_dict['file_path'],
                                      reduction_run_id=reduction_run.id) # pylint: disable=no-member
         session.add(data_location)
         session.commit()

--- a/systemtests/test_end_to_end.py
+++ b/systemtests/test_end_to_end.py
@@ -15,7 +15,7 @@ import json
 import time
 import shutil
 
-
+from message.job import Message
 from scripts.manual_operations import manual_remove as remove
 
 from utils import service_handling as external
@@ -75,13 +75,13 @@ if os.name != 'nt':
                                                         vars_script='')
 
             # Create and send json message to ActiveMQ
-            data_ready_message = self.queue_client.serialise_data(rb_number=self.rb_number,
-                                                                  instrument=self.instrument,
-                                                                  location=file_location,
-                                                                  run_number=self.run_number,
-                                                                  started_by=0)
+            data_ready_message = Message(rb_number=self.rb_number,
+                                         instrument=self.instrument,
+                                         file_path=file_location,
+                                         run_number=self.run_number,
+                                         started_by=0)
             self.queue_client.send('/queue/DataReady',
-                                   json.dumps(data_ready_message))
+                                   data_ready_message)
 
             # Get Result from database
             results = self._find_run_in_database()
@@ -106,13 +106,13 @@ if os.name != 'nt':
                                                         vars_script='')
 
             # Create and send json message to ActiveMQ
-            data_ready_message = self.queue_client.serialise_data(instrument=self.instrument,
-                                                                  rb_number=self.rb_number,
-                                                                  run_number=self.run_number,
-                                                                  location=file_location,
-                                                                  started_by=0)
+            data_ready_message = Message(rb_number=self.rb_number,
+                                         instrument=self.instrument,
+                                         file_path=file_location,
+                                         run_number=self.run_number,
+                                         started_by=0)
             self.queue_client.send('/queue/DataReady',
-                                   json.dumps(data_ready_message))
+                                   data_ready_message)
 
             # Get Result from database
             results = self._find_run_in_database()

--- a/utils/clients/queue_client.py
+++ b/utils/clients/queue_client.py
@@ -134,17 +134,17 @@ class QueueClient(AbstractClient):
         # pylint:disable=no-value-for-parameter
         self._connection.ack(frame)
 
-    @staticmethod
-    def serialise_data(rb_number, instrument, location, run_number, started_by):
-        """
-        Packs the specified data into a dictionary ready to send to a processor queue
-        """
-        return {'rb_number': rb_number,
-                'instrument': instrument,
-                'data': location,
-                'run_number': run_number,
-                'facility': 'ISIS',
-                'started_by': started_by}
+    # @staticmethod
+    # def serialise_data(rb_number, instrument, location, run_number, started_by):
+    #     """
+    #     Packs the specified data into a dictionary ready to send to a processor queue
+    #     """
+    #     return {'rb_number': rb_number,
+    #             'instrument': instrument,
+    #             'data': location,
+    #             'run_number': run_number,
+    #             'facility': 'ISIS',
+    #             'started_by': started_by}
 
     # pylint:disable=too-many-arguments
     def send(self, destination, message, persistent='true', priority='4', delay=None):

--- a/utils/clients/tests/test_queue_client.py
+++ b/utils/clients/tests/test_queue_client.py
@@ -87,19 +87,19 @@ class TestQueueClient(unittest.TestCase):
         client.disconnect()
         self.assertIsNone(client._connection)
 
-    def test_serialise_message(self):
-        """
-        Test: Data is correctly serialised
-        When: serialise_data is called with valid arguments
-        """
-        client = QueueClient()
-        data = client.serialise_data('123', 'WISH', 'file/path', '001', 0)
-        self.assertEqual(data['rb_number'], '123')
-        self.assertEqual(data['instrument'], 'WISH')
-        self.assertEqual(data['data'], 'file/path')
-        self.assertEqual(data['run_number'], '001')
-        self.assertEqual(data['facility'], 'ISIS')
-        self.assertEqual(data['started_by'], 0)
+    # def test_serialise_message(self):
+    #     """
+    #     Test: Data is correctly serialised
+    #     When: serialise_data is called with valid arguments
+    #     """
+    #     client = QueueClient()
+    #     data = client.serialise_data('123', 'WISH', 'file/path', '001', 0)
+    #     self.assertEqual(data['rb_number'], '123')
+    #     self.assertEqual(data['instrument'], 'WISH')
+    #     self.assertEqual(data['data'], 'file/path')
+    #     self.assertEqual(data['run_number'], '001')
+    #     self.assertEqual(data['facility'], 'ISIS')
+    #     self.assertEqual(data['started_by'], 0)
 
     # pylint:disable=no-self-use
     @patch('stomp.connect.StompConnection11.send')


### PR DESCRIPTION
### Summary of work
> - This PR continues integrates the Message class  into `run_detection`
> - This is done by replacing the data dictionary used to pass run data with a Message instance
> - Tests are refactored to accommodate the change

### How to test your work
- Ensure all tests pass
- Code review

Part of #512

**Before merging ensure the release notes have been updated**