### PR TITLE
reduction_message not null and instrument used

### DIFF
--- a/message/job.py
+++ b/message/job.py
@@ -38,8 +38,8 @@ class Message:
     job_id = attr.ib(default=None)
     reduction_script = attr.ib(default=None)
     reduction_arguments = attr.ib(default=None)
-    reduction_log = attr.ib(default=None)
-    admin_log = attr.ib(default=None)
+    reduction_log = attr.ib(default="")  # Cannot be null in database
+    admin_log = attr.ib(default="")  # Cannot be null in database
     message = attr.ib(default=None)
     retry_in = attr.ib(default=None)
     reduction_data = attr.ib(default=None)  # Required by PPA

--- a/message/tests/test_job.py
+++ b/message/tests/test_job.py
@@ -38,8 +38,8 @@ class TestMessage(unittest.TestCase):
                       'job_id': None,
                       'reduction_script': None,
                       'reduction_arguments': None,
-                      'reduction_log': None,
-                      'admin_log': None,
+                      'reduction_log': "",
+                      'admin_log': "",
                       'return_message': None,
                       'retry_in': None}
         return empty_msg, empty_dict
@@ -65,8 +65,8 @@ class TestMessage(unittest.TestCase):
                           'job_id': None,
                           'reduction_script': None,
                           'reduction_arguments': None,
-                          'reduction_log': None,
-                          'admin_log': None,
+                          'reduction_log': "",
+                          'admin_log': "",
                           'message': None,
                           'retry_in': None,
                           'reduction_data': None,
@@ -92,8 +92,8 @@ class TestMessage(unittest.TestCase):
         self.assertIsNone(empty_msg.job_id)
         self.assertIsNone(empty_msg.reduction_script)
         self.assertIsNone(empty_msg.reduction_arguments)
-        self.assertIsNone(empty_msg.reduction_log)
-        self.assertIsNone(empty_msg.admin_log)
+        self.assertEqual(empty_msg.reduction_log, "")
+        self.assertEqual(empty_msg.admin_log, "")
         self.assertIsNone(empty_msg.message)
         self.assertIsNone(empty_msg.retry_in)
         self.assertIsNone(empty_msg.reduction_data)

--- a/monitors/run_detection.py
+++ b/monitors/run_detection.py
@@ -129,7 +129,8 @@ class InstrumentMonitor:
             if rb_number is None:
                 rb_number = summary_rb_number
             EORM_LOG.info("Submitting '%s' with RB number '%s'", file_name, rb_number)
-            message = Message(rb_number=rb_number,
+            message = Message(instrument=self.instrument_name,
+                              rb_number=rb_number,
                               run_number=run_number,
                               data=file_path)
             self.client.send('/queue/DataReady', message, priority='9')

--- a/monitors/tests/test_run_detection.py
+++ b/monitors/tests/test_run_detection.py
@@ -134,7 +134,8 @@ class TestRunDetection(unittest.TestCase):
         data_loc = os.path.join(inst_mon.data_dir, CYCLE_FOLDER, FILE_NAME)
 
         inst_mon.submit_run(RUN_DATA['summary_rb_number'], RUN_DATA['run_number'], FILE_NAME)
-        message = Message(rb_number=RUN_DATA['rb_number'],
+        message = Message(instrument='WISH',
+                          rb_number=RUN_DATA['rb_number'],
                           run_number=RUN_DATA['run_number'],
                           data=data_loc)
         client.send.assert_called_with('/queue/DataReady', message, priority='9')
@@ -165,7 +166,8 @@ class TestRunDetection(unittest.TestCase):
         data_loc = os.path.join(inst_mon.data_dir, CYCLE_FOLDER, FILE_NAME)
 
         inst_mon.submit_run(RUN_DATA['summary_rb_number'], RUN_DATA['run_number'], FILE_NAME)
-        message = Message(rb_number=RUN_DATA['summary_rb_number'],
+        message = Message(instrument='WISH',
+                          rb_number=RUN_DATA['summary_rb_number'],
                           run_number=RUN_DATA['run_number'],
                           data=data_loc)
         client.send.assert_called_with('/queue/DataReady',


### PR DESCRIPTION
### Summary of work
* Fix run submission process
* Add defaults to some Message elements

### How to test your work
* checkout this branch on develop ingestion node
* change the most recent run for an instrument in the `C:\lastrun\lastrun.csv` file
* check these runs get re-submitted and go through the webapp / db correctly

### Additional comments
This is currently broken on production


**Before merging ensure the release notes have been updated**