### PR TITLE
Allow for multiple runs to be removed at once

### DIFF
--- a/scripts/manual_operations/manual_remove.py
+++ b/scripts/manual_operations/manual_remove.py
@@ -195,7 +195,7 @@ def remove(instrument, run_number):
 
 def handle_input():
     """Handles input from users via the command line
-    :return (list) run numbers to remove, (str) name of instrument associated to runs
+    :return (list) run numbers to remove, (str) name of instruments associated to runs
     """
     parser = argparse.ArgumentParser(description='Remove a run from the autoreduction service.',
                                      epilog='./manual_remove.py GEM 83880')

--- a/scripts/manual_operations/manual_remove.py
+++ b/scripts/manual_operations/manual_remove.py
@@ -11,7 +11,6 @@ from __future__ import print_function
 
 import sys
 import argparse
-import logging
 
 from utils.clients.django_database_client import DatabaseClient
 from model.database import access as db
@@ -239,7 +238,7 @@ def user_input_check(instrument, run_numbers):
     try:
         return valid[user_input]
     except KeyError:
-        logging.error("Invalid input, please enter either 'Y' or 'N' to continue to exit script")
+        print("Invalid input, please enter either 'Y' or 'N' to continue to exit script")
     return user_input
 
 

--- a/scripts/manual_operations/tests/test_manual_remove.py
+++ b/scripts/manual_operations/tests/test_manual_remove.py
@@ -208,7 +208,6 @@ class TestManualRemove(unittest.TestCase):
     @patch('scripts.manual_operations.manual_remove.ManualRemove.find_runs_in_database')
     @patch('scripts.manual_operations.manual_remove.ManualRemove.process_results')
     @patch('scripts.manual_operations.manual_remove.ManualRemove.delete_records')
-    @patch('scripts.manual_operations.manual_remove.user_input_check')
     @patch('scripts.manual_operations.manual_remove.handle_input')
     def test_main_range(self, mock_handle_input, mock_delete, mock_process, mock_find):
         """

--- a/scripts/manual_operations/tests/test_manual_remove.py
+++ b/scripts/manual_operations/tests/test_manual_remove.py
@@ -13,7 +13,8 @@ import sys
 
 from mock import patch, call, Mock
 
-from scripts.manual_operations.manual_remove import ManualRemove, main, remove
+from scripts.manual_operations.manual_remove import ManualRemove, main, remove, handle_input, \
+    user_input_check
 from utils.clients.django_database_client import DatabaseClient
 
 
@@ -203,6 +204,26 @@ class TestManualRemove(unittest.TestCase):
         mock_process.assert_called_once()
         mock_delete.assert_called_once()
 
+    # pylint:disable=no-self-use
+    @patch('scripts.manual_operations.manual_remove.ManualRemove.find_runs_in_database')
+    @patch('scripts.manual_operations.manual_remove.ManualRemove.process_results')
+    @patch('scripts.manual_operations.manual_remove.ManualRemove.delete_records')
+    @patch('scripts.manual_operations.manual_remove.user_input_check')
+    @patch('scripts.manual_operations.manual_remove.handle_input')
+    def test_main_range(self, mock_handle_input, mock_uic, mock_delete, mock_process, mock_find):
+        """
+        Test: The correct control functions are called
+        When: The main() function is called
+        """
+        mock_handle_input.return_value = 'GEM', range(1, 12)
+        sys.argv = ['', 'GEM', '1', '-e', '11']
+        main()
+        mock_handle_input.assert_called_once()
+        # mock_uic.assert_called_once()
+        mock_find.assert_called()
+        mock_process.assert_called()
+        mock_delete.assert_called()
+
 
     # pylint:disable=no-self-use
     @patch('scripts.manual_operations.manual_remove.ManualRemove.find_runs_in_database')
@@ -295,3 +316,40 @@ class TestManualRemove(unittest.TestCase):
         mock_variable_model.RunVariable.objects.filter \
             .assert_has_calls(([call(variable_ptr_id=3), call().delete(),
                                 call(variable_ptr_id=5), call().delete()]))
+
+    @patch('scripts.manual_operations.manual_remove.ManualRemove.find_runs_in_database')
+    @patch('scripts.manual_operations.manual_remove.ManualRemove.process_results')
+    @patch('scripts.manual_operations.manual_remove.ManualRemove.delete_records')
+    @patch('scripts.manual_operations.manual_remove.user_input_check')
+    @patch('scripts.manual_operations.manual_remove.remove')
+    def test_handle_input(self, mock_remove, mock_uic, mock_delete, mock_process, mock_find):
+        """
+        Test: User input is handled correctly
+        When: handle_input function is called.
+        """
+        mock_uic.return_value = True
+        sys.argv = ['', 'GEM', '1', '-e', '10']
+        main()
+
+        run_numbers, instrument = handle_input()
+        expected_run_numbers = range(1, 11)
+        expected_instrument = 'GEM'
+
+        self.assertEqual(run_numbers, expected_run_numbers)
+        self.assertEqual(instrument, expected_instrument)
+        self.assertIsInstance(run_numbers, range)
+        self.assertIsInstance(instrument, str)
+
+    @patch('scripts.manual_operations.manual_remove.user_input_check')
+    def test_user_input_check(self, mock_uic):
+        """
+           Test: user_input_check() returns True of false
+           When based on user input if range of runs to remove is larger than 10
+        """
+        with patch.object(builtins, 'input', lambda _: 'Y'):
+            self.assertEqual(user_input_check(range(1, 11), 'GEM'), True)
+
+        with patch.object(builtins, 'input', lambda _: 'N'):
+            self.assertEqual(user_input_check(range(1, 11), 'GEM'), False)
+
+

--- a/scripts/manual_operations/tests/test_manual_remove.py
+++ b/scripts/manual_operations/tests/test_manual_remove.py
@@ -314,19 +314,14 @@ class TestManualRemove(unittest.TestCase):
             .assert_has_calls(([call(variable_ptr_id=3), call().delete(),
                                 call(variable_ptr_id=5), call().delete()]))
 
-    @patch('scripts.manual_operations.manual_remove.ManualRemove.find_runs_in_database')
-    @patch('scripts.manual_operations.manual_remove.ManualRemove.process_results')
-    @patch('scripts.manual_operations.manual_remove.ManualRemove.delete_records')
     @patch('scripts.manual_operations.manual_remove.user_input_check')
-    @patch('scripts.manual_operations.manual_remove.remove')
-    def test_handle_input(self, mock_remove, mock_uic, mock_delete, mock_process, mock_find):
+    def test_handle_input(self, mock_uic):
         """
         Test: User input is handled correctly
         When: handle_input function is called.
         """
         mock_uic.return_value = True
         sys.argv = ['', 'GEM', '1', '-e', '10']
-        main()
 
         run_numbers, instrument = handle_input()
         expected_run_numbers = range(1, 11)
@@ -337,8 +332,7 @@ class TestManualRemove(unittest.TestCase):
         self.assertIsInstance(run_numbers, range)
         self.assertIsInstance(instrument, str)
 
-    @patch('scripts.manual_operations.manual_remove.user_input_check')
-    def test_user_input_check(self, mock_uic):
+    def test_user_input_check(self):
         """
            Test: user_input_check() returns True of false
            When based on user input if range of runs to remove is larger than 10

--- a/scripts/manual_operations/tests/test_manual_remove.py
+++ b/scripts/manual_operations/tests/test_manual_remove.py
@@ -210,20 +210,18 @@ class TestManualRemove(unittest.TestCase):
     @patch('scripts.manual_operations.manual_remove.ManualRemove.delete_records')
     @patch('scripts.manual_operations.manual_remove.user_input_check')
     @patch('scripts.manual_operations.manual_remove.handle_input')
-    def test_main_range(self, mock_handle_input, mock_uic, mock_delete, mock_process, mock_find):
+    def test_main_range(self, mock_handle_input, mock_delete, mock_process, mock_find):
         """
-        Test: The correct control functions are called
+        Test: The correct control functions are called including handle_input for many runs
         When: The main() function is called
         """
         mock_handle_input.return_value = 'GEM', range(1, 12)
         sys.argv = ['', 'GEM', '1', '-e', '11']
         main()
         mock_handle_input.assert_called_once()
-        # mock_uic.assert_called_once()
         mock_find.assert_called()
         mock_process.assert_called()
         mock_delete.assert_called()
-
 
     # pylint:disable=no-self-use
     @patch('scripts.manual_operations.manual_remove.ManualRemove.find_runs_in_database')
@@ -351,5 +349,3 @@ class TestManualRemove(unittest.TestCase):
 
         with patch.object(builtins, 'input', lambda _: 'N'):
             self.assertEqual(user_input_check(range(1, 11), 'GEM'), False)
-
-


### PR DESCRIPTION
### Summary of work
Allow for removal of many runs for a given instrument as command line argument to match functionality of manual_submission.

Prompts user for validation as safe guard if attempting to remove 10 or more runs.

### How to test your work
* Test all unit tests pass
* Manual testing - Try to manually remove one run; many runs, but less than 10; 10 or more runs and check runs are removed.
* No drop in coveralls

### Additional comments
Both manual_remove and manual submission need refactoring to bee more python3 and OOP i the future to align with project standards followed throughout the rest of Autoreduction codebase. Note this is a low priority and may be a good new starter issue. 

Fixes #577 
