### PR TITLE
Remove all ICAT references from build script

### DIFF
--- a/build/commands/help.py
+++ b/build/commands/help.py
@@ -42,7 +42,7 @@ class Help(Command):
                     ('     externals', 'Install all external programs'),
                     ('              ', 'Use the -s argument to specify a comma'
                                        'separated list of services:'),
-                    ('              ', '    python setup.py externals -s activemq,icat,mantid'),
+                    ('              ', '    python setup.py externals -s activemq,mantid'),
                     ('     start', 'starts required services: activemq'),
                     ('     help', 'Show the help documentation')
                    )

--- a/build/commands/installs.py
+++ b/build/commands/installs.py
@@ -8,7 +8,6 @@
 Module to install external programs not required by the project
 7zip
 ActiveMQ
-ICAT
 Mantid
 """
 import sys
@@ -47,7 +46,6 @@ class InstallExternals(Command):
             self.services = service_dict
         else:
             self.services = {'activemq': False,
-                             'icat': False,
                              'mantid': False}
         if os.name == 'nt' and '7zip' not in self.services:
             self.services['7zip'] = False
@@ -135,7 +133,7 @@ class InstallExternals(Command):
     def _validate_services(list_of_services, quiet=True):
         """
         Check if services are installed and usable. Current checks:
-            7Zip, ActiveMQ, icat, Mantid
+            7Zip, ActiveMQ, Mantid
         :param quiet: boolean to decide if anything is printed on validation failure
         :return: dictionary of {"service_name": validity(True/False)}
         """

--- a/build/install/activemq.bat
+++ b/build/install/activemq.bat
@@ -15,11 +15,17 @@ if not exist %folder% (
 
 if not exist %destination% (
     echo Information: Downloading activemq - this could take several minutes
-    powershell -Command "(new-object System.Net.WebClient).DownloadFile('http://www.apache.org/dyn/closer.cgi?filename=/activemq/5.15.9/apache-activemq-5.15.9-bin.zip&action=download', '"%destination%"')"
-    echo Information: Download complete
-    echo Information: Extracting ActiveMQ
-    %path_to_7z%\7z x %destination% -o%folder%
-    del %destination%
+    powershell -Command "(new-object System.Net.WebClient).DownloadFile('https://archive.apache.org/dist/activemq/5.15.9/apache-activemq-5.15.9-bin.zip', '"%destination%"')"
+    REM if download failed then file still does not exist
+    if not exist %destination% (
+        echo Error: Download failed
+        exit /b 1
+    ) else (
+        echo Information: Download complete
+        echo Information: Extracting ActiveMQ
+        %path_to_7z%\7z x %destination% -o%folder%
+        del %destination%
+    )
 ) else (
     echo Information: ActiveMQ files already detected in this location
     echo Information: If validation fails - delete %destination% and re-run this script

--- a/build/install/install_services.py
+++ b/build/install/install_services.py
@@ -20,7 +20,7 @@ def valid_services():
     """
     :return: A list of all valid services for the operating system
     """
-    valid = ['icat', 'activemq', 'mantid']
+    valid = ['activemq', 'mantid']
     if os.name == 'nt':
         valid.append('7zip')
     return valid

--- a/build/test_settings.py
+++ b/build/test_settings.py
@@ -14,7 +14,6 @@ if os.name == 'nt':
     # WINDOWS SETTINGS
     INSTALL_DIRS = {
         'activemq': 'C:\\autoreduction_deps\\activemq\\',
-        'icat': 'C:\\autoreduction_deps\\icat\\',
         'mantid': 'C:\\autoreduction_deps\\mantid\\',
         '7zip': 'C:\\autoreduction_deps\\7zip\\',
         '7zip-location': 'C:\\Program Files\\7-Zip',  # Expected install location of 7Zip
@@ -23,7 +22,6 @@ else:
     # LINUX SETTINGS
     INSTALL_DIRS = {
         'activemq': '/opt/autoreduce_deps/activemq',
-        'icat': '/opt/autoreduce_deps/icat',
         'mantid': '/opt/Mantid'
     }
     # 7Zip not required on linux

--- a/build/tests/validate_installs.py
+++ b/build/tests/validate_installs.py
@@ -6,7 +6,6 @@
 # ############################################################################### #
 """
 A collection of tests to validate external requirements:
-icat
 mantid
 activemq
 """
@@ -25,8 +24,6 @@ def validate_installs(list_of_services):
         service = service.lower()
         if service == 'activemq':
             service_validity['activemq'] = _validate_activemq()
-        elif service == 'icat':
-            service_validity['icat'] = _validate_icat()
         elif service == 'mantid':
             service_validity['mantid'] = _validate_mantid()
         elif service == '7zip':
@@ -43,15 +40,6 @@ def _validate_7zip():
 def _validate_activemq():
     """ Validate the existence of the activemq executable"""
     return os.path.isfile(ACTIVEMQ_EXECUTABLE)
-
-
-def _validate_icat():
-    try:
-        # pylint:disable=import-outside-toplevel,unused-import
-        import icat
-    except ImportError:
-        return False
-    return True
 
 
 def _validate_mantid():


### PR DESCRIPTION
### Summary of work
* Remove the remaining references to icat from the build scripts 
  * failed to get all of these in #600 

### How to test your work
* run `python setup.py externals` - ensure all works as expected
* run `python setup.py externals -s icat` - ensure this does not do anything / reports an incorrect key given to externals
* code review, ensure ICAT is not mentioned in the build module
