### PR TITLE
Integrate Message into test_end_to_end

### DIFF
--- a/monitors/tests/test_run_detection.py
+++ b/monitors/tests/test_run_detection.py
@@ -159,7 +159,6 @@ class TestRunDetection(unittest.TestCase):
     def test_submit_run_invalid_nexus(self, read_rb_mock, isfile_mock):
         client = Mock()
         client.send = Mock(return_value=None)
-        client.serialise_data = Mock(return_value=RUN_DATA['summary_rb_number'])
 
         inst_mon = InstrumentMonitor(client, 'WISH')
         inst_mon.data_dir = '/my/data/dir'

--- a/systemtests/test_end_to_end.py
+++ b/systemtests/test_end_to_end.py
@@ -11,7 +11,6 @@ Tests that data can traverse through the autoreduction system successfully
 from __future__ import print_function
 import os
 import unittest
-import json
 import time
 import shutil
 

--- a/systemtests/test_end_to_end.py
+++ b/systemtests/test_end_to_end.py
@@ -15,6 +15,7 @@ import json
 import time
 import shutil
 
+from message.job import Message
 from scripts.manual_operations import manual_remove as remove
 
 from utils import service_handling as external
@@ -74,13 +75,15 @@ if os.name != 'nt':
                                                         vars_script='')
 
             # Create and send json message to ActiveMQ
-            data_ready_message = self.queue_client.serialise_data(rb_number=self.rb_number,
-                                                                  instrument=self.instrument,
-                                                                  location=file_location,
-                                                                  run_number=self.run_number,
-                                                                  started_by=0)
+            data_ready_message = Message(rb_number=self.rb_number,
+                                         instrument=self.instrument,
+                                         data=file_location,
+                                         run_number=self.run_number,
+                                         facility="ISIS",
+                                         started_by=0)
+
             self.queue_client.send('/queue/DataReady',
-                                   json.dumps(data_ready_message))
+                                   data_ready_message)
 
             # Get Result from database
             results = self._find_run_in_database()
@@ -105,13 +108,15 @@ if os.name != 'nt':
                                                         vars_script='')
 
             # Create and send json message to ActiveMQ
-            data_ready_message = self.queue_client.serialise_data(instrument=self.instrument,
-                                                                  rb_number=self.rb_number,
-                                                                  run_number=self.run_number,
-                                                                  location=file_location,
-                                                                  started_by=0)
+            data_ready_message = Message(rb_number=self.rb_number,
+                                         instrument=self.instrument,
+                                         data=file_location,
+                                         run_number=self.run_number,
+                                         facility="ISIS",
+                                         started_by=0)
+
             self.queue_client.send('/queue/DataReady',
-                                   json.dumps(data_ready_message))
+                                   data_ready_message)
 
             # Get Result from database
             results = self._find_run_in_database()

--- a/utils/clients/queue_client.py
+++ b/utils/clients/queue_client.py
@@ -134,21 +134,6 @@ class QueueClient(AbstractClient):
         # pylint:disable=no-value-for-parameter
         self._connection.ack(frame)
 
-    @staticmethod
-    def serialise_data(rb_number, instrument, location, run_number, started_by):
-        """
-        Packs the specified data into a dictionary ready to send to a processor queue
-        """
-        # pylint:disable=fixme
-        # TODO: When this method is removed, need to ensure caller adds facility themselves
-        #   OR set facility default to "ISIS"?
-        return {'rb_number': rb_number,
-                'instrument': instrument,
-                'data': location,
-                'run_number': run_number,
-                'facility': 'ISIS',
-                'started_by': started_by}
-
     # pylint:disable=too-many-arguments
     def send(self, destination, message, persistent='true', priority='4', delay=None):
         """

--- a/utils/clients/tests/test_queue_client.py
+++ b/utils/clients/tests/test_queue_client.py
@@ -87,20 +87,6 @@ class TestQueueClient(unittest.TestCase):
         client.disconnect()
         self.assertIsNone(client._connection)
 
-    def test_serialise_message(self):
-        """
-        Test: Data is correctly serialised
-        When: serialise_data is called with valid arguments
-        """
-        client = QueueClient()
-        data = client.serialise_data('123', 'WISH', 'file/path', '001', 0)
-        self.assertEqual(data['rb_number'], '123')
-        self.assertEqual(data['instrument'], 'WISH')
-        self.assertEqual(data['data'], 'file/path')
-        self.assertEqual(data['run_number'], '001')
-        self.assertEqual(data['facility'], 'ISIS')
-        self.assertEqual(data['started_by'], 0)
-
     # pylint:disable=no-self-use
     @patch('stomp.connect.StompConnection11.send')
     def test_send_with_raw_string(self, mock_stomp_send):


### PR DESCRIPTION
### Summary of work
- This PR integrates the Message class into `test_end_to_end`.
- This in turn removes the last usage of `queue_client.serialise_data` (outside of tests), and therefore this method was removed as well.

### How to test your work
- Ensure tests pass
- Test on dev

### Additional comments
- This is part of a series of PRs to integrate the Message class throughout the database.
- After this branch and #584 are merged, only the WebApp is not covered by Message integration.
- This change was attempted before but failed due to not accounting for `facility="ISIS"`

Fixes #512

**Before merging ensure the release notes have been updated**