### PR TITLE
Add 'get filenames matching regex' method to SFTPClient

### DIFF
--- a/utils/clients/sftp_client.py
+++ b/utils/clients/sftp_client.py
@@ -9,6 +9,8 @@ Client class for retrieving files via SFTP from servers (e.g. CEPH)
 """
 import os.path
 import logging
+import re
+
 import pysftp
 from utils.clients.abstract_client import AbstractClient
 from utils.clients.connection_exception import ConnectionException
@@ -19,8 +21,6 @@ from utils.project.static_content import LOG_FORMAT
 
 logging.basicConfig(filename=get_log_file('sftp_client.log'), level=logging.INFO,
                     format=LOG_FORMAT)
-
-# TODO: extend tests
 
 class SFTPClient(AbstractClient):
     """
@@ -104,16 +104,23 @@ class SFTPClient(AbstractClient):
             raise RuntimeError("The local_file_path is a directory. "
                                "Please ensure the local_path includes a full filename.")
 
-    def get_filenames(self, server_dir_path):
+    def get_filenames(self, server_dir_path, regex=".*"):
         """
+        Gets filenames from a given server directory which meet a regular expression
         :param server_dir_path: The server directory to get filenames from.
-        :return: A list of files within the given server directory.
+        :param regex: A regular expression for the files to meet (default allows for all files).
+        :return: A list of filenames which match the regex within the server directory.
         """
         self._server_path_check(server_dir_path)
 
-        return self._connection.listdir()
+        filenames = self._connection.listdir()
+        matches = []
 
+        for name in filenames:
+            if re.match(regex, name) is not None:
+                matches.append(name)
 
+        return matches
 
     def _server_path_check(self, server_path):
         """

--- a/utils/clients/tests/test_sftp_client.py
+++ b/utils/clients/tests/test_sftp_client.py
@@ -24,7 +24,7 @@ class TestSFTPClient(unittest.TestCase):
     def setUp(self):
         self.valid_argument = "valid"
         self.filenames = ["textfile.txt", "nexusfile.nxs", "image.png"]
-        self.textfile_regex = ".*\.txt"
+        self.textfile_regex = r".*\.txt"
 
     def is_argument_valid(self, value):
         """ Checks whether the value is a valid argument
@@ -77,11 +77,19 @@ class TestSFTPClient(unittest.TestCase):
         self.assertTrue(client._test_connection())
 
     def test_server_path_check_with_invalid_path(self):
+        """
+        Test: A RuntimeError is raised
+        When: _server_path_check is called with an invalid server path
+        """
         client = self.create_mocked_connection_client()
         with self.assertRaises(RuntimeError):
             client._server_path_check(server_path="invalid")
 
     def test_server_path_check_with_valid_path(self):
+        """
+        Test: pysftp.Connection.exists is called, but no errors are raised
+        When: _server_path_check is called with a valid server path
+        """
         client = self.create_mocked_connection_client()
         client._server_path_check(server_path=self.valid_argument)
         client._connection.exists.assert_called_with(self.valid_argument)
@@ -127,7 +135,8 @@ class TestSFTPClient(unittest.TestCase):
     def test_server_file_path_and_local_file_path_are_valid(self):
         """
         Test: retrieve finds a file from a given server_file_path and puts a copy in local_file_path
-        When: retrieve is called with a valid server_file_path (i.e. a path which point to a real file)
+        When: retrieve is called with a valid server_file_path
+        (i.e. a path which point to a real file)
         and a valid local_file_path (i.e. a local path which exists)
         """
         client = self.create_mocked_connection_client()


### PR DESCRIPTION
### Summary of work
- This PR adds a `get_filenames` method to `sftp_client` which returns a list of filenames within a given SFTP-server directory which match a given regex
- It additionally refactors server path checking into it's own method (since it is now used across `retrieve` and this new method)
- Lastly, it changes parameter names for paths to be more explicit about the type of path expected (file or directory)
- **Note:** regex' must match the [python re lib specification](https://docs.python.org/2/library/re.html)

### How to test your work
- Check that `get_filenames` returns a list of filenames which match the given regex

Fixes #565


**Before merging ensure the release notes have been updated**