### PR TITLE
Refactor ppa 'do not overwrite' handling

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,9 +33,6 @@ script:
   # ================ Functional tests =============== #
   - echo "Running Unit tests"
   - py.test --ignore=systemtests --cov=build --cov=monitors --cov=queue_processors --cov=scripts --cov=utils --cov=WebApp/autoreduce_webapp --cov=docker_reduction --cov=paths --cov=plotting --cov=message --cov=model
-  - cat logs/queue_processor.log
-  - cat logs/queue_client.log
-  - cat logs/autoreduction_processor.log
 
   - echo "Running System Tests"
   - py.test systemtests --cov-append

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ script:
   - py.test --ignore=systemtests --cov=build --cov=monitors --cov=queue_processors --cov=scripts --cov=utils --cov=WebApp/autoreduce_webapp --cov=docker_reduction --cov=paths --cov=plotting --cov=message --cov=model
   - cat logs/queue_processor.log
   - cat logs/queue_client.log
-  - cat logs/autoreductionProcessor.log
+  - cat logs/autoreduction_processor.log
 
   - echo "Running System Tests"
   - py.test systemtests --cov-append

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,9 @@ script:
   # ================ Functional tests =============== #
   - echo "Running Unit tests"
   - py.test --ignore=systemtests --cov=build --cov=monitors --cov=queue_processors --cov=scripts --cov=utils --cov=WebApp/autoreduce_webapp --cov=docker_reduction --cov=paths --cov=plotting --cov=message --cov=model
+  - cat logs/queue_processor.log
+  - cat logs/queue_client.log
+  - cat logs/autoreductionProcessor.log
 
   - echo "Running System Tests"
   - py.test systemtests --cov-append

--- a/WebApp/autoreduce_webapp/reduction_viewer/models.py
+++ b/WebApp/autoreduce_webapp/reduction_viewer/models.py
@@ -62,7 +62,7 @@ class ReductionRun(models.Model):
     # Text fields
     admin_log = models.TextField(blank=True)
     graph = models.TextField(null=True, blank=True)
-    message = models.TextField(blank=True)
+    message = models.TextField(null=True, blank=True)
     reduction_log = models.TextField(blank=True)
     # Scripts should be 100,000 chars or less. The DB supports up to 4GB strings here
     script = models.TextField(blank=False, validators=[MaxLengthValidator(100000)])

--- a/message/job.py
+++ b/message/job.py
@@ -31,7 +31,7 @@ class Message:
     instrument = attr.ib(default=None)
     rb_number = attr.ib(default=None)
     started_by = attr.ib(default=None)
-    file_path = attr.ib(default=None)
+    data = attr.ib(default=None)
     overwrite = attr.ib(default=None)
     run_version = attr.ib(default=None)
     job_id = attr.ib(default=None)
@@ -39,8 +39,13 @@ class Message:
     reduction_arguments = attr.ib(default=None)
     reduction_log = attr.ib(default=None)
     admin_log = attr.ib(default=None)
-    return_message = attr.ib(default=None)
+    message = attr.ib(default=None)
     retry_in = attr.ib(default=None)
+
+    reduction_data = attr.ib(default=None)
+    run_description = attr.ib(default=None)
+    error = attr.ib(default=None)
+
 
     def serialize(self, indent=None):
         """

--- a/message/job.py
+++ b/message/job.py
@@ -25,8 +25,6 @@ class Message:
     A class that represents an AMQ Message.
     Messages can be serialized and deserialized for sending messages to and from AMQ
     """
-    # Note: Attributes default to None, but when sent to the DB, they cannot be null.
-    #   Perhaps could add check in QueueClient before sending, or change the defaults here.
     description = attr.ib(default=None)
     facility = attr.ib(default=None)
     run_number = attr.ib(default=None)

--- a/message/job.py
+++ b/message/job.py
@@ -25,6 +25,8 @@ class Message:
     A class that represents an AMQ Message.
     Messages can be serialized and deserialized for sending messages to and from AMQ
     """
+    # Note: Attributes default to None, but when sent to the DB, they cannot be null.
+    #   Perhaps could add check in QueueClient before sending, or change the defaults here.
     description = attr.ib(default=None)
     facility = attr.ib(default=None)
     run_number = attr.ib(default=None)

--- a/message/tests/test_job.py
+++ b/message/tests/test_job.py
@@ -57,7 +57,7 @@ class TestMessage(unittest.TestCase):
                           'instrument': None,
                           'rb_number': rb_number,
                           'started_by': None,
-                          'file_path': None,
+                          'data': None,
                           'overwrite': None,
                           'run_version': None,
                           'job_id': None,
@@ -65,8 +65,12 @@ class TestMessage(unittest.TestCase):
                           'reduction_arguments': None,
                           'reduction_log': None,
                           'admin_log': None,
-                          'return_message': None,
-                          'retry_in': None}
+                          'message': None,
+                          'retry_in': None,
+                          'reduction_data': None,
+                          'run_description': None,
+                          'error': None
+                          }
         return populated_msg, populated_dict
 
     def test_init(self):
@@ -81,7 +85,7 @@ class TestMessage(unittest.TestCase):
         self.assertIsNone(empty_msg.instrument)
         self.assertIsNone(empty_msg.rb_number)
         self.assertIsNone(empty_msg.started_by)
-        self.assertIsNone(empty_msg.file_path)
+        self.assertIsNone(empty_msg.data)
         self.assertIsNone(empty_msg.overwrite)
         self.assertIsNone(empty_msg.run_version)
         self.assertIsNone(empty_msg.job_id)
@@ -89,8 +93,11 @@ class TestMessage(unittest.TestCase):
         self.assertIsNone(empty_msg.reduction_arguments)
         self.assertIsNone(empty_msg.reduction_log)
         self.assertIsNone(empty_msg.admin_log)
-        self.assertIsNone(empty_msg.return_message)
+        self.assertIsNone(empty_msg.message)
         self.assertIsNone(empty_msg.retry_in)
+        self.assertIsNone(empty_msg.reduction_data)
+        self.assertIsNone(empty_msg.run_description)
+        self.assertIsNone(empty_msg.error)
 
     def test_to_dict_populated(self):
         """

--- a/monitors/run_detection.py
+++ b/monitors/run_detection.py
@@ -131,7 +131,7 @@ class InstrumentMonitor:
             EORM_LOG.info("Submitting '%s' with RB number '%s'", file_name, rb_number)
             message = Message(rb_number=rb_number,
                               run_number=run_number,
-                              file_path=file_path)
+                              data=file_path)
             self.client.send('/queue/DataReady', message, priority='9')
         else:
             raise FileNotFoundError("File does not exist '{}'".format(file_path))

--- a/monitors/tests/test_run_detection.py
+++ b/monitors/tests/test_run_detection.py
@@ -25,7 +25,7 @@ INVALID_LAST_RUN_FILE = "INVALID LAST RUN FILE"
 FILE_NAME = "WISH00044733.nxs"
 RUN_DATA = {'instrument': 'WISH',
             'run_number': '00044733',
-            'file_path': '/my/data/dir/cycle_18_4/' + FILE_NAME,
+            'data': '/my/data/dir/cycle_18_4/' + FILE_NAME,
             'rb_number': '1820461',
             'summary_rb_number': '1820333',
             'facility': 'ISIS',
@@ -136,7 +136,7 @@ class TestRunDetection(unittest.TestCase):
         inst_mon.submit_run(RUN_DATA['summary_rb_number'], RUN_DATA['run_number'], FILE_NAME)
         message = Message(rb_number=RUN_DATA['rb_number'],
                           run_number=RUN_DATA['run_number'],
-                          file_path=data_loc)
+                          data=data_loc)
         client.send.assert_called_with('/queue/DataReady', message, priority='9')
         isfile_mock.assert_called_with(data_loc)
         read_rb_mock.assert_called_once_with(data_loc)
@@ -168,7 +168,7 @@ class TestRunDetection(unittest.TestCase):
         inst_mon.submit_run(RUN_DATA['summary_rb_number'], RUN_DATA['run_number'], FILE_NAME)
         message = Message(rb_number=RUN_DATA['summary_rb_number'],
                           run_number=RUN_DATA['run_number'],
-                          file_path=data_loc)
+                          data=data_loc)
         client.send.assert_called_with('/queue/DataReady',
                                        message,
                                        priority='9')

--- a/queue_processors/autoreduction_processor/autoreduction_logging_setup.py
+++ b/queue_processors/autoreduction_processor/autoreduction_logging_setup.py
@@ -11,7 +11,7 @@ import os
 from utils.project.structure import get_project_root
 
 LOGGING_LEVEL = logging.INFO
-LOGGING_LOC = os.path.join(get_project_root(), 'logs', 'autoreductionProcessor.log')
+LOGGING_LOC = os.path.join(get_project_root(), 'logs', 'autoreduction_processor.log')
 
 logger = logging.getLogger('AutoreductionProcessor')
 logger.setLevel(LOGGING_LEVEL)

--- a/queue_processors/autoreduction_processor/autoreduction_processor.py
+++ b/queue_processors/autoreduction_processor/autoreduction_processor.py
@@ -29,7 +29,7 @@ class Listener(stomp.ConnectionListener):
         self.proc_list = []
         self.rb_list = []  # list of RB numbers of active reduction runs
         self.cancel_list = []  # list of (run number, run version)s to drop (once) used
-        logger.info("Entered Listener __init__.\n")
+        logger.info("Entered run_tuple.\n")
 
     @staticmethod
     # pylint:disable=arguments-differ
@@ -55,8 +55,7 @@ class Listener(stomp.ConnectionListener):
 
     def hold_message(self, destination, data, headers):
         """ Calls the reduction script. """
-        logger.debug("Enter hold_message")
-        logger.info("holding thread")
+        logger.debug("holding thread")
         data_dict = json.loads(data)
 
         self.update_child_process_list()
@@ -89,7 +88,7 @@ class Listener(stomp.ConnectionListener):
 
     def update_child_process_list(self):
         """ Updates the list of processes by checking they still exist. """
-        logger.info("Entered update_child_process_list.\n")
+        logger.debug("Entered update_child_process_list.\n")
         for process in self.proc_list:
             if process.poll() is not None:
                 index = self.proc_list.index(process)
@@ -100,13 +99,13 @@ class Listener(stomp.ConnectionListener):
 
     def add_process(self, proc, data_dict):
         """ Add child process to list. """
-        logger.info("Entered add_process.\n")
+        logger.debug("Entered add_process.\n")
         self.proc_list.append(proc)
         self.rb_list.append(data_dict["rb_number"])
 
     def should_proceed(self, data_dict):
         """ Check whether there's a job already running with the same RB. """
-        logger.info("Entered should_proceed.\n")
+        logger.debug("Entered should_proceed.\n")
         if data_dict["rb_number"] in self.rb_list:
             logger.info("Duplicate RB run #%s, waiting for the first to finish.",
                         data_dict["rb_number"])
@@ -117,27 +116,27 @@ class Listener(stomp.ConnectionListener):
     @staticmethod
     def run_tuple(data_dict):
         """ return the tuple of (run_number, run version) from a dictionary. """
-        logger.info("Entered run_tuple.\n")
+        logger.debug("Entered run_tuple.\n")
         run_number = data_dict["run_number"]
         run_version = data_dict["run_version"] if data_dict["run_version"] is not None else 0
         return run_number, run_version
 
     def add_cancel(self, data_dict):
         """ Add this run to the cancel list, to cancel it next time it comes up. """
-        logger.info("Entered add_cancel.\n")
+        logger.debug("Entered run_tuple.\n")
         tup = self.run_tuple(data_dict)
         if tup not in self.cancel_list:
             self.cancel_list.append(tup)
 
     def should_cancel(self, data_dict):
         """ Return whether a run is in the list of runs to be canceled. """
-        logger.info("Entered should_cancel.\n")
+        logger.debug("Entered should_cancel.\n")
         tup = self.run_tuple(data_dict)
         return tup in self.cancel_list
 
     def cancel_run(self, data_dict):
         """ Cancel the reduction run. """
-        logger.info("Entered cancel_run.\n")
+        logger.debug("Entered cancel_run.\n")
         tup = self.run_tuple(data_dict)
         self.cancel_list.remove(tup)
 
@@ -148,14 +147,14 @@ class Consumer:
     def __init__(self):
         """ Initialise consumer. """
         self.consumer_name = "autoreduction_processor"
-        logger.info("Entered Consumer init.\n")
+        logger.debug("Entered Consumer init.\n")
 
     def run(self):
         """
         Connect to ActiveMQ via the QueueClient and listen to the
         /ReductionPending queue for messages.
         """
-        logger.info("Entered run.\n")
+        logger.debug("Entered run.\n")
         activemq_client = QueueClient()
         activemq_client.connect()
         activemq_client.subscribe_amq(consumer_name=self.consumer_name,

--- a/queue_processors/autoreduction_processor/autoreduction_processor.py
+++ b/queue_processors/autoreduction_processor/autoreduction_processor.py
@@ -87,28 +87,20 @@ class Listener(stomp.ConnectionListener):
 
     def update_child_process_list(self):
         """ Updates the list of processes by checking they still exist. """
-        logger.info("\nEntered update_child_process_list."
-                    "\nself.proc_list=%s", self.proc_list)
         for process in self.proc_list:
             if process.poll() is not None:
                 index = self.proc_list.index(process)
                 self.proc_list.pop(index)
                 self.rb_list.pop(index)
-                logger.info("\nprocess: %s (%s) is NOT NONE",
-                            process, index)
 
     def add_process(self, proc, data_dict):
         """ Add child process to list. """
-        logger.info("\nEntered add_process."
-                    "\nproc=%s"
-                    "\ndata_dict=%s", proc, data_dict)
+        logger.info("Entered add_process. proc=%s data_dict=%s", proc, data_dict)
         self.proc_list.append(proc)
         self.rb_list.append(data_dict["rb_number"])
 
     def should_proceed(self, data_dict):
         """ Check whether there's a job already running with the same RB. """
-        logger.info("\nshould_proceed add_process."
-                    "\ndata_dict=%s", data_dict)
         if data_dict["rb_number"] in self.rb_list:
             logger.info("Duplicate RB run #%s, waiting for the first to finish.",
                         data_dict["rb_number"])

--- a/queue_processors/autoreduction_processor/autoreduction_processor.py
+++ b/queue_processors/autoreduction_processor/autoreduction_processor.py
@@ -81,6 +81,12 @@ class Listener(stomp.ConnectionListener):
         python_path = sys.executable
         logger.info("Calling: %s %s %s %s",
                     python_path, MISC['post_process_directory'], destination, print_dict)
+
+        logger.info("subprocess.Popen parameters:\n"
+                    "python_path= %s\n"
+                    "MISC['post_process_directory']= %s\n"
+                    "destination= %s\n"
+                    "data= %s\n")
         proc = subprocess.Popen([python_path,
                                  MISC['post_process_directory'],
                                  destination,

--- a/queue_processors/autoreduction_processor/autoreduction_processor.py
+++ b/queue_processors/autoreduction_processor/autoreduction_processor.py
@@ -29,7 +29,7 @@ class Listener(stomp.ConnectionListener):
         self.proc_list = []
         self.rb_list = []  # list of RB numbers of active reduction runs
         self.cancel_list = []  # list of (run number, run version)s to drop (once) used
-        logger.info("Entered run_tuple.\n")
+        logger.info("Entered Listener __init__.\n")
 
     @staticmethod
     # pylint:disable=arguments-differ
@@ -55,7 +55,8 @@ class Listener(stomp.ConnectionListener):
 
     def hold_message(self, destination, data, headers):
         """ Calls the reduction script. """
-        logger.debug("holding thread")
+        logger.debug("Enter hold_message")
+        logger.info("holding thread")
         data_dict = json.loads(data)
 
         self.update_child_process_list()
@@ -88,7 +89,7 @@ class Listener(stomp.ConnectionListener):
 
     def update_child_process_list(self):
         """ Updates the list of processes by checking they still exist. """
-        logger.debug("Entered update_child_process_list.\n")
+        logger.info("Entered update_child_process_list.\n")
         for process in self.proc_list:
             if process.poll() is not None:
                 index = self.proc_list.index(process)
@@ -99,13 +100,13 @@ class Listener(stomp.ConnectionListener):
 
     def add_process(self, proc, data_dict):
         """ Add child process to list. """
-        logger.debug("Entered add_process.\n")
+        logger.info("Entered add_process.\n")
         self.proc_list.append(proc)
         self.rb_list.append(data_dict["rb_number"])
 
     def should_proceed(self, data_dict):
         """ Check whether there's a job already running with the same RB. """
-        logger.debug("Entered should_proceed.\n")
+        logger.info("Entered should_proceed.\n")
         if data_dict["rb_number"] in self.rb_list:
             logger.info("Duplicate RB run #%s, waiting for the first to finish.",
                         data_dict["rb_number"])
@@ -116,27 +117,27 @@ class Listener(stomp.ConnectionListener):
     @staticmethod
     def run_tuple(data_dict):
         """ return the tuple of (run_number, run version) from a dictionary. """
-        logger.debug("Entered run_tuple.\n")
+        logger.info("Entered run_tuple.\n")
         run_number = data_dict["run_number"]
         run_version = data_dict["run_version"] if data_dict["run_version"] is not None else 0
         return run_number, run_version
 
     def add_cancel(self, data_dict):
         """ Add this run to the cancel list, to cancel it next time it comes up. """
-        logger.debug("Entered run_tuple.\n")
+        logger.info("Entered add_cancel.\n")
         tup = self.run_tuple(data_dict)
         if tup not in self.cancel_list:
             self.cancel_list.append(tup)
 
     def should_cancel(self, data_dict):
         """ Return whether a run is in the list of runs to be canceled. """
-        logger.debug("Entered should_cancel.\n")
+        logger.info("Entered should_cancel.\n")
         tup = self.run_tuple(data_dict)
         return tup in self.cancel_list
 
     def cancel_run(self, data_dict):
         """ Cancel the reduction run. """
-        logger.debug("Entered cancel_run.\n")
+        logger.info("Entered cancel_run.\n")
         tup = self.run_tuple(data_dict)
         self.cancel_list.remove(tup)
 
@@ -147,14 +148,14 @@ class Consumer:
     def __init__(self):
         """ Initialise consumer. """
         self.consumer_name = "autoreduction_processor"
-        logger.debug("Entered Consumer init.\n")
+        logger.info("Entered Consumer init.\n")
 
     def run(self):
         """
         Connect to ActiveMQ via the QueueClient and listen to the
         /ReductionPending queue for messages.
         """
-        logger.debug("Entered run.\n")
+        logger.info("Entered run.\n")
         activemq_client = QueueClient()
         activemq_client.connect()
         activemq_client.subscribe_amq(consumer_name=self.consumer_name,

--- a/queue_processors/autoreduction_processor/autoreduction_processor.py
+++ b/queue_processors/autoreduction_processor/autoreduction_processor.py
@@ -95,6 +95,7 @@ class Listener(stomp.ConnectionListener):
 
     def add_process(self, proc, data_dict):
         """ Add child process to list. """
+        logger.info("Entered add_process. proc=%s data_dict=%s", proc, data_dict)
         self.proc_list.append(proc)
         self.rb_list.append(data_dict["rb_number"])
 

--- a/queue_processors/autoreduction_processor/autoreduction_processor.py
+++ b/queue_processors/autoreduction_processor/autoreduction_processor.py
@@ -29,6 +29,7 @@ class Listener(stomp.ConnectionListener):
         self.proc_list = []
         self.rb_list = []  # list of RB numbers of active reduction runs
         self.cancel_list = []  # list of (run number, run version)s to drop (once) used
+        logger.info("Entered run_tuple.\n")
 
     @staticmethod
     # pylint:disable=arguments-differ
@@ -87,28 +88,24 @@ class Listener(stomp.ConnectionListener):
 
     def update_child_process_list(self):
         """ Updates the list of processes by checking they still exist. """
-        logger.info("\nEntered update_child_process_list."
-                    "\nself.proc_list=%s", self.proc_list)
+        logger.debug("Entered update_child_process_list.\n")
         for process in self.proc_list:
             if process.poll() is not None:
                 index = self.proc_list.index(process)
                 self.proc_list.pop(index)
                 self.rb_list.pop(index)
-                logger.info("\nprocess: %s (%s) is NOT NONE",
+                logger.debug("\nprocess: %s (%s) is NOT NONE",
                             process, index)
 
     def add_process(self, proc, data_dict):
         """ Add child process to list. """
-        logger.info("\nEntered add_process."
-                    "\nproc=%s"
-                    "\ndata_dict=%s", proc, data_dict)
+        logger.debug("Entered add_process.\n")
         self.proc_list.append(proc)
         self.rb_list.append(data_dict["rb_number"])
 
     def should_proceed(self, data_dict):
         """ Check whether there's a job already running with the same RB. """
-        logger.info("\nshould_proceed add_process."
-                    "\ndata_dict=%s", data_dict)
+        logger.debug("Entered should_proceed.\n")
         if data_dict["rb_number"] in self.rb_list:
             logger.info("Duplicate RB run #%s, waiting for the first to finish.",
                         data_dict["rb_number"])
@@ -119,23 +116,27 @@ class Listener(stomp.ConnectionListener):
     @staticmethod
     def run_tuple(data_dict):
         """ return the tuple of (run_number, run version) from a dictionary. """
+        logger.debug("Entered run_tuple.\n")
         run_number = data_dict["run_number"]
         run_version = data_dict["run_version"] if data_dict["run_version"] is not None else 0
         return run_number, run_version
 
     def add_cancel(self, data_dict):
         """ Add this run to the cancel list, to cancel it next time it comes up. """
+        logger.debug("Entered run_tuple.\n")
         tup = self.run_tuple(data_dict)
         if tup not in self.cancel_list:
             self.cancel_list.append(tup)
 
     def should_cancel(self, data_dict):
         """ Return whether a run is in the list of runs to be canceled. """
+        logger.debug("Entered should_cancel.\n")
         tup = self.run_tuple(data_dict)
         return tup in self.cancel_list
 
     def cancel_run(self, data_dict):
         """ Cancel the reduction run. """
+        logger.debug("Entered cancel_run.\n")
         tup = self.run_tuple(data_dict)
         self.cancel_list.remove(tup)
 
@@ -146,12 +147,14 @@ class Consumer:
     def __init__(self):
         """ Initialise consumer. """
         self.consumer_name = "autoreduction_processor"
+        logger.debug("Entered Consumer init.\n")
 
     def run(self):
         """
         Connect to ActiveMQ via the QueueClient and listen to the
         /ReductionPending queue for messages.
         """
+        logger.debug("Entered run.\n")
         activemq_client = QueueClient()
         activemq_client.connect()
         activemq_client.subscribe_amq(consumer_name=self.consumer_name,

--- a/queue_processors/autoreduction_processor/autoreduction_processor.py
+++ b/queue_processors/autoreduction_processor/autoreduction_processor.py
@@ -81,12 +81,6 @@ class Listener(stomp.ConnectionListener):
         python_path = sys.executable
         logger.info("Calling: %s %s %s %s",
                     python_path, MISC['post_process_directory'], destination, print_dict)
-
-        logger.info("subprocess.Popen parameters:\n"
-                    "python_path= %s\n"
-                    "MISC['post_process_directory']= %s\n"
-                    "destination= %s\n"
-                    "data= %s\n")
         proc = subprocess.Popen([python_path,
                                  MISC['post_process_directory'],
                                  destination,

--- a/queue_processors/autoreduction_processor/autoreduction_processor.py
+++ b/queue_processors/autoreduction_processor/autoreduction_processor.py
@@ -87,20 +87,28 @@ class Listener(stomp.ConnectionListener):
 
     def update_child_process_list(self):
         """ Updates the list of processes by checking they still exist. """
+        logger.info("\nEntered update_child_process_list."
+                    "\nself.proc_list=%s", self.proc_list)
         for process in self.proc_list:
             if process.poll() is not None:
                 index = self.proc_list.index(process)
                 self.proc_list.pop(index)
                 self.rb_list.pop(index)
+                logger.info("\nprocess: %s (%s) is NOT NONE",
+                            process, index)
 
     def add_process(self, proc, data_dict):
         """ Add child process to list. """
-        logger.info("Entered add_process. proc=%s data_dict=%s", proc, data_dict)
+        logger.info("\nEntered add_process."
+                    "\nproc=%s"
+                    "\ndata_dict=%s", proc, data_dict)
         self.proc_list.append(proc)
         self.rb_list.append(data_dict["rb_number"])
 
     def should_proceed(self, data_dict):
         """ Check whether there's a job already running with the same RB. """
+        logger.info("\nshould_proceed add_process."
+                    "\ndata_dict=%s", data_dict)
         if data_dict["rb_number"] in self.rb_list:
             logger.info("Duplicate RB run #%s, waiting for the first to finish.",
                         data_dict["rb_number"])

--- a/queue_processors/autoreduction_processor/post_process_admin.py
+++ b/queue_processors/autoreduction_processor/post_process_admin.py
@@ -267,7 +267,9 @@ class PostProcessAdmin:
                 raise exp
 
             self.data['reduction_data'] = []
-            if "message" not in self.data:
+            # if "message" not in self.data:  # Note: this will never be true using Message class
+            # Note: this change avoids the need for 'None' checking past this
+            if "message" not in self.data or self.data["message"] is None:
                 self.data["message"] = ""
 
             logger.info("----------------")
@@ -443,7 +445,7 @@ class PostProcessAdmin:
         """ Helper function to add text to the outgoing activemq message and to the info logs """
         logger.info("Entered log_and_message.\n")
         logger.info(msg)
-        if self.data["message"] == "":
+        if self.data["message"] == "" or self.data["message"] is None:
             # Only send back first message as there is a char limit
             self.data["message"] = msg
 

--- a/queue_processors/autoreduction_processor/post_process_admin.py
+++ b/queue_processors/autoreduction_processor/post_process_admin.py
@@ -192,6 +192,7 @@ class PostProcessAdmin:
     def reduce(self):
         """ Start the reduction job.  """
         # pylint: disable=too-many-nested-blocks
+        logger.info("reduce started")
         try:
             logger.debug("Calling: %s\n%s",
                          ACTIVEMQ_SETTINGS.reduction_started,
@@ -498,6 +499,7 @@ class PostProcessAdmin:
 
 def main():
     """ Main method. """
+    logger.info("ppa started")
     json_data = None
     queue_client = QueueClient()
     try:

--- a/queue_processors/autoreduction_processor/post_process_admin.py
+++ b/queue_processors/autoreduction_processor/post_process_admin.py
@@ -264,10 +264,6 @@ class PostProcessAdmin:
                 raise exp
 
             self.data['reduction_data'] = []
-            # Note: Open question: where to set Message=""
-            #  (here? QueueClient.send? Message class? allow null in DB?)
-            if "message" not in self.data or self.data["message"] is None:
-                self.data["message"] = ""
 
             logger.info("----------------")
             logger.info("Reduction script: %s ...", self.reduction_script[:50])
@@ -354,9 +350,7 @@ class PostProcessAdmin:
         self.data['reduction_log'] = self.reduction_log_stream.getvalue()
         self.data["admin_log"] = self.admin_log_stream.getvalue()
 
-        # Note: at this point, 'message' should never been None
-        #  (unless assignment (message="") has moved)
-        if self.data["message"] != "" and self.data['message'] is not None:
+        if 'message' in self.data and self.data['message'] is not None:
             # This means an error has been produced somewhere
             try:
                 if 'skip' in self.data['message'].lower():
@@ -372,7 +366,6 @@ class PostProcessAdmin:
 
         else:
             # reduction has successfully completed
-            self.data["message"] = ""   # Note: this assignment is redundant but precautionary
             self.client.send(ACTIVEMQ_SETTINGS.reduction_complete, json.dumps(self.data))
             logger.info("Calling: %s\n%s",
                         ACTIVEMQ_SETTINGS.reduction_complete,

--- a/queue_processors/autoreduction_processor/post_process_admin.py
+++ b/queue_processors/autoreduction_processor/post_process_admin.py
@@ -373,21 +373,23 @@ class PostProcessAdmin:
                         prettify(self.data))
             logger.info("Reduction job successfully complete")
 
-    def _new_reduction_data_path(self, path):   # note: should be given directory, ending in separator
+    def _new_reduction_data_path(self, path):
         logger.info("_new_reduction_data_path argument: %s", path)
+        # if there is an 'overwrite' key/member with a None/False value
         if 'overwrite' in self.data and not self.data["overwrite"]:
-            if os.path.isdir(path):
+            if os.path.isdir(path):           # if the given path already exists..
                 contents = os.listdir(path)
                 highest_vers = 0
-                for item in contents:
+                for item in contents:         # ..for every item, if it's a dir and a int..
                     if os.path.isdir(os.path.join(path, item)):
-                        try:
+                        try:                  # ..store the highest int
                             vers = int(item)
                             highest_vers = max(highest_vers, vers)
                         except ValueError:
                             pass
                 this_vers = highest_vers + 1
                 return append_path(path, [str(this_vers)])
+        # (else) if overwrite doesn't exist, is true, or the path doesn't exist, return unedited
         return path
 
     def _send_message_and_log(self, destination):

--- a/queue_processors/autoreduction_processor/post_process_admin.py
+++ b/queue_processors/autoreduction_processor/post_process_admin.py
@@ -354,7 +354,8 @@ class PostProcessAdmin:
         self.data['reduction_log'] = self.reduction_log_stream.getvalue()
         self.data["admin_log"] = self.admin_log_stream.getvalue()
 
-        # Note: at this point, 'message' should never been None (unless assignment (message="") has moved)
+        # Note: at this point, 'message' should never been None
+        #  (unless assignment (message="") has moved)
         if self.data["message"] != "" and self.data['message'] is not None:
             # This means an error has been produced somewhere
             try:

--- a/queue_processors/autoreduction_processor/post_process_admin.py
+++ b/queue_processors/autoreduction_processor/post_process_admin.py
@@ -374,12 +374,17 @@ class PostProcessAdmin:
             logger.info("Reduction job successfully complete")
 
     def _new_reduction_data_path(self, path):
+        """
+        Creates a pathname for the reduction data, factoring in existing run data.
+        :param path: Base path for the run data (should follow convention, without version number)
+        :return: A pathname for the new reduction data
+        """
         logger.info("_new_reduction_data_path argument: %s", path)
         # if there is an 'overwrite' key/member with a None/False value
         if 'overwrite' in self.data and not self.data["overwrite"]:
             if os.path.isdir(path):           # if the given path already exists..
                 contents = os.listdir(path)
-                highest_vers = 0
+                highest_vers = -1
                 for item in contents:         # ..for every item, if it's a dir and a int..
                     if os.path.isdir(os.path.join(path, item)):
                         try:                  # ..store the highest int
@@ -389,8 +394,8 @@ class PostProcessAdmin:
                             pass
                 this_vers = highest_vers + 1
                 return append_path(path, [str(this_vers)])
-        # (else) if overwrite doesn't exist, is true, or the path doesn't exist, return unedited
-        return path
+        # (else) if no overwrite, overwrite true, or the path doesn't exist: return version 0 path
+        return append_path(path, "0")
 
     def _send_message_and_log(self, destination):
         """ Send reduction run to error. """

--- a/queue_processors/autoreduction_processor/post_process_admin.py
+++ b/queue_processors/autoreduction_processor/post_process_admin.py
@@ -222,30 +222,8 @@ class PostProcessAdmin:
             final_result_dir = reduce_result_dir[len(MISC["temp_root_directory"]):]
             final_log_dir = log_dir[len(MISC["temp_root_directory"]):]
 
-            if 'overwrite' in self.data:
-                if not self.data["overwrite"]:
-                    logger.info('Don\'t want to overwrite previous data')
-                    path_parts = final_result_dir.split('/')
-                    new_path = '/'
-                    for part in path_parts:
-                        if part not in ('autoreduced', ''):
-                            new_path = new_path + part + '/'
-                    maximum = 0
-                    for folder in os.listdir(new_path):
-                        if folder.startswith('autoreduced'):
-                            number = folder.replace('autoreduced', '')
-                            if number != '':
-                                number = int(number) + 1
-                                if number > maximum:
-                                    maximum = number
-                            else:
-                                maximum = 1
-                    if maximum == 0:
-                        new_path = new_path + 'autoreduced'
-                    else:
-                        new_path = new_path + 'autoreduced' + str(maximum) + '/'
-                    final_result_dir = new_path
-                    final_log_dir = new_path + 'reduction_log/'
+            final_result_dir = self._new_reduction_data_path(final_result_dir)
+            final_log_dir = final_result_dir + 'reduction_log/'
 
             logger.info('Final Result Directory = %s', final_result_dir)
             logger.info('Final Log Directory = %s', final_log_dir)
@@ -393,6 +371,34 @@ class PostProcessAdmin:
                         ACTIVEMQ_SETTINGS.reduction_complete,
                         prettify(self.data))
             logger.info("Reduction job successfully complete")
+
+    def _new_reduction_data_path(self, directory):
+        logger.info("directory argument: %s", directory)
+        new_path = directory
+        if 'overwrite' in self.data:
+            if not self.data["overwrite"]:
+                logger.info('Don\'t want to overwrite previous data')
+                path_parts = directory.split('/')
+                new_path = '/'
+                for part in path_parts:
+                    if part not in ('autoreduced', ''):
+                        new_path = new_path + part + '/'
+                maximum = 0
+                for folder in os.listdir(new_path):
+                    if folder.startswith('autoreduced'):
+                        number = folder.replace('autoreduced', '')
+                        if number != '':
+                            number = int(number) + 1
+                            if number > maximum:
+                                maximum = number
+                        else:
+                            maximum = 1
+                if maximum == 0:
+                    new_path = new_path + 'autoreduced'
+                else:
+                    new_path = new_path + 'autoreduced' + str(maximum) + '/'
+        logger.info("new path: %s", new_path)
+        return new_path
 
     def _send_message_and_log(self, destination):
         """ Send reduction run to error. """

--- a/queue_processors/autoreduction_processor/post_process_admin.py
+++ b/queue_processors/autoreduction_processor/post_process_admin.py
@@ -111,7 +111,6 @@ class PostProcessAdmin:
 
     # pylint: disable=too-many-instance-attributes
     def __init__(self, data, client):
-        logger.debug("Entered PostProcessAdmin init.\n")
         logger.debug("json data: %s", prettify(data))
         data["information"] = socket.gethostname()
         self.data = data
@@ -157,7 +156,7 @@ class PostProcessAdmin:
             Merge self.reduction_arguments[dictName] into reduce_script.web_var[dictName],
             overwriting any key that exists in both with the value from sourceDict.
             """
-            logger.debug("Entered merge_dicts.\n")
+
             def merge_dict_to_name(dictionary_name, source_dict):
                 """ Merge the two dictionaries. """
                 old_dict = {}
@@ -184,18 +183,16 @@ class PostProcessAdmin:
     @staticmethod
     def _reduction_script_location(instrument_name):
         """ Returns the reduction script location. """
-        logger.debug("Entered _reduction_script_location.\n")
         return MISC["scripts_directory"] % instrument_name
 
     def _load_reduction_script(self, instrument_name):
         """ Returns the path of the reduction script for an instrument. """
-        logger.debug("Entered _load_reduction_script.\n")
         return os.path.join(self._reduction_script_location(instrument_name), 'reduce.py')
 
     def reduce(self):
         """ Start the reduction job.  """
         # pylint: disable=too-many-nested-blocks
-        logger.debug("Entered merge_dicts.\n")
+        logger.info("reduce started")
         try:
             logger.debug("Calling: %s\n%s",
                          ACTIVEMQ_SETTINGS.reduction_started,
@@ -388,7 +385,7 @@ class PostProcessAdmin:
         :param path: Base path for the run data (should follow convention, without version number)
         :return: A pathname for the new reduction data
         """
-        logger.info("Entered _new_reduction_data_path. argument: %s\n", path)
+        logger.info("_new_reduction_data_path argument: %s", path)
         # if there is an 'overwrite' key/member with a None/False value
         if 'overwrite' in self.data and not self.data["overwrite"]:
             if os.path.isdir(path):           # if the given path already exists..
@@ -408,7 +405,6 @@ class PostProcessAdmin:
 
     def _send_message_and_log(self, destination):
         """ Send reduction run to error. """
-        logger.debug("Entered _send_message_and_log.\n")
         logger.info("\nCalling " + destination + " --- " + prettify(self.data))
         self.client.send(destination, json.dumps(self.data))
 
@@ -420,7 +416,6 @@ class PostProcessAdmin:
         EXCITATION instrument are treated as a special case because they're done with run number
         sub-folders.
         """
-        logger.debug("Entered copy_temp_directory.\n")
         if os.path.isdir(copy_destination) \
                 and self.instrument not in MISC["excitation_instruments"]:
             self._remove_directory(copy_destination)
@@ -443,7 +438,6 @@ class PostProcessAdmin:
 
     def log_and_message(self, msg):
         """ Helper function to add text to the outgoing activemq message and to the info logs """
-        logger.debug("Entered log_and_message.\n")
         logger.info(msg)
         if self.data["message"] == "" or self.data["message"] is None:
             # Only send back first message as there is a char limit
@@ -451,7 +445,6 @@ class PostProcessAdmin:
 
     def _remove_with_wait(self, remove_folder, full_path):
         """ Removes a folder or file and waits for it to be removed. """
-        logger.debug("Entered _remove_with_wait.\n")
         file_deleted = False
         for sleep in [0, 0.1, 0.2, 0.5, 1, 2, 5, 10, 20]:
             try:
@@ -478,7 +471,6 @@ class PostProcessAdmin:
 
     def _copy_tree(self, source, dest):
         """ Copy directory tree. """
-        logger.debug("Entered _copy_tree.\n")
         if not os.path.exists(dest):
             os.makedirs(dest)
         for item in os.listdir(source):
@@ -495,7 +487,6 @@ class PostProcessAdmin:
         Helper function to remove a directory. shutil.rmtree cannot be used as it is not robust
         enough when folders are open over the network.
         """
-        logger.debug("Entered _remove_directory.\n")
         try:
             for target_file in os.listdir(directory):
                 full_path = os.path.join(directory, target_file)
@@ -513,7 +504,7 @@ class PostProcessAdmin:
 
 def main():
     """ Main method. """
-    logger.debug("Entered PPA main.\n")
+    logger.info("ppa started")
     json_data = None
     queue_client = QueueClient()
     try:

--- a/queue_processors/autoreduction_processor/post_process_admin.py
+++ b/queue_processors/autoreduction_processor/post_process_admin.py
@@ -374,6 +374,7 @@ class PostProcessAdmin:
 
     def _new_reduction_data_path(self, directory):
         logger.info("directory argument: %s", directory)
+
         new_path = directory
         if 'overwrite' in self.data:
             if not self.data["overwrite"]:

--- a/queue_processors/autoreduction_processor/post_process_admin.py
+++ b/queue_processors/autoreduction_processor/post_process_admin.py
@@ -355,7 +355,7 @@ class PostProcessAdmin:
         self.data['reduction_log'] = self.reduction_log_stream.getvalue()
         self.data["admin_log"] = self.admin_log_stream.getvalue()
 
-        if self.data["message"] != "":
+        if self.data["message"] != "" and not self.data['message'] is None:
             # This means an error has been produced somewhere
             try:
                 if 'skip' in self.data['message'].lower():

--- a/queue_processors/autoreduction_processor/post_process_admin.py
+++ b/queue_processors/autoreduction_processor/post_process_admin.py
@@ -111,6 +111,7 @@ class PostProcessAdmin:
 
     # pylint: disable=too-many-instance-attributes
     def __init__(self, data, client):
+        logger.debug("Entered PostProcessAdmin init.\n")
         logger.debug("json data: %s", prettify(data))
         data["information"] = socket.gethostname()
         self.data = data
@@ -156,7 +157,7 @@ class PostProcessAdmin:
             Merge self.reduction_arguments[dictName] into reduce_script.web_var[dictName],
             overwriting any key that exists in both with the value from sourceDict.
             """
-
+            logger.debug("Entered merge_dicts.\n")
             def merge_dict_to_name(dictionary_name, source_dict):
                 """ Merge the two dictionaries. """
                 old_dict = {}
@@ -183,16 +184,18 @@ class PostProcessAdmin:
     @staticmethod
     def _reduction_script_location(instrument_name):
         """ Returns the reduction script location. """
+        logger.debug("Entered _reduction_script_location.\n")
         return MISC["scripts_directory"] % instrument_name
 
     def _load_reduction_script(self, instrument_name):
         """ Returns the path of the reduction script for an instrument. """
+        logger.debug("Entered _load_reduction_script.\n")
         return os.path.join(self._reduction_script_location(instrument_name), 'reduce.py')
 
     def reduce(self):
         """ Start the reduction job.  """
         # pylint: disable=too-many-nested-blocks
-        logger.info("reduce started")
+        logger.debug("Entered merge_dicts.\n")
         try:
             logger.debug("Calling: %s\n%s",
                          ACTIVEMQ_SETTINGS.reduction_started,
@@ -380,7 +383,7 @@ class PostProcessAdmin:
         :param path: Base path for the run data (should follow convention, without version number)
         :return: A pathname for the new reduction data
         """
-        logger.info("_new_reduction_data_path argument: %s", path)
+        logger.info("Entered _new_reduction_data_path. argument: %s\n", path)
         # if there is an 'overwrite' key/member with a None/False value
         if 'overwrite' in self.data and not self.data["overwrite"]:
             if os.path.isdir(path):           # if the given path already exists..
@@ -400,6 +403,7 @@ class PostProcessAdmin:
 
     def _send_message_and_log(self, destination):
         """ Send reduction run to error. """
+        logger.debug("Entered _send_message_and_log.\n")
         logger.info("\nCalling " + destination + " --- " + prettify(self.data))
         self.client.send(destination, json.dumps(self.data))
 
@@ -411,6 +415,7 @@ class PostProcessAdmin:
         EXCITATION instrument are treated as a special case because they're done with run number
         sub-folders.
         """
+        logger.debug("Entered copy_temp_directory.\n")
         if os.path.isdir(copy_destination) \
                 and self.instrument not in MISC["excitation_instruments"]:
             self._remove_directory(copy_destination)
@@ -433,6 +438,7 @@ class PostProcessAdmin:
 
     def log_and_message(self, msg):
         """ Helper function to add text to the outgoing activemq message and to the info logs """
+        logger.debug("Entered log_and_message.\n")
         logger.info(msg)
         if self.data["message"] == "":
             # Only send back first message as there is a char limit
@@ -440,6 +446,7 @@ class PostProcessAdmin:
 
     def _remove_with_wait(self, remove_folder, full_path):
         """ Removes a folder or file and waits for it to be removed. """
+        logger.debug("Entered _remove_with_wait.\n")
         file_deleted = False
         for sleep in [0, 0.1, 0.2, 0.5, 1, 2, 5, 10, 20]:
             try:
@@ -466,6 +473,7 @@ class PostProcessAdmin:
 
     def _copy_tree(self, source, dest):
         """ Copy directory tree. """
+        logger.debug("Entered _copy_tree.\n")
         if not os.path.exists(dest):
             os.makedirs(dest)
         for item in os.listdir(source):
@@ -482,6 +490,7 @@ class PostProcessAdmin:
         Helper function to remove a directory. shutil.rmtree cannot be used as it is not robust
         enough when folders are open over the network.
         """
+        logger.debug("Entered _remove_directory.\n")
         try:
             for target_file in os.listdir(directory):
                 full_path = os.path.join(directory, target_file)
@@ -499,7 +508,7 @@ class PostProcessAdmin:
 
 def main():
     """ Main method. """
-    logger.info("ppa started")
+    logger.debug("Entered PPA main.\n")
     json_data = None
     queue_client = QueueClient()
     try:

--- a/queue_processors/autoreduction_processor/post_process_admin.py
+++ b/queue_processors/autoreduction_processor/post_process_admin.py
@@ -111,7 +111,7 @@ class PostProcessAdmin:
 
     # pylint: disable=too-many-instance-attributes
     def __init__(self, data, client):
-        logger.info("Entered PostProcessAdmin init.\n")
+        logger.debug("Entered PostProcessAdmin init.\n")
         logger.debug("json data: %s", prettify(data))
         data["information"] = socket.gethostname()
         self.data = data
@@ -157,7 +157,7 @@ class PostProcessAdmin:
             Merge self.reduction_arguments[dictName] into reduce_script.web_var[dictName],
             overwriting any key that exists in both with the value from sourceDict.
             """
-            logger.info("Entered merge_dicts.\n")
+            logger.debug("Entered merge_dicts.\n")
             def merge_dict_to_name(dictionary_name, source_dict):
                 """ Merge the two dictionaries. """
                 old_dict = {}
@@ -184,18 +184,18 @@ class PostProcessAdmin:
     @staticmethod
     def _reduction_script_location(instrument_name):
         """ Returns the reduction script location. """
-        logger.info("Entered _reduction_script_location.\n")
+        logger.debug("Entered _reduction_script_location.\n")
         return MISC["scripts_directory"] % instrument_name
 
     def _load_reduction_script(self, instrument_name):
         """ Returns the path of the reduction script for an instrument. """
-        logger.info("Entered _load_reduction_script.\n")
+        logger.debug("Entered _load_reduction_script.\n")
         return os.path.join(self._reduction_script_location(instrument_name), 'reduce.py')
 
     def reduce(self):
         """ Start the reduction job.  """
         # pylint: disable=too-many-nested-blocks
-        logger.info("Entered reduce.\n")
+        logger.debug("Entered merge_dicts.\n")
         try:
             logger.debug("Calling: %s\n%s",
                          ACTIVEMQ_SETTINGS.reduction_started,
@@ -408,7 +408,7 @@ class PostProcessAdmin:
 
     def _send_message_and_log(self, destination):
         """ Send reduction run to error. """
-        logger.info("Entered _send_message_and_log.\n")
+        logger.debug("Entered _send_message_and_log.\n")
         logger.info("\nCalling " + destination + " --- " + prettify(self.data))
         self.client.send(destination, json.dumps(self.data))
 
@@ -420,7 +420,7 @@ class PostProcessAdmin:
         EXCITATION instrument are treated as a special case because they're done with run number
         sub-folders.
         """
-        logger.info("Entered copy_temp_directory.\n")
+        logger.debug("Entered copy_temp_directory.\n")
         if os.path.isdir(copy_destination) \
                 and self.instrument not in MISC["excitation_instruments"]:
             self._remove_directory(copy_destination)
@@ -443,7 +443,7 @@ class PostProcessAdmin:
 
     def log_and_message(self, msg):
         """ Helper function to add text to the outgoing activemq message and to the info logs """
-        logger.info("Entered log_and_message.\n")
+        logger.debug("Entered log_and_message.\n")
         logger.info(msg)
         if self.data["message"] == "" or self.data["message"] is None:
             # Only send back first message as there is a char limit
@@ -451,7 +451,7 @@ class PostProcessAdmin:
 
     def _remove_with_wait(self, remove_folder, full_path):
         """ Removes a folder or file and waits for it to be removed. """
-        logger.info("Entered _remove_with_wait.\n")
+        logger.debug("Entered _remove_with_wait.\n")
         file_deleted = False
         for sleep in [0, 0.1, 0.2, 0.5, 1, 2, 5, 10, 20]:
             try:
@@ -478,7 +478,7 @@ class PostProcessAdmin:
 
     def _copy_tree(self, source, dest):
         """ Copy directory tree. """
-        logger.info("Entered _copy_tree.\n")
+        logger.debug("Entered _copy_tree.\n")
         if not os.path.exists(dest):
             os.makedirs(dest)
         for item in os.listdir(source):
@@ -495,7 +495,7 @@ class PostProcessAdmin:
         Helper function to remove a directory. shutil.rmtree cannot be used as it is not robust
         enough when folders are open over the network.
         """
-        logger.info("Entered _remove_directory.\n")
+        logger.debug("Entered _remove_directory.\n")
         try:
             for target_file in os.listdir(directory):
                 full_path = os.path.join(directory, target_file)
@@ -513,7 +513,7 @@ class PostProcessAdmin:
 
 def main():
     """ Main method. """
-    logger.info("Entered PPA main.\n")
+    logger.debug("Entered PPA main.\n")
     json_data = None
     queue_client = QueueClient()
     try:

--- a/queue_processors/autoreduction_processor/post_process_admin.py
+++ b/queue_processors/autoreduction_processor/post_process_admin.py
@@ -371,6 +371,9 @@ class PostProcessAdmin:
 
         else:
             # reduction has successfully completed
+            # Note: Below to avoid SQL-cant-be-null error. Could default to "" in Message class instead?
+            #   If we do that instead, need to think about is None check above
+            self.data["message"] = ""
             self.client.send(ACTIVEMQ_SETTINGS.reduction_complete, json.dumps(self.data))
             logger.info("Calling: %s\n%s",
                         ACTIVEMQ_SETTINGS.reduction_complete,

--- a/queue_processors/autoreduction_processor/post_process_admin.py
+++ b/queue_processors/autoreduction_processor/post_process_admin.py
@@ -111,7 +111,7 @@ class PostProcessAdmin:
 
     # pylint: disable=too-many-instance-attributes
     def __init__(self, data, client):
-        logger.debug("Entered PostProcessAdmin init.\n")
+        logger.info("Entered PostProcessAdmin init.\n")
         logger.debug("json data: %s", prettify(data))
         data["information"] = socket.gethostname()
         self.data = data
@@ -157,7 +157,7 @@ class PostProcessAdmin:
             Merge self.reduction_arguments[dictName] into reduce_script.web_var[dictName],
             overwriting any key that exists in both with the value from sourceDict.
             """
-            logger.debug("Entered merge_dicts.\n")
+            logger.info("Entered merge_dicts.\n")
             def merge_dict_to_name(dictionary_name, source_dict):
                 """ Merge the two dictionaries. """
                 old_dict = {}
@@ -184,18 +184,18 @@ class PostProcessAdmin:
     @staticmethod
     def _reduction_script_location(instrument_name):
         """ Returns the reduction script location. """
-        logger.debug("Entered _reduction_script_location.\n")
+        logger.info("Entered _reduction_script_location.\n")
         return MISC["scripts_directory"] % instrument_name
 
     def _load_reduction_script(self, instrument_name):
         """ Returns the path of the reduction script for an instrument. """
-        logger.debug("Entered _load_reduction_script.\n")
+        logger.info("Entered _load_reduction_script.\n")
         return os.path.join(self._reduction_script_location(instrument_name), 'reduce.py')
 
     def reduce(self):
         """ Start the reduction job.  """
         # pylint: disable=too-many-nested-blocks
-        logger.debug("Entered merge_dicts.\n")
+        logger.info("Entered reduce.\n")
         try:
             logger.debug("Calling: %s\n%s",
                          ACTIVEMQ_SETTINGS.reduction_started,
@@ -403,7 +403,7 @@ class PostProcessAdmin:
 
     def _send_message_and_log(self, destination):
         """ Send reduction run to error. """
-        logger.debug("Entered _send_message_and_log.\n")
+        logger.info("Entered _send_message_and_log.\n")
         logger.info("\nCalling " + destination + " --- " + prettify(self.data))
         self.client.send(destination, json.dumps(self.data))
 
@@ -415,7 +415,7 @@ class PostProcessAdmin:
         EXCITATION instrument are treated as a special case because they're done with run number
         sub-folders.
         """
-        logger.debug("Entered copy_temp_directory.\n")
+        logger.info("Entered copy_temp_directory.\n")
         if os.path.isdir(copy_destination) \
                 and self.instrument not in MISC["excitation_instruments"]:
             self._remove_directory(copy_destination)
@@ -438,7 +438,7 @@ class PostProcessAdmin:
 
     def log_and_message(self, msg):
         """ Helper function to add text to the outgoing activemq message and to the info logs """
-        logger.debug("Entered log_and_message.\n")
+        logger.info("Entered log_and_message.\n")
         logger.info(msg)
         if self.data["message"] == "":
             # Only send back first message as there is a char limit
@@ -446,7 +446,7 @@ class PostProcessAdmin:
 
     def _remove_with_wait(self, remove_folder, full_path):
         """ Removes a folder or file and waits for it to be removed. """
-        logger.debug("Entered _remove_with_wait.\n")
+        logger.info("Entered _remove_with_wait.\n")
         file_deleted = False
         for sleep in [0, 0.1, 0.2, 0.5, 1, 2, 5, 10, 20]:
             try:
@@ -473,7 +473,7 @@ class PostProcessAdmin:
 
     def _copy_tree(self, source, dest):
         """ Copy directory tree. """
-        logger.debug("Entered _copy_tree.\n")
+        logger.info("Entered _copy_tree.\n")
         if not os.path.exists(dest):
             os.makedirs(dest)
         for item in os.listdir(source):
@@ -490,7 +490,7 @@ class PostProcessAdmin:
         Helper function to remove a directory. shutil.rmtree cannot be used as it is not robust
         enough when folders are open over the network.
         """
-        logger.debug("Entered _remove_directory.\n")
+        logger.info("Entered _remove_directory.\n")
         try:
             for target_file in os.listdir(directory):
                 full_path = os.path.join(directory, target_file)
@@ -508,7 +508,7 @@ class PostProcessAdmin:
 
 def main():
     """ Main method. """
-    logger.debug("Entered PPA main.\n")
+    logger.info("Entered PPA main.\n")
     json_data = None
     queue_client = QueueClient()
     try:

--- a/queue_processors/autoreduction_processor/tests/test_post_process_admin.py
+++ b/queue_processors/autoreduction_processor/tests/test_post_process_admin.py
@@ -49,6 +49,11 @@ class TestPostProcessAdmin(unittest.TestCase):
                      'run_number': '4321',
                      'reduction_script': 'print(\'hello\')',
                      'reduction_arguments': 'None'}
+        self.test_directory = "/instrument/GEM/RBNumber/RB2010163/autoreduced/90369"
+        os.makedirs(self.test_directory)
+
+    def tearDown(self):
+        os.rmdir(self.test_directory)
 
     def test_init(self):
         ppa = PostProcessAdmin(self.data, None)
@@ -279,3 +284,11 @@ class TestPostProcessAdmin(unittest.TestCase):
         mock_exit.assert_called_once()
         mock_send.assert_called_once_with(ACTIVEMQ_SETTINGS.reduction_error,
                                           json.dumps(self.data))
+
+    # def test_new_reduction_data_path(self):
+    #     print(os.path.isdir(self.test_directory))
+    #     # directory = "/instrument/GEM/RBNumber/RB2010163/autoreduced/90369"
+    #     mock_self = Mock()
+    #     mock_self.data = {'overwrite': None}
+    #     result = PostProcessAdmin._new_reduction_data_path(mock_self, self.test_directory)
+    #     # print(result)

--- a/queue_processors/autoreduction_processor/tests/test_post_process_admin.py
+++ b/queue_processors/autoreduction_processor/tests/test_post_process_admin.py
@@ -16,6 +16,7 @@ import json
 from tempfile import mkdtemp, NamedTemporaryFile
 from mock import patch, call, Mock
 
+from paths.path_manipulation import append_path
 from utils.settings import ACTIVEMQ_SETTINGS
 from utils.project.structure import get_project_root
 from queue_processors.autoreduction_processor.settings import MISC
@@ -56,10 +57,8 @@ class TestPostProcessAdmin(unittest.TestCase):
                            os.path.join(self.test_root, "1", self.test_fname),
                            os.path.join(self.test_root, "2", self.test_fname)]
 
-        print(f"self.test_paths: {self.test_paths}")
-        self.remove_test_dir_structure(self.test_root)
 
-        self.setup_test_dir_structure(self.test_paths)
+
 
 
     def tearDown(self):
@@ -72,7 +71,6 @@ class TestPostProcessAdmin(unittest.TestCase):
         # test_root = path_parts[0]
 
         abs_test_root = os.path.join(os.getcwd(), test_root)
-        print(f"abs_test_root: {abs_test_root}")
         if os.path.isdir(abs_test_root):
             shutil.rmtree(test_root)
 
@@ -80,14 +78,11 @@ class TestPostProcessAdmin(unittest.TestCase):
     def setup_test_dir_structure(test_paths):
         for file_path in test_paths:
             (path, file) = os.path.split(file_path)
-            print(f"path: {path}\nfile: {file}")
             abs_path = os.path.join(os.getcwd(), path)
-            print(f"abs_path: {abs_path}")
             if not os.path.isdir(abs_path):
                 os.makedirs(abs_path)
 
             abs_file_path = os.path.join(abs_path, file)
-            print(f"abs_file_path: {abs_file_path}")
             with open(abs_file_path, 'w') as file:
                 file.write("test file")
 
@@ -323,10 +318,13 @@ class TestPostProcessAdmin(unittest.TestCase):
                                           json.dumps(self.data))
 
     def test_new_reduction_data_path(self):
-        pass
-        # print(os.path.isdir(self.test_directory))
-    #     # directory = "/instrument/GEM/RBNumber/RB2010163/autoreduced/90369"
-    #     mock_self = Mock()
-    #     mock_self.data = {'overwrite': None}
-    #     result = PostProcessAdmin._new_reduction_data_path(mock_self, self.test_directory)
-    #     # print(result)
+        # self.remove_test_dir_structure(self.test_root)
+        self.setup_test_dir_structure(self.test_paths)
+        mock_self = Mock()
+        mock_self.data = {'overwrite': None}
+
+        expected = append_path(self.test_root, "3")
+        actual = PostProcessAdmin._new_reduction_data_path(mock_self, self.test_root)
+        self.assertEqual(expected, actual)
+
+        self.remove_test_dir_structure(self.test_root)

--- a/queue_processors/autoreduction_processor/tests/test_post_process_admin.py
+++ b/queue_processors/autoreduction_processor/tests/test_post_process_admin.py
@@ -164,8 +164,8 @@ class TestPostProcessAdmin(unittest.TestCase):  # pylint:disable=too-many-public
         activemq_client_mock = Mock()
         ppa = PostProcessAdmin(self.data, activemq_client_mock)
         ppa._send_message_and_log(ACTIVEMQ_SETTINGS.reduction_error)
-        mock_logger.assert_called_with("\nCalling " + ACTIVEMQ_SETTINGS.reduction_error
-                                                    + " --- " + prettify(self.data))
+        mock_logger.assert_called_with("\nCalling " + ACTIVEMQ_SETTINGS.reduction_error +
+                                       " --- " + prettify(self.data))
         activemq_client_mock.send.assert_called_once_with(ACTIVEMQ_SETTINGS.reduction_error,
                                                           json.dumps(ppa.data))
 

--- a/queue_processors/autoreduction_processor/tests/test_post_process_admin.py
+++ b/queue_processors/autoreduction_processor/tests/test_post_process_admin.py
@@ -40,8 +40,10 @@ class TestPostProcessAdminHelpers(unittest.TestCase):
         self.assertEqual(actual, '/temp/data/some/more/path.nxs')
 
 
-class TestPostProcessAdmin(unittest.TestCase):  # pylint:disable=too-many-public-methods
+# pylint:disable=too-many-public-methods
+class TestPostProcessAdmin(unittest.TestCase):
     DIR = "queue_processors.autoreduction_processor"
+
     def setUp(self):
         self.data = {'data': '\\\\isis\\inst$\\data.nxs',
                      'facility': 'ISIS',

--- a/queue_processors/autoreduction_processor/tests/test_post_process_admin.py
+++ b/queue_processors/autoreduction_processor/tests/test_post_process_admin.py
@@ -51,36 +51,43 @@ class TestPostProcessAdmin(unittest.TestCase):
                      'reduction_arguments': 'None'}
         # self.test_rel_path = "\\instrument\\GEM\\RBNumber\\RB2010163\\autoreduced\\90369\\"
         self.test_fname = "111.txt"
-        self.test_root = "\\test_run\\"
-        self.test_paths = [self.test_root + self.test_fname,
-                           self.test_root + "1\\" + self.test_fname,
-                           self.test_root + "2\\" + self.test_fname]
-        # self.remove_test_dir_structure(self.test_dir)
+        self.test_root = "test_run"
+        self.test_paths = [os.path.join(self.test_root, self.test_fname),
+                           os.path.join(self.test_root, "1", self.test_fname),
+                           os.path.join(self.test_root, "2", self.test_fname)]
+
+        print(f"self.test_paths: {self.test_paths}")
+        self.remove_test_dir_structure(self.test_root)
+
         self.setup_test_dir_structure(self.test_paths)
+
 
     def tearDown(self):
         self.remove_test_dir_structure(self.test_root)
 
     @staticmethod
-    def remove_test_dir_structure(test_dir):
-        split = test_dir.split("\\")
-        path_parts = [part for part in split if part]   # Removes empty items
-        test_root = path_parts[0]
+    def remove_test_dir_structure(test_root):
+        # split = test_dir.split("\\")
+        # path_parts = [part for part in split if part]   # Removes empty items
+        # test_root = path_parts[0]
 
-        cwd = os.getcwd()
-        abs_test_root = cwd + "\\" + test_root
+        abs_test_root = os.path.join(os.getcwd(), test_root)
+        print(f"abs_test_root: {abs_test_root}")
         if os.path.isdir(abs_test_root):
             shutil.rmtree(test_root)
 
     @staticmethod
     def setup_test_dir_structure(test_paths):
-        cwd = os.getcwd()
         for file_path in test_paths:
-            (path, file) = file_path.rsplit("\\", 1)
-            abs_path = cwd + path
-            os.makedirs(abs_path)
+            (path, file) = os.path.split(file_path)
+            print(f"path: {path}\nfile: {file}")
+            abs_path = os.path.join(os.getcwd(), path)
+            print(f"abs_path: {abs_path}")
+            if not os.path.isdir(abs_path):
+                os.makedirs(abs_path)
 
-            abs_file_path = cwd + file_path
+            abs_file_path = os.path.join(abs_path, file)
+            print(f"abs_file_path: {abs_file_path}")
             with open(abs_file_path, 'w') as file:
                 file.write("test file")
 

--- a/queue_processors/autoreduction_processor/tests/test_post_process_admin.py
+++ b/queue_processors/autoreduction_processor/tests/test_post_process_admin.py
@@ -41,6 +41,7 @@ class TestPostProcessAdminHelpers(unittest.TestCase):
 
 
 class TestPostProcessAdmin(unittest.TestCase):  # pylint:disable=too-many-public-methods
+    DIR = "queue_processors.autoreduction_processor"
     def setUp(self):
         self.data = {'data': '\\\\isis\\inst$\\data.nxs',
                      'facility': 'ISIS',
@@ -110,11 +111,9 @@ class TestPostProcessAdmin(unittest.TestCase):  # pylint:disable=too-many-public
         location = PostProcessAdmin._reduction_script_location('WISH')
         self.assertEqual(location, MISC['scripts_directory'] % 'WISH')
 
-    @patch('queue_processors.autoreduction_processor.post_process_admin.'
-           'PostProcessAdmin._remove_directory')
-    @patch('queue_processors.autoreduction_processor.post_process_admin.'
-           'PostProcessAdmin._copy_tree')
-    @patch('queue_processors.autoreduction_processor.autoreduction_logging_setup.logger.info')
+    @patch(DIR + '.post_process_admin.PostProcessAdmin._remove_directory')
+    @patch(DIR + '.post_process_admin.PostProcessAdmin._copy_tree')
+    @patch(DIR + '.autoreduction_logging_setup.logger.info')
     def test_copy_temp_dir(self, mock_logger, mock_copy, mock_remove):
         result_dir = mkdtemp()
         copy_dir = mkdtemp()
@@ -128,9 +127,8 @@ class TestPostProcessAdmin(unittest.TestCase):  # pylint:disable=too-many-public
         shutil.rmtree(result_dir)
         shutil.rmtree(copy_dir)
 
-    @patch('queue_processors.autoreduction_processor.post_process_admin.'
-           'PostProcessAdmin._copy_tree')
-    @patch('queue_processors.autoreduction_processor.autoreduction_logging_setup.logger.info')
+    @patch(DIR + '.post_process_admin.PostProcessAdmin._copy_tree')
+    @patch(DIR + '.autoreduction_logging_setup.logger.info')
     def test_copy_temp_dir_with_excitation(self, _, mock_copy):
         result_dir = mkdtemp()
         ppa = PostProcessAdmin(self.data, None)
@@ -140,11 +138,9 @@ class TestPostProcessAdmin(unittest.TestCase):  # pylint:disable=too-many-public
         mock_copy.assert_called_once_with(result_dir, 'copy-dir')
         shutil.rmtree(result_dir)
 
-    @patch('queue_processors.autoreduction_processor.post_process_admin.'
-           'PostProcessAdmin._copy_tree')
-    @patch('queue_processors.autoreduction_processor.post_process_admin.PostProcessAdmin.'
-           'log_and_message')
-    @patch('queue_processors.autoreduction_processor.autoreduction_logging_setup.logger.info')
+    @patch(DIR + '.post_process_admin.PostProcessAdmin._copy_tree')
+    @patch(DIR + '.post_process_admin.PostProcessAdmin.log_and_message')
+    @patch(DIR + '.autoreduction_logging_setup.logger.info')
     def test_copy_temp_dir_with_error(self, _, mock_log_and_msg, mock_copy):
         # pylint:disable=unused-argument
         def raise_runtime(arg1, arg2):  # pragma : no cover
@@ -159,7 +155,7 @@ class TestPostProcessAdmin(unittest.TestCase):  # pylint:disable=too-many-public
                                                                                 'test'))
         shutil.rmtree(result_dir)
 
-    @patch('queue_processors.autoreduction_processor.autoreduction_logging_setup.logger.info')
+    @patch(DIR + '.autoreduction_logging_setup.logger.info')
     def test_send_error_and_log(self, mock_logger):
         activemq_client_mock = Mock()
         ppa = PostProcessAdmin(self.data, activemq_client_mock)
@@ -170,7 +166,7 @@ class TestPostProcessAdmin(unittest.TestCase):  # pylint:disable=too-many-public
                                                           json.dumps(ppa.data))
 
     @patch('shutil.rmtree')
-    @patch('queue_processors.autoreduction_processor.autoreduction_logging_setup.logger.info')
+    @patch(DIR + '.autoreduction_logging_setup.logger.info')
     def test_delete_temp_dir_valid(self, mock_logger, mock_remove_dir):
         temp_dir = mkdtemp()
         PostProcessAdmin.delete_temp_directory(temp_dir)
@@ -180,7 +176,7 @@ class TestPostProcessAdmin(unittest.TestCase):  # pylint:disable=too-many-public
         shutil.rmtree(temp_dir)
 
     @patch('shutil.rmtree')
-    @patch('queue_processors.autoreduction_processor.autoreduction_logging_setup.logger.info')
+    @patch(DIR + '.autoreduction_logging_setup.logger.info')
     def test_delete_temp_dir_invalid(self, mock_logger, mock_remove_dir):
         def raise_runtime():  # pragma: no cover
             raise RuntimeError('test')
@@ -190,7 +186,7 @@ class TestPostProcessAdmin(unittest.TestCase):  # pylint:disable=too-many-public
                                       call('Unable to remove temporary directory - %s',
                                            'not-a-file-path.test')])
 
-    @patch('queue_processors.autoreduction_processor.autoreduction_logging_setup.logger.info')
+    @patch(DIR + '.autoreduction_logging_setup.logger.info')
     def test_empty_log_and_message(self, mock_logger):
         ppa = PostProcessAdmin(self.data, None)
         ppa.data['message'] = ''
@@ -198,7 +194,7 @@ class TestPostProcessAdmin(unittest.TestCase):  # pylint:disable=too-many-public
         self.assertEqual(ppa.data['message'], 'test')
         mock_logger.assert_called_with('test')
 
-    @patch('queue_processors.autoreduction_processor.autoreduction_logging_setup.logger.info')
+    @patch(DIR + '.autoreduction_logging_setup.logger.info')
     def test_load_and_message_with_preexisting_message(self, mock_logger):
         ppa = PostProcessAdmin(self.data, None)
         ppa.data['message'] = 'Old message'
@@ -241,9 +237,8 @@ class TestPostProcessAdmin(unittest.TestCase):  # pylint:disable=too-many-public
         ppa._remove_directory(directory_to_remove)
         self.assertFalse(os.path.exists(directory_to_remove))
 
-    @patch('queue_processors.autoreduction_processor.post_process_admin.windows_to_linux_path',
-           return_value='path')
-    @patch('queue_processors.autoreduction_processor.post_process_admin.PostProcessAdmin.reduce')
+    @patch(DIR + '.post_process_admin.windows_to_linux_path', return_value='path')
+    @patch(DIR + '.post_process_admin.PostProcessAdmin.reduce')
     @patch('utils.clients.queue_client.QueueClient.connect')
     @patch('utils.clients.queue_client.QueueClient.__init__', return_value=None)
     def test_main(self, mock_init, mock_connect, mock_reduce, _):
@@ -257,12 +252,10 @@ class TestPostProcessAdmin(unittest.TestCase):  # pylint:disable=too-many-public
         mock_connect.assert_called_once()
         mock_reduce.assert_called_once()
 
-    @patch('queue_processors.autoreduction_processor.post_process_admin.prettify',
-           return_value='test')
+    @patch(DIR + '.post_process_admin.prettify', return_value='test')
     @patch('sys.exit')
-    @patch('queue_processors.autoreduction_processor.autoreduction_logging_setup.logger.info')
-    @patch('queue_processors.autoreduction_processor.post_process_admin.PostProcessAdmin.__init__',
-           return_value=None)
+    @patch(DIR + '.autoreduction_logging_setup.logger.info')
+    @patch(DIR + '.post_process_admin.PostProcessAdmin.__init__', return_value=None)
     @patch('utils.clients.queue_client.QueueClient.send')
     @patch('utils.clients.queue_client.QueueClient.connect')
     @patch('utils.clients.queue_client.QueueClient.__init__', return_value=None)
@@ -287,9 +280,8 @@ class TestPostProcessAdmin(unittest.TestCase):  # pylint:disable=too-many-public
                                           json.dumps(self.data))
 
     @patch('sys.exit')
-    @patch('queue_processors.autoreduction_processor.autoreduction_logging_setup.logger.info')
-    @patch('queue_processors.autoreduction_processor.post_process_admin.PostProcessAdmin.__init__',
-           return_value=None)
+    @patch(DIR + '.autoreduction_logging_setup.logger.info')
+    @patch(DIR + '.post_process_admin.PostProcessAdmin.__init__', return_value=None)
     @patch('utils.clients.queue_client.QueueClient.send')
     @patch('utils.clients.queue_client.QueueClient.connect')
     @patch('utils.clients.queue_client.QueueClient.__init__', return_value=None)

--- a/queue_processors/autoreduction_processor/tests/test_post_process_admin.py
+++ b/queue_processors/autoreduction_processor/tests/test_post_process_admin.py
@@ -123,7 +123,7 @@ class TestPostProcessAdmin(unittest.TestCase):  # pylint:disable=too-many-public
         ppa.data['reduction_data'] = ['']
         ppa.copy_temp_directory(result_dir, copy_dir)
         mock_remove.assert_called_once_with(copy_dir)
-        mock_logger.assert_called_once_with("Moving %s to %s", result_dir, copy_dir)
+        mock_logger.assert_called_with("Moving %s to %s", result_dir, copy_dir)
         mock_copy.assert_called_once_with(result_dir, copy_dir)
         shutil.rmtree(result_dir)
         shutil.rmtree(copy_dir)
@@ -164,8 +164,8 @@ class TestPostProcessAdmin(unittest.TestCase):  # pylint:disable=too-many-public
         activemq_client_mock = Mock()
         ppa = PostProcessAdmin(self.data, activemq_client_mock)
         ppa._send_message_and_log(ACTIVEMQ_SETTINGS.reduction_error)
-        mock_logger.assert_called_once_with("\nCalling " + ACTIVEMQ_SETTINGS.reduction_error
-                                            + " --- " + prettify(self.data))
+        mock_logger.assert_called_with("\nCalling " + ACTIVEMQ_SETTINGS.reduction_error
+                                                    + " --- " + prettify(self.data))
         activemq_client_mock.send.assert_called_once_with(ACTIVEMQ_SETTINGS.reduction_error,
                                                           json.dumps(ppa.data))
 
@@ -196,7 +196,7 @@ class TestPostProcessAdmin(unittest.TestCase):  # pylint:disable=too-many-public
         ppa.data['message'] = ''
         ppa.log_and_message('test')
         self.assertEqual(ppa.data['message'], 'test')
-        mock_logger.assert_called_once_with('test')
+        mock_logger.assert_called_with('test')
 
     @patch('queue_processors.autoreduction_processor.autoreduction_logging_setup.logger.info')
     def test_load_and_message_with_preexisting_message(self, mock_logger):
@@ -204,7 +204,7 @@ class TestPostProcessAdmin(unittest.TestCase):  # pylint:disable=too-many-public
         ppa.data['message'] = 'Old message'
         ppa.log_and_message('New message')
         self.assertEqual(ppa.data['message'], 'Old message')
-        mock_logger.assert_called_once_with('New message')
+        mock_logger.assert_called_with('New message')
 
     def test_remove_with_wait_folder(self):
         directory_to_remove = mkdtemp()

--- a/queue_processors/autoreduction_processor/tests/test_post_process_admin.py
+++ b/queue_processors/autoreduction_processor/tests/test_post_process_admin.py
@@ -50,7 +50,8 @@ class TestPostProcessAdmin(unittest.TestCase):  # pylint:disable=too-many-public
                      'reduction_script': 'print(\'hello\')',
                      'reduction_arguments': 'None'}
         self.test_fname = "111.txt"
-        self.test_root = "test_run"
+        self.test_root = os.path.join("instrument", "GEM", "RBNumber",
+                                      "RB2010163", "autoreduced", "111")
         self.test_paths = [os.path.join(self.test_root, "0"),
                            os.path.join(self.test_root, "1"),
                            os.path.join(self.test_root, "2")]

--- a/queue_processors/autoreduction_processor/tests/test_post_process_admin.py
+++ b/queue_processors/autoreduction_processor/tests/test_post_process_admin.py
@@ -50,13 +50,16 @@ class TestPostProcessAdmin(unittest.TestCase):
                      'reduction_script': 'print(\'hello\')',
                      'reduction_arguments': 'None'}
         # self.test_rel_path = "\\instrument\\GEM\\RBNumber\\RB2010163\\autoreduced\\90369\\"
-        self.test_dir = "\\test\\"
-        self.test_fname = "run_data_file.txt"
+        self.test_fname = "111.txt"
+        self.test_root = "\\test_run\\"
+        self.test_paths = [self.test_root + self.test_fname,
+                           self.test_root + "1\\" + self.test_fname,
+                           self.test_root + "2\\" + self.test_fname]
         # self.remove_test_dir_structure(self.test_dir)
-        self.setup_test_dir_structure(self.test_dir, self.test_fname)
+        self.setup_test_dir_structure(self.test_paths)
 
     def tearDown(self):
-        self.remove_test_dir_structure(self.test_dir)
+        self.remove_test_dir_structure(self.test_root)
 
     @staticmethod
     def remove_test_dir_structure(test_dir):
@@ -70,30 +73,17 @@ class TestPostProcessAdmin(unittest.TestCase):
             shutil.rmtree(test_root)
 
     @staticmethod
-    def setup_test_dir_structure(test_dir, fname):
+    def setup_test_dir_structure(test_paths):
         cwd = os.getcwd()
-        abs_path = cwd + test_dir + fname
-        os.makedirs(abs_path)
+        for file_path in test_paths:
+            (path, file) = file_path.rsplit("\\", 1)
+            abs_path = cwd + path
+            os.makedirs(abs_path)
 
-        abs_file_path = abs_path + fname
-        with open(abs_file_path, 'w') as file:
-            file.write("test file")
+            abs_file_path = cwd + file_path
+            with open(abs_file_path, 'w') as file:
+                file.write("test file")
 
-
-        # exit()
-        # shutil.rmtree(path_parts[0])
-        # if os.path.isdir(os.getcwd() + "\\instrument"):
-        #     print("REMOVE")
-        #     os.rmdir(os.getcwd() + "\\instrument")
-        #
-        # abs_path = os.getcwd() + dir
-        #
-        # os.makedirs(abs_path)
-        # # print(os.path.abspath(self.test_directory))
-        #
-        # abs_file_path = abs_path + "/" + fname
-        # with open(abs_file_path, 'w') as file:
-        #     file.write("test file")
 
     def test_init(self):
         ppa = PostProcessAdmin(self.data, None)

--- a/queue_processors/autoreduction_processor/tests/test_post_process_admin.py
+++ b/queue_processors/autoreduction_processor/tests/test_post_process_admin.py
@@ -49,11 +49,17 @@ class TestPostProcessAdmin(unittest.TestCase):
                      'run_number': '4321',
                      'reduction_script': 'print(\'hello\')',
                      'reduction_arguments': 'None'}
-        self.test_directory = "/instrument/GEM/RBNumber/RB2010163/autoreduced/90369"
-        os.makedirs(self.test_directory)
+        self.test_directory = "/instrument/GEM/RBNumber/RB2010163/autoreduced/90369/"
+        # os.makedirs(self.test_directory)
+        # print(os.path.abspath(self.test_directory))
+        #
+        # self.filename = "rundata.nxs"
+        # path = self.test_directory + "/" + self.filename
+        # with open(path, 'w') as file:
+        #     file.write("test file")
 
-    def tearDown(self):
-        os.rmdir(self.test_directory)
+    # def tearDown(self):
+    #     os.rmdir(self.test_directory)
 
     def test_init(self):
         ppa = PostProcessAdmin(self.data, None)
@@ -286,7 +292,8 @@ class TestPostProcessAdmin(unittest.TestCase):
                                           json.dumps(self.data))
 
     # def test_new_reduction_data_path(self):
-    #     print(os.path.isdir(self.test_directory))
+    #     pass
+        # print(os.path.isdir(self.test_directory))
     #     # directory = "/instrument/GEM/RBNumber/RB2010163/autoreduced/90369"
     #     mock_self = Mock()
     #     mock_self.data = {'overwrite': None}

--- a/queue_processors/autoreduction_processor/tests/test_post_process_admin.py
+++ b/queue_processors/autoreduction_processor/tests/test_post_process_admin.py
@@ -49,17 +49,51 @@ class TestPostProcessAdmin(unittest.TestCase):
                      'run_number': '4321',
                      'reduction_script': 'print(\'hello\')',
                      'reduction_arguments': 'None'}
-        self.test_directory = "/instrument/GEM/RBNumber/RB2010163/autoreduced/90369/"
-        # os.makedirs(self.test_directory)
-        # print(os.path.abspath(self.test_directory))
-        #
-        # self.filename = "rundata.nxs"
-        # path = self.test_directory + "/" + self.filename
-        # with open(path, 'w') as file:
-        #     file.write("test file")
+        # self.test_rel_path = "\\instrument\\GEM\\RBNumber\\RB2010163\\autoreduced\\90369\\"
+        self.test_dir = "\\test\\"
+        self.test_fname = "run_data_file.txt"
+        # self.remove_test_dir_structure(self.test_dir)
+        self.setup_test_dir_structure(self.test_dir, self.test_fname)
 
-    # def tearDown(self):
-    #     os.rmdir(self.test_directory)
+    def tearDown(self):
+        self.remove_test_dir_structure(self.test_dir)
+
+    @staticmethod
+    def remove_test_dir_structure(test_dir):
+        split = test_dir.split("\\")
+        path_parts = [part for part in split if part]   # Removes empty items
+        test_root = path_parts[0]
+
+        cwd = os.getcwd()
+        abs_test_root = cwd + "\\" + test_root
+        if os.path.isdir(abs_test_root):
+            shutil.rmtree(test_root)
+
+    @staticmethod
+    def setup_test_dir_structure(test_dir, fname):
+        cwd = os.getcwd()
+        abs_path = cwd + test_dir + fname
+        os.makedirs(abs_path)
+
+        abs_file_path = abs_path + fname
+        with open(abs_file_path, 'w') as file:
+            file.write("test file")
+
+
+        # exit()
+        # shutil.rmtree(path_parts[0])
+        # if os.path.isdir(os.getcwd() + "\\instrument"):
+        #     print("REMOVE")
+        #     os.rmdir(os.getcwd() + "\\instrument")
+        #
+        # abs_path = os.getcwd() + dir
+        #
+        # os.makedirs(abs_path)
+        # # print(os.path.abspath(self.test_directory))
+        #
+        # abs_file_path = abs_path + "/" + fname
+        # with open(abs_file_path, 'w') as file:
+        #     file.write("test file")
 
     def test_init(self):
         ppa = PostProcessAdmin(self.data, None)
@@ -291,8 +325,8 @@ class TestPostProcessAdmin(unittest.TestCase):
         mock_send.assert_called_once_with(ACTIVEMQ_SETTINGS.reduction_error,
                                           json.dumps(self.data))
 
-    # def test_new_reduction_data_path(self):
-    #     pass
+    def test_new_reduction_data_path(self):
+        pass
         # print(os.path.isdir(self.test_directory))
     #     # directory = "/instrument/GEM/RBNumber/RB2010163/autoreduced/90369"
     #     mock_self = Mock()

--- a/queue_processors/queue_processor/queue_processor.py
+++ b/queue_processors/queue_processor/queue_processor.py
@@ -387,6 +387,8 @@ class Listener:
         session.add(reduction_run)
         session.commit()
 
+        # Note: once the Message class fully integrated, won't need to check data_dict has
+        #  attributes like the first part of this condition
         if 'retry_in' in self._data_dict and 'retry_in' is not None:
             experiment = session.query(Experiment).filter_by(
                 reference_number=self._data_dict['rb_number']).first()

--- a/queue_processors/queue_processor/queue_processor.py
+++ b/queue_processors/queue_processor/queue_processor.py
@@ -389,7 +389,7 @@ class Listener:
 
         # Note: once the Message class fully integrated, won't need to check data_dict has
         #  attributes like the first part of this condition
-        if 'retry_in' in self._data_dict and 'retry_in' is not None:
+        if 'retry_in' in self._data_dict and self._data_dict['retry_in'] is not None:
             experiment = session.query(Experiment).filter_by(
                 reference_number=self._data_dict['rb_number']).first()
             previous_runs = session.query(ReductionRun).filter_by(

--- a/queue_processors/queue_processor/queue_processor.py
+++ b/queue_processors/queue_processor/queue_processor.py
@@ -187,6 +187,7 @@ class Listener:
         # Create a new data location entry which has a foreign key linking it to the current
         # reduction run. The file path itself will point to a datafile
         # (e.g. "\isis\inst$\NDXWISH\Instrument\data\cycle_17_1\WISH00038774.nxs")
+        logger.info("data dict: %s", self._data_dict)
         data_location = DataLocation(file_path=self._data_dict['data'],
                                      reduction_run_id=reduction_run.id) # pylint: disable=no-member
         session.add(data_location)

--- a/queue_processors/queue_processor/queue_processor.py
+++ b/queue_processors/queue_processor/queue_processor.py
@@ -387,7 +387,7 @@ class Listener:
         session.add(reduction_run)
         session.commit()
 
-        if 'retry_in' in self._data_dict:
+        if 'retry_in' in self._data_dict and 'retry_in' is not None:
             experiment = session.query(Experiment).filter_by(
                 reference_number=self._data_dict['rb_number']).first()
             previous_runs = session.query(ReductionRun).filter_by(

--- a/scripts/manual_operations/manual_submission.py
+++ b/scripts/manual_operations/manual_submission.py
@@ -38,7 +38,7 @@ def submit_run(active_mq_client, rb_number, instrument, data_file_location, run_
 
     message = Message(rb_number=rb_number,
                       instrument=instrument,
-                      file_path=data_file_location,
+                      data=data_file_location,
                       run_number=run_number,
                       started_by=-1)
     active_mq_client.send('/queue/DataReady', message, priority=1)

--- a/scripts/manual_operations/tests/test_manual_submission.py
+++ b/scripts/manual_operations/tests/test_manual_submission.py
@@ -150,7 +150,7 @@ class TestManualSubmission(unittest.TestCase):
         ms.submit_run(*self.sub_run_args)
         message = Message(rb_number=self.sub_run_args[1],
                           instrument=self.sub_run_args[2],
-                          file_path=self.sub_run_args[3],
+                          data=self.sub_run_args[3],
                           run_number=self.sub_run_args[4],
                           started_by=-1)
         self.sub_run_args[0].send.assert_called_with('/queue/DataReady',


### PR DESCRIPTION
### Summary of work
- This PR refactors the code which handles cases where the overwrite flag is False/None in `post_process_admin.reduce`
- The old implementation was broken, but never used until changes to other areas of the code were changed (#557)
- _Note: to enable this code to run, additional changes were required._
  * Due to the Message class having been integrated into manual submission (#542), the data dictionary passed to PPA contained a full set of keys.
  * The previous code only checked whether a `message` key existed. This PR extended this by checking whether the value was `None`.
  * Additionally, since message cannot be null in the DB, this PR converts a None `message` to `=""`
    * This is an open question regarding where in the code this should occur.
___
- Additionally, this PR cherry-picks commits from #557 which revert the data_dict keys (/Message attributes) to their original names

### How to test your work
- Pull the code to the dev server
- Perform a manual submission
- Ensure the run completes without error

### Additional comments
<!---Anything else: e.g. was the estimate reasonable for this issue?---> 

Fixes #564


**Before merging ensure the release notes have been updated**