### PR TITLE
Handle multiple images for a single job

### DIFF
--- a/WebApp/autoreduce_webapp/reduction_viewer/views.py
+++ b/WebApp/autoreduce_webapp/reduction_viewer/views.py
@@ -397,9 +397,9 @@ def run_summary(request, instrument_name=None, run_number=None, run_version=0):
                                        rb_number=rb_number,
                                        run_number=run.run_number,
                                        server_dir=reduction_location)
-            plot_location = plot_handler.get_plot_file()
-            if plot_location:
-                context_dictionary['plot_location'] = plot_location
+            plot_locations = plot_handler.get_plot_file()
+            if plot_locations:
+                context_dictionary['plot_locations'] = plot_locations
 
     except PermissionDenied:
         raise

--- a/WebApp/autoreduce_webapp/templates/run_summary.html
+++ b/WebApp/autoreduce_webapp/templates/run_summary.html
@@ -17,10 +17,12 @@
                 {% endif %}
             </div>
         </div>
-        {% if plot_location %}
-        <div>
-            <img src="{{ plot_location }}">
-        </div>
+        {% if plot_locations %}
+            {% for plot_file in plot_locations %}
+            <div>
+                <img src="{{ plot_file }}">
+            </div>
+            {% endfor %}
         {% endif %}
         {% if run.message %}
             {% if 'Skipped' in run.message %}

--- a/plotting/plot_handler.py
+++ b/plotting/plot_handler.py
@@ -84,20 +84,23 @@ class PlotHandler:
         :return: (str) local path to downloaded files OR None if no files found
         """
         _existing_plot_files = self._check_for_plot_files()
+        local_plot_paths = []
         if _existing_plot_files:
-            # Generate paths to data on server and destination on local machine
-            _server_path = self.server_dir + _existing_plot_files[0]
-            _local_path = os.path.join(self.static_graph_dir, _existing_plot_files[0])
-
             client = SFTPClient()
-            try:
-                client.retrieve(server_file_path=_server_path,
-                                local_file_path=_local_path,
-                                override=True)
-                LOGGER.info('File %s found and saved to %s', _server_path, _local_path)
-            except RuntimeError:
-                LOGGER.error("file does not exist")
-                return None
-            return f'/static/graphs/{_existing_plot_files[0]}'  # shortcut to static dir
+            for plot_file in _existing_plot_files:
+                # Generate paths to data on server and destination on local machine
+                _server_path = self.server_dir + plot_file
+                _local_path = os.path.join(self.static_graph_dir, plot_file)
+
+                try:
+                    client.retrieve(server_file_path=_server_path,
+                                    local_file_path=_local_path,
+                                    override=True)
+                    LOGGER.info('File %s found and saved to %s', _server_path, _local_path)
+                except RuntimeError:
+                    LOGGER.error("file does not exist")
+                    return None
+                local_plot_paths.append(f'/static/graphs/{plot_file}')  # shortcut to static dir
+            return local_plot_paths
         # No files found
         return None

--- a/plotting/plot_handler.py
+++ b/plotting/plot_handler.py
@@ -96,9 +96,9 @@ class PlotHandler:
                     client.retrieve(server_file_path=_server_path,
                                     local_file_path=_local_path,
                                     override=True)
-                    LOGGER.info('File %s found and saved to %s', _server_path, _local_path)
+                    LOGGER.info('File \'%s\' found and saved to %s', _server_path, _local_path)
                 except RuntimeError:
-                    LOGGER.error("file does not exist")
+                    LOGGER.error("File \'%s\' does not exist", _server_path)
                     return None
                 local_plot_paths.append(f'/static/graphs/{plot_file}')  # shortcut to static dir
             return local_plot_paths

--- a/plotting/tests/test_plot_handler.py
+++ b/plotting/tests/test_plot_handler.py
@@ -122,6 +122,21 @@ class TestPlotHandler(unittest.TestCase):
             server_file_path=expected_server, local_file_path=expected_local, override=True)
         self.assertEqual(f'/static/graphs/{expected_files[0]}', actual_path)
 
+    @patch('utils.clients.sftp_client.SFTPClient.retrieve')
+    @patch('plotting.plot_handler.PlotHandler._check_for_plot_files')
+    @patch('utils.clients.sftp_client.SFTPClient.__init__', return_value=None)
+    def test_get_plot_files_multiple(self,  mock_client_init, mock_find_files, _):
+        expected_files = ['expected_1.png', 'expected_2.png']
+        mock_find_files.return_value = expected_files
+
+        expected_paths = [f'/static/graphs/{expected_files[0]}',
+                          f'/static/graphs/{expected_files[0]}']
+
+        actual_paths = self.test_plot_handler.get_plot_file()
+        mock_client_init.assert_called_once()  # Ensure this is not initialised more than once
+        self.assertEqual(expected_paths, actual_paths)
+
+
     @patch('plotting.plot_handler.PlotHandler._check_for_plot_files', return_value=[])
     def test_get_plot_file_none_found(self, _):
         """

--- a/plotting/tests/test_plot_handler.py
+++ b/plotting/tests/test_plot_handler.py
@@ -120,22 +120,25 @@ class TestPlotHandler(unittest.TestCase):
         mock_client_init.assert_called_once()
         mock_retrieve.assert_called_once_with(
             server_file_path=expected_server, local_file_path=expected_local, override=True)
-        self.assertEqual(f'/static/graphs/{expected_files[0]}', actual_path)
+        self.assertEqual([f'/static/graphs/{expected_files[0]}'], actual_path)
 
     @patch('utils.clients.sftp_client.SFTPClient.retrieve')
     @patch('plotting.plot_handler.PlotHandler._check_for_plot_files')
     @patch('utils.clients.sftp_client.SFTPClient.__init__', return_value=None)
-    def test_get_plot_files_multiple(self,  mock_client_init, mock_find_files, _):
+    def test_get_plot_files_multiple(self, mock_client_init, mock_find_files, _):
+        """
+        Test: Multiple file paths are returned as a list
+        When: Multiple image files exist on the server relating to the same run
+        """
         expected_files = ['expected_1.png', 'expected_2.png']
         mock_find_files.return_value = expected_files
 
         expected_paths = [f'/static/graphs/{expected_files[0]}',
-                          f'/static/graphs/{expected_files[0]}']
+                          f'/static/graphs/{expected_files[1]}']
 
         actual_paths = self.test_plot_handler.get_plot_file()
         mock_client_init.assert_called_once()  # Ensure this is not initialised more than once
         self.assertEqual(expected_paths, actual_paths)
-
 
     @patch('plotting.plot_handler.PlotHandler._check_for_plot_files', return_value=[])
     def test_get_plot_file_none_found(self, _):


### PR DESCRIPTION
### Summary of work
* Allow the webapp to show multiple images for a single reduction job 

### How to test your work
* Re-run MAR27036
* After it completes find the run in the dev webapp (afetr switching to this branch)
* Observe multiple plots in the webapp

### Additional comments
* Note: this does not handle the drop down menu for plot selection but instead shows all. We will handle the display of this in a separate issue

Fixes #617