### PR TITLE
Remove django ORM from manual_remove.py

### DIFF
--- a/scripts/manual_operations/README.md
+++ b/scripts/manual_operations/README.md
@@ -37,13 +37,5 @@ Example:
 ```
 $ python manual_remove.py WISH 40421
 ```
-When you want to submit multiple contiguous datafiles/runs for reduction.
-```
-$ python manual_remove.py [Instrument Name] [Start Run Number] -e [End Run Number]
-```
-Example:
-```
-$ python manual_remove.py WISH 40421 -e 40425
-```
 
 *Note: Whilst runs are removed from the database, the reduce data will still remain on CEPH*

--- a/scripts/manual_operations/manual_remove.py
+++ b/scripts/manual_operations/manual_remove.py
@@ -19,6 +19,9 @@ class ManualRemove:
     """
 
     def __init__(self, instrument):
+        """
+        :param instrument: (str) The name of the instrument associated with runs
+        """
         self.database = DatabaseClient()
         self.database.connect()
         self.to_delete = {}
@@ -27,7 +30,7 @@ class ManualRemove:
     def find_runs_in_database(self, run_number):
         """
         Find all run versions in the database that relate to a given instrument and run number
-        :param run_number: the run to search for in the database
+        :param run_number: (int) The run to search for in the database
         :return: The result of the query
         """
         instrument_record = self.database.get_instrument(self.instrument)
@@ -54,7 +57,7 @@ class ManualRemove:
     def run_not_found(self, run_number):
         """
         Inform user and remove key from dictionary
-        :param run_number: The run to remove from the dictionary
+        :param run_number: (int) The run to remove from the dictionary
         """
         print('No runs found associated with {} for instrument {}'.format(run_number,
                                                                           self.instrument))
@@ -64,7 +67,7 @@ class ManualRemove:
         """
         Ask the user which versions they want to remove
         Update the self.to_delete dictionary by removing unwanted versions
-        :param run_number: The run number with multiple versions
+        :param run_number: (int) The run number with multiple versions
         """
         # Display run_number - title - version for all matching runs
         print("Discovered multiple reduction versions for {}{}:".format(self. instrument,
@@ -106,7 +109,7 @@ class ManualRemove:
     def delete_reduction_location(self, reduction_run_id):
         """
         Delete a ReductionLocation record from the database
-        :param reduction_run_id: The id of the associated reduction job
+        :param reduction_run_id: (int) The id of the associated reduction job
         """
         self.database.data_model.ReductionLocation.objects \
             .filter(reduction_run_id=reduction_run_id) \
@@ -115,7 +118,7 @@ class ManualRemove:
     def delete_data_location(self, reduction_run_id):
         """
         Delete a DataLocation record from the database
-        :param reduction_run_id: The id of the associated reduction job
+        :param reduction_run_id: (int) The id of the associated reduction job
         """
         self.database.data_model.DataLocation.objects \
             .filter(reduction_run_id=reduction_run_id) \
@@ -124,7 +127,7 @@ class ManualRemove:
     def delete_variables(self, reduction_run_id):
         """
         Removes all the RunVariable records associated with a given ReductionRun from the database
-        :param reduction_run_id: The id of the associated reduction job
+        :param reduction_run_id: (int) The id of the associated reduction job
         """
         run_variables = self.find_variables_of_reduction(reduction_run_id)
         for record in run_variables:
@@ -135,8 +138,8 @@ class ManualRemove:
     def find_variables_of_reduction(self, reduction_run_id):
         """
         Find all the RunVariable records in the database associated with a reduction job
-        :param reduction_run_id: The id of the reduction job to filter by
-        :return: A QuerySet of the associated RunVariables
+        :param reduction_run_id: (int) The id of the reduction job to filter by
+        :return: (QuerySet) of the associated RunVariables
         """
         return self.database.variable_model.RunVariable.objects \
             .filter(reduction_run_id=reduction_run_id)
@@ -144,7 +147,7 @@ class ManualRemove:
     def delete_reduction_run(self, reduction_run_id):
         """
         Delete a ReductionRun record from the database
-        :param reduction_run_id: The id of the associated reduction job
+        :param reduction_run_id: (int) The id of the associated reduction job
         """
         self.database.data_model.ReductionRun.objects \
             .filter(id=reduction_run_id) \

--- a/scripts/manual_operations/tests/test_manual_remove.py
+++ b/scripts/manual_operations/tests/test_manual_remove.py
@@ -11,55 +11,64 @@ import unittest
 import builtins
 import sys
 
-from mock import Mock, patch, call
+from mock import patch, call, Mock
 
 from scripts.manual_operations.manual_remove import ManualRemove, main, remove
-from utils.clients.database_client import DatabaseClient
-from utils.settings import MYSQL_SETTINGS
+from utils.clients.django_database_client import DatabaseClient
 
 
-# pylint:disable=invalid-name
-class TestManualSubmission(unittest.TestCase):
+# pylint:disable=invalid-name,too-many-public-methods
+class TestManualRemove(unittest.TestCase):
     """
-    Test manual_submission.py
+    Test manual_remove.py
     """
     def setUp(self):
-        self.manual_remove = ManualRemove(instrument='GEM', credentials=MYSQL_SETTINGS)
+        self.manual_remove = ManualRemove(instrument='GEM')
         # Setup database connection so it is possible to use
         # ReductionRun objects with valid meta data
-        self.database_client = DatabaseClient(MYSQL_SETTINGS)
+        self.database_client = DatabaseClient()
         self.database_client.connect()
 
         # Fake ReductionRun objects for testing
-        self.gem_object_1 = self.database_client.reduction_run()
-        self.gem_object_1.run_number = '123'
-        self.gem_object_1.run_name = 'first version of GEM123'
-        self.gem_object_1.run_version = '1'
+        self.gem_object_1 = self.database_client.data_model.ReductionRun(run_number='123',
+                                                                         run_name='v1 of GEM123',
+                                                                         run_version='1')
 
-        self.gem_object_2 = self.database_client.reduction_run()
-        self.gem_object_2.run_number = '123'
-        self.gem_object_2.run_name = 'second version of GEM123'
-        self.gem_object_2.run_version = '2'
+        self.gem_object_2 = self.database_client.data_model.ReductionRun(run_number='123',
+                                                                         run_name='v2 of GEM123',
+                                                                         run_version='2')
+
+    @staticmethod
+    def _run_variable(reduction_run_id=None, variable_ptr_id=None):
+        """
+        Create a mock object that represents a RunVariable object from the database
+        """
+        mock = Mock()
+        mock.reduction_run_id = reduction_run_id
+        mock.variable_ptr_id = variable_ptr_id
+        return mock
 
     def test_find_run(self):
         """
-        Check if a run exists in the database
+        Test: The correct number of runs are discovered
+        When: find_runs_in_database is called
         """
         actual = self.manual_remove.find_runs_in_database(run_number='001')
         self.assertEqual(2, len(actual))
 
     def test_find_run_invalid(self):
         """
-        Check if a run does not exist in the database
+        Test: An empty list is returned
+        When find_runs_in_database does not find any runs
         """
         actual = self.manual_remove.find_runs_in_database(run_number='000')
-        expected = []
-        self.assertEqual(expected, actual)
+        self.assertEqual(0, len(actual))
 
     @patch('scripts.manual_operations.manual_remove.ManualRemove.run_not_found')
     def test_process_results_not_found(self, mock_not_found):
         """
-        Test process_results function routes to correct function if the run is not found
+        Test: run_not_found is called
+        When: No matching records are found in the database
         """
         self.manual_remove.to_delete['123'] = []
         self.manual_remove.process_results()
@@ -69,7 +78,8 @@ class TestManualSubmission(unittest.TestCase):
     @patch('scripts.manual_operations.manual_remove.ManualRemove.multiple_versions_found')
     def test_process_results_single(self, mock_multi, mock_not_found):
         """
-        Test that if the results only contain single runs then just continue
+        Test: That the code falls through to multiple_version_found
+        When If the results only contain single runs (not multiple versions)
         """
         self.manual_remove.to_delete['123'] = ['test']
         self.manual_remove.process_results()
@@ -79,7 +89,9 @@ class TestManualSubmission(unittest.TestCase):
     @patch('scripts.manual_operations.manual_remove.ManualRemove.multiple_versions_found')
     def test_process_results_multi(self, mock_multi_version):
         """
-        Test process_results function routes to correct function if the run has multiple versions
+        Test: process_results function routes to correct function if the run has multiple versions
+        When: Multiple runs / versions are found in the database
+
         Note: for this test the content of results[key] list does not have to be Run objects
         """
         self.manual_remove.to_delete['123'] = ['test', 'test2']
@@ -88,7 +100,8 @@ class TestManualSubmission(unittest.TestCase):
 
     def test_run_not_found(self):
         """
-        Test that the corresponding key is deleted if the value if empty
+        Test: The correct corresponding key is deleted
+        When: The value of the key is empty
         """
         self.manual_remove.to_delete['123'] = []
         self.manual_remove.run_not_found('123')
@@ -98,7 +111,8 @@ class TestManualSubmission(unittest.TestCase):
     @patch.object(builtins, 'input')
     def test_multiple_versions_found_single_input(self, mock_input, mock_validate_csv):
         """
-        Test that the user is not asked more than once for input if the input is valid
+        Test: That the user is not asked more than once for input
+        When: The input is valid
         """
         self.manual_remove.to_delete['123'] = [self.gem_object_1,
                                                self.gem_object_2]
@@ -114,7 +128,8 @@ class TestManualSubmission(unittest.TestCase):
     @patch.object(builtins, 'input')
     def test_multiple_versions_retry_user_input(self, mock_input, mock_validate_csv):
         """
-        Test if the user gives incorrect input it is re-validated
+        Test: Input is re-validated
+        When: the user initially gives incorrect input
         """
         self.manual_remove.to_delete['123'] = [self.gem_object_1,
                                                self.gem_object_2]
@@ -129,7 +144,8 @@ class TestManualSubmission(unittest.TestCase):
     @patch.object(builtins, 'input')
     def test_multiple_versions_found_list_input(self, mock_input, mock_validate_csv):
         """
-        Test that the user is not asked more than once for input if the input is valid
+        Test: The correct version is delete
+        When: The user asks to delete the second run version
         """
         self.manual_remove.to_delete['123'] = [self.gem_object_1,
                                                self.gem_object_2]
@@ -140,74 +156,34 @@ class TestManualSubmission(unittest.TestCase):
         # We said to delete version 2 so it should be the only entry for that run number
         self.assertEqual(2, len(self.manual_remove.to_delete['123']))
 
-    @patch('scripts.manual_operations.manual_remove.ManualRemove.delete_record')
-    def test_delete_records(self, mock_delete):
-        """
-        Test that the correct query is sent to attempt to delete a record from the database
-        """
-        self.manual_remove.find_runs_in_database('1')
-        self.assertEqual(2, len(self.manual_remove.to_delete['1']))
-        del self.manual_remove.to_delete['1'][0]
-        # have to use long as this is supported type in DB
-        self.assertEqual(int(1), self.manual_remove.to_delete['1'][0].run_version)
-        self.manual_remove.delete_records()
-        self.assertEqual(0, len(self.manual_remove.to_delete))
-        # Ensure that the delete functions were called on the expected tables
-        mocked_delete_calls = mock_delete.call_args_list
-        self.assertEqual(type(self.database_client.reduction_location()),
-                         type(mocked_delete_calls[0][0][0]))
-        self.assertEqual(type(self.database_client.reduction_data_location()),
-                         type(mocked_delete_calls[1][0][0]))
-        self.assertEqual(type(self.database_client.run_variables()),
-                         type(mocked_delete_calls[2][0][0]))
-        self.assertEqual(type(self.database_client.reduction_run()),
-                         type(mocked_delete_calls[3][0][0]))
-
-    @patch('utils.clients.database_client.DatabaseClient.get_connection')
-    def test_delete_record_from_database(self, mock_get_connection):
-        """
-        Test that the correct functions are called on the database for deleting runs
-        """
-        # Construct mocks for  connection, query and filter sub calls
-        database_connection_mock = Mock()
-        query_mock = Mock()
-        filter_mock = Mock()
-        database_connection_mock.query.return_value = query_mock
-        query_mock.filter.return_value = filter_mock
-        mock_get_connection.return_value = database_connection_mock
-
-        # Run test code
-        self.manual_remove.delete_record('database query', 'filter_value')
-        mock_get_connection.assert_called_once()
-        database_connection_mock.query.assert_called_once_with('database query')
-        query_mock.filter.assert_called_once_with('filter_value')
-        filter_mock.delete.assert_called_once()
-        database_connection_mock.commit.assert_called_once()
-
     def test_validate_csv_single_val(self):
         """
-        Test user input validation
+        Test: For expected validation result
+        When: user input contains a single run
         """
         actual = self.manual_remove.validate_csv_input('1')
         self.assertEqual((True, [1]), actual)
 
     def test_validate_csv_single_val_invalid(self):
         """
-        Tests user input validation with single value that is invalid
+        Test: For expected validation result (False, [])
+        When: user input validation with single value that is invalid
         """
         actual = self.manual_remove.validate_csv_input('a')
         self.assertEqual((False, []), actual)
 
     def test_validate_csv_list(self):
         """
-        Test user input validation
+        Test: For expected validation result
+        When: user input contains multiple runs
         """
         actual = self.manual_remove.validate_csv_input('1,2,3')
         self.assertEqual((True, [1, 2, 3]), actual)
 
     def test_validate_csv_invalid(self):
         """
-        Test user input validation
+        Test: For expected validation result (False, [])
+        When: User input is invalid type and multiple
         """
         actual = self.manual_remove.validate_csv_input('t,e,s,t')
         self.assertEqual((False, []), actual)
@@ -218,7 +194,8 @@ class TestManualSubmission(unittest.TestCase):
     @patch('scripts.manual_operations.manual_remove.ManualRemove.delete_records')
     def test_main(self, mock_delete, mock_process, mock_find):
         """
-        Tests the main() function that is used to control the ManualRemove class
+        Test: The correct control functions are called
+        When: The main() function is called
         """
         sys.argv = ['', 'GEM', '1']
         main()
@@ -233,9 +210,88 @@ class TestManualSubmission(unittest.TestCase):
     @patch('scripts.manual_operations.manual_remove.ManualRemove.delete_records')
     def test_run(self, mock_delete, mock_process, mock_find):
         """
-        Tests the run() function that is used to control the ManualRemove class
+        Test: The correct control functions are called
+        When: The run() function is called
         """
         remove('GEM', 1)
         mock_find.assert_called_once_with(1)
         mock_process.assert_called_once()
         mock_delete.assert_called_once()
+
+    def test_delete_data_location(self):
+        """
+        Test: The correct query is run and associated records are removed
+        When: calling delete_data_location
+        """
+        mock_data_model = Mock()
+        self.manual_remove.database.data_model = mock_data_model
+        self.manual_remove.delete_data_location(123)
+        mock_data_model.DataLocation.objects.filter.\
+            assert_called_once_with(reduction_run_id=123)
+
+    def test_delete_reduction_location(self):
+        """
+        Test: The correct query is run and associated records are removed
+        When: calling delete_reduction_location
+        """
+        mock_data_model = Mock()
+        self.manual_remove.database.data_model = mock_data_model
+        self.manual_remove.delete_reduction_location(123)
+        mock_data_model.ReductionLocation.objects.filter.\
+            assert_called_once_with(reduction_run_id=123)
+
+    def test_delete_reduction_run_location(self):
+        """
+        Test: The correct query is run and associated records are removed
+        When: calling delete_reduction_run_location
+        """
+        mock_data_model = Mock()
+        self.manual_remove.database.data_model = mock_data_model
+        self.manual_remove.delete_reduction_run(123)
+        mock_data_model.ReductionRun.objects.filter.assert_called_once_with(id=123)
+
+    @patch('scripts.manual_operations.manual_remove.ManualRemove.delete_reduction_location')
+    @patch('scripts.manual_operations.manual_remove.ManualRemove.delete_data_location')
+    @patch('scripts.manual_operations.manual_remove.ManualRemove.delete_variables')
+    @patch('scripts.manual_operations.manual_remove.ManualRemove.delete_reduction_run')
+    def test_delete_records(self, mock_rr, mock_rv, mock_dl, mock_rl):
+        """
+        Test: The appropriate functions are called with expected variables
+        When: delete_records is called while self.to_delete is populated
+        """
+        mock_record = Mock()
+        mock_record.id = 12
+        self.manual_remove.to_delete = {'1234': [mock_record]}
+        self.manual_remove.delete_records()
+        mock_rr.assert_called_once_with(12)
+        mock_rv.assert_called_once_with(12)
+        mock_dl.assert_called_once_with(12)
+        mock_rl.assert_called_once_with(12)
+
+    def test_find_variables(self):
+        """
+        Test: The correct query is run
+        When: calling find_variables_of_reduction
+        """
+        mock_variable_model = Mock()
+        self.manual_remove.database.variable_model = mock_variable_model
+        self.manual_remove.find_variables_of_reduction(123)
+        mock_variable_model.RunVariable.objects.filter \
+            .assert_called_once_with(reduction_run_id=123)
+
+    @patch('scripts.manual_operations.manual_remove.ManualRemove.find_variables_of_reduction')
+    def test_delete_variables(self, mock_find_vars):
+        """
+        Test: ALL variable records are successfully deleted from the database
+        When: delete_variables function is called.
+        """
+        mock_run_variables = [self._run_variable(variable_ptr_id=3),
+                              self._run_variable(variable_ptr_id=5)]
+        mock_find_vars.return_value = mock_run_variables
+        mock_variable_model = Mock()
+        self.manual_remove.database.variable_model = mock_variable_model
+        self.manual_remove.delete_variables(20)
+        mock_find_vars.assert_called_once_with(20)
+        mock_variable_model.RunVariable.objects.filter \
+            .assert_has_calls(([call(variable_ptr_id=3), call().delete(),
+                                call(variable_ptr_id=5), call().delete()]))

--- a/utils/clients/database_client.py
+++ b/utils/clients/database_client.py
@@ -119,54 +119,6 @@ class DatabaseClient(AbstractClient):
                                       foreign_keys='ReductionRun.experiment_id')
         return ReductionRun
 
-    def reduction_data_location(self):
-        """
-        :return: ReductionDataLocation Table to replicate what we expect in the database
-        """
-        # pylint: disable=too-few-public-methods
-        class ReductionDataLocation(declarative_base()):
-            """
-            Table for reduction_viewer_datalocation entity
-            """
-            __table__ = Table('reduction_viewer_datalocation',
-                              self._meta_data, autoload=True,
-                              autoload_with=self._engine)
-            reduction_run = relationship(self.reduction_run(),
-                                         foreign_keys='ReductionDataLocation.reduction_run_id')
-        return ReductionDataLocation
-
-    def reduction_location(self):
-        """
-        :return: ReductionLocation Table to replicate what we expect in the database
-        """
-        # pylint: disable=too-few-public-methods
-        class ReductionLocation(declarative_base()):
-            """
-            Table for reduction_viewer_reductionlocation entity
-            """
-            __table__ = Table('reduction_viewer_reductionlocation',
-                              self._meta_data, autoload=True,
-                              autoload_with=self._engine)
-            reduction_run = relationship(self.reduction_run(),
-                                         foreign_keys='ReductionLocation.reduction_run_id')
-        return ReductionLocation
-
-    def run_variables(self):
-        """
-        :return: RunVariables Table to replicate what we expect in the database
-        """
-        # pylint: disable=too-few-public-methods
-        class RunVariable(declarative_base()):
-            """
-            Table for reduction_variables_runvariable entity
-            """
-            __table__ = Table('reduction_variables_runvariable',
-                              self._meta_data, autoload=True,
-                              autoload_with=self._engine)
-            reduction_run = relationship(self.reduction_run(),
-                                         foreign_keys='RunVariable.reduction_run_id')
-        return RunVariable
-
     def experiment(self):
         """
         :return: Experiment Table to replicate what we expect in the database


### PR DESCRIPTION
### Summary of work
* Remove use of old database SQLAlchemy connections in manual_remove.
* Update tests to use Django ORM 

### How to test your work
* Ensure the tests pass
* Attempt to use the script to manually remove a run from the database
   * see instructions in `scripts/manual_operations/README.md` 

Part of #546 

**Before merging ensure the release notes have been updated**