### PR TITLE
Move block scripts sections to it's previous state

### DIFF
--- a/WebApp/autoreduce_webapp/templates/base.html
+++ b/WebApp/autoreduce_webapp/templates/base.html
@@ -28,13 +28,12 @@
                 {% block footer %}{% endblock %}
                 {% include "footer.html" %}
             </div>
-            {% block scripts %}
             <script src="{% static "javascript/vendor/jquery.min.js" %}"></script>
             <script src="{% static "javascript/vendor/bootstrap.min.js" %}"></script>
             <script src="{% static "javascript/cookies.js" %}"></script>
             <script src="{% static "javascript/polyfills.js" %}"></script>
             <script src="{% static "javascript/base.js" %}"></script>
-            {% endblock %}
+            {% block scripts %}{% endblock %}
             <title>ISIS Auto-reduction</title>
         {% endif %}
     </body>


### PR DESCRIPTION
### Summary of work
- Reverts a change made in #550 which caused a bug
- For an unknown reason, this caused jQuery (and potentially other scripts) to not load on run_summary.js (and presumably other pages since the change was in `base.html`).

### How to test your work
- Ensure scripts load throughout webapp as expected.

Fixes #589 


**Before merging ensure the release notes have been updated**