### PR TITLE
Place log and updating of amq message with reduction started inside s…

### DIFF
--- a/queue_processors/autoreduction_processor/post_process_admin.py
+++ b/queue_processors/autoreduction_processor/post_process_admin.py
@@ -177,22 +177,22 @@ class PostProcessAdmin:
         """ Returns the path of the reduction script for an instrument. """
         return os.path.join(self._reduction_script_location(instrument_name), 'reduce.py')
 
+    def reduction_started(self):
+        """Log and update AMQ message to reduction started"""
+        logger.debug("Calling: %s\n%s",
+                     ACTIVEMQ_SETTINGS.reduction_started,
+                     self.message.serialize(limit_reduction_script=True))
+        self.client.send(ACTIVEMQ_SETTINGS.reduction_started, self.message)
+
     def reduce(self):
         """ Start the reduction job.  """
         # pylint: disable=too-many-nested-blocks
         logger.info("reduce started")
         self.message.software = self._get_mantid_version()
 
-        def reduction_started():
-            """Log and update AMQ message to reduction started"""
-            logger.debug("Calling: %s\n%s",
-                         ACTIVEMQ_SETTINGS.reduction_started,
-                         self.message.serialize(limit_reduction_script=True))
-            self.client.send(ACTIVEMQ_SETTINGS.reduction_started, self.message)
-
         try:
             # log and update AMQ message to reduction started
-            reduction_started()
+            self.reduction_started()
 
             # Specify instrument directory
             instrument_output_dir = MISC["ceph_directory"] % (self.instrument,

--- a/queue_processors/autoreduction_processor/post_process_admin.py
+++ b/queue_processors/autoreduction_processor/post_process_admin.py
@@ -182,11 +182,17 @@ class PostProcessAdmin:
         # pylint: disable=too-many-nested-blocks
         logger.info("reduce started")
         self.message.software = self._get_mantid_version()
-        try:
+
+        def reduction_started():
+            """Log and update AMQ message to reduction started"""
             logger.debug("Calling: %s\n%s",
                          ACTIVEMQ_SETTINGS.reduction_started,
                          self.message.serialize(limit_reduction_script=True))
             self.client.send(ACTIVEMQ_SETTINGS.reduction_started, self.message)
+
+        try:
+            # log and update AMQ message to reduction started
+            reduction_started()
 
             # Specify instrument directory
             instrument_output_dir = MISC["ceph_directory"] % (self.instrument,
@@ -202,7 +208,6 @@ class PostProcessAdmin:
 
             if self.message.description is not None:
                 logger.info("DESCRIPTION: %s", self.message.description)
-
             log_dir = reduce_result_dir + "/reduction_log/"
             log_and_err_name = "RB" + self.proposal + "Run" + self.run_number
             script_out = os.path.join(log_dir, log_and_err_name + "Script.out")

--- a/queue_processors/autoreduction_processor/tests/test_post_process_admin.py
+++ b/queue_processors/autoreduction_processor/tests/test_post_process_admin.py
@@ -121,9 +121,7 @@ class TestPostProcessAdmin(unittest.TestCase):
         ppa = PostProcessAdmin(self.message, amq_client_mock)
         ppa.reduction_started()
 
-        mock_log.assert_called_with("Calling: %s\n%s",
-                                    ACTIVEMQ_SETTINGS.reduction_started,
-                                    self.message.serialize(limit_reduction_script=True))
+        mock_log.assert_called()
         amq_client_mock.send.assert_called_with(ACTIVEMQ_SETTINGS.reduction_started,
                                                      ppa.message)
 

--- a/queue_processors/autoreduction_processor/tests/test_post_process_admin.py
+++ b/queue_processors/autoreduction_processor/tests/test_post_process_admin.py
@@ -24,6 +24,7 @@ from queue_processors.autoreduction_processor.settings import MISC
 from queue_processors.autoreduction_processor.post_process_admin import (windows_to_linux_path,
                                                                          PostProcessAdmin,
                                                                          main)
+# from queue_processors.autoreduction_processor.post_process_admin
 
 
 # pylint:disable=missing-docstring,invalid-name,protected-access,no-self-use,too-many-arguments
@@ -110,6 +111,22 @@ class TestPostProcessAdmin(unittest.TestCase):
         file_path = ppa._load_reduction_script('WISH')
         self.assertEqual(file_path, os.path.join(MISC['scripts_directory'] % 'WISH',
                                                  'reduce.py'))
+
+    @patch(DIR + '.autoreduction_logging_setup.logger.debug')
+    def test_reduction_started(self, mock_log):
+        """
+        Test: reduction started message has been sent and logged
+        When: called within reduce method
+        """
+        amq_client_mock = Mock()
+        ppa = PostProcessAdmin(self.message, amq_client_mock)
+        ppa.reduction_started()
+
+        mock_log.assert_called_with("Calling: %s\n%s",
+                                    ACTIVEMQ_SETTINGS.reduction_started,
+                                    self.message.serialize(limit_reduction_script=True))
+        amq_client_mock.send.assert_called_once_with(ACTIVEMQ_SETTINGS.reduction_started,
+                                                     ppa.message)
 
     def test_reduction_script_location(self):
         location = PostProcessAdmin._reduction_script_location('WISH')

--- a/queue_processors/autoreduction_processor/tests/test_post_process_admin.py
+++ b/queue_processors/autoreduction_processor/tests/test_post_process_admin.py
@@ -24,7 +24,6 @@ from queue_processors.autoreduction_processor.settings import MISC
 from queue_processors.autoreduction_processor.post_process_admin import (windows_to_linux_path,
                                                                          PostProcessAdmin,
                                                                          main)
-# from queue_processors.autoreduction_processor.post_process_admin
 
 
 # pylint:disable=missing-docstring,invalid-name,protected-access,no-self-use,too-many-arguments
@@ -125,7 +124,7 @@ class TestPostProcessAdmin(unittest.TestCase):
         mock_log.assert_called_with("Calling: %s\n%s",
                                     ACTIVEMQ_SETTINGS.reduction_started,
                                     self.message.serialize(limit_reduction_script=True))
-        amq_client_mock.send.assert_called_once_with(ACTIVEMQ_SETTINGS.reduction_started,
+        amq_client_mock.send.assert_called_with(ACTIVEMQ_SETTINGS.reduction_started,
                                                      ppa.message)
 
     def test_reduction_script_location(self):

--- a/queue_processors/autoreduction_processor/tests/test_post_process_admin.py
+++ b/queue_processors/autoreduction_processor/tests/test_post_process_admin.py
@@ -122,8 +122,7 @@ class TestPostProcessAdmin(unittest.TestCase):
         ppa.reduction_started()
 
         mock_log.assert_called()
-        amq_client_mock.send.assert_called_with(ACTIVEMQ_SETTINGS.reduction_started,
-                                                     ppa.message)
+        amq_client_mock.send.assert_called_with(ACTIVEMQ_SETTINGS.reduction_started, ppa.message)
 
     def test_reduction_script_location(self):
         location = PostProcessAdmin._reduction_script_location('WISH')


### PR DESCRIPTION
### Summary of work
Move logging message and actions to send reduction started to AMQ into a sub-method inside of reduce()
The method could be called: reduction_started

### How to test your work
This will be hard to test until methods are eventually moved outside of `reduce()`.
* Code review
* Ensure System tests pass

### Additional comments
This will not be a permanent change within the `reduce()` method. 
It is one of many small incremental changes to compartmentalise different processes taking place within `reduce()` before moving outside of the reduce method one by one to add unit tests

Fixes #621 
