### PR TITLE
Change reductionlocation to datalocation

### DIFF
--- a/scripts/manual_operations/manual_submission.py
+++ b/scripts/manual_operations/manual_submission.py
@@ -60,7 +60,7 @@ def get_location_and_rb_from_database(database_client, run_number):
     db_connection = database_client.connect()
     location_query = f"""
                     SELECT file_path
-                    FROM reduction_viewer_reductionlocation
+                    FROM reduction_viewer_datalocation
                     WHERE reduction_run_id = {run_number}
                     """
     location_result = db_connection.execute(location_query).fetchall()


### PR DESCRIPTION
### Summary of work
- This PR simply changes manual_submission to take `file_path` (i.e. the path to the data to be reduced) from datalocation (as it should be) rather than reductionlocation.

### How to test your work
- Ensure reductionlocation is replaced with datalocation
- Check that jobs submitted after being retrieved from the database run as expected

Fixes #562

**Before merging ensure the release notes have been updated**