### PR TITLE
Ensure that custom UOWS Auth matches updated django API

### DIFF
--- a/WebApp/autoreduce_webapp/autoreduce_webapp/backends.py
+++ b/WebApp/autoreduce_webapp/autoreduce_webapp/backends.py
@@ -14,7 +14,7 @@ from django.contrib.auth.models import User
 from .uows_client import UOWSClient
 from .icat_cache import ICATCache
 
-LOGGER = logging.getLogger(__name__)
+LOGGER = logging.getLogger('app')
 
 
 class UOWSAuthenticationBackend(object):
@@ -22,7 +22,7 @@ class UOWSAuthenticationBackend(object):
     Custom authentication for use with the User Office Web Service
     """
     @staticmethod
-    def authenticate(token=None):
+    def authenticate(request, token=None):
         """
         Checks that the given session ID (token) is still valid and
         returns an appropriate user object.
@@ -51,7 +51,6 @@ class UOWSAuthenticationBackend(object):
                         int(person['usernumber'])) or user.is_superuser)
                 user.save()
                 return user
-
         return None
 
     @staticmethod

--- a/WebApp/autoreduce_webapp/autoreduce_webapp/view_utils.py
+++ b/WebApp/autoreduce_webapp/autoreduce_webapp/view_utils.py
@@ -39,7 +39,7 @@ def has_valid_login(request):
     if DEVELOPMENT_MODE:
         LOGGER.debug("DEVELOPMENT_MODE True so allowing access")
         return True
-    if request.user.is_authenticated() and 'sessionid' in request.session:
+    if request.user.is_authenticated and 'sessionid' in request.session:
         LOGGER.debug("User is authenticated and has a sessionid from the UOWS")
         return True
     return False

--- a/WebApp/autoreduce_webapp/autoreduce_webapp/views.py
+++ b/WebApp/autoreduce_webapp/autoreduce_webapp/views.py
@@ -58,8 +58,8 @@ def handler403(request, exception):
 
 def handler500(request):
     """Error 500 handler"""
-    response = render('500.html',
-                      {'admin_email': get_admin_email()},
-                      RequestContext(request))
+    response = render(RequestContext(request),
+                      '500.html',
+                      {'admin_email': get_admin_email()})
     response.status_code = 500
     return response

--- a/WebApp/autoreduce_webapp/reduction_viewer/views.py
+++ b/WebApp/autoreduce_webapp/reduction_viewer/views.py
@@ -60,8 +60,9 @@ def index(request):
         login(request, user)
         authenticated = True
     else:
-        authenticated = request.user.is_authenticated() and 'sessionid' in request.session \
-                        and UOWSClient().check_session(request.session['sessionid'])
+        if 'sessionid' in request.session.keys():
+            authenticated = request.user.is_authenticated \
+                            and UOWSClient().check_session(request.session['sessionId'])
 
     if authenticated:
         if request.GET.get('next'):


### PR DESCRIPTION
### Summary of work
* Fix errors in Authentication on the webapp

### How to test your work
* Ensure the production webapp loads correctly and runs (It might not be able to send messages to compute because that has not been python3 upgraded just yet!)

### Additional comments
* When we updated django version (with python 3 upgrade) the function definitions in custom authentication classes changed. We did not pick this up at the time as the development node does not auth through the UOWS. Adding this to the production environment revealed this error
* Also updated to Apache24 as part of this issue.

