### PR TITLE
Place the specifying of directory locations which Autoreduction shoul…

### DIFF
--- a/queue_processors/autoreduction_processor/post_process_admin.py
+++ b/queue_processors/autoreduction_processor/post_process_admin.py
@@ -182,14 +182,19 @@ class PostProcessAdmin:
                                        instrument_output_directory,
                                        excitations,
                                        temporary_directory):
-        """Specifies instrument directories, including removal of run_number folder
+        """
+        Specifies instrument directories, including removal of run_number folder
         if excitations instrument
-        :return (str) Directories where Autoreduction should output"""
+        :param instrument_output_directory: (str) Ceph directory using instrument, proposal, run no
+        :param excitations: (list) List of excitations instruments
+        :param temporary_directory: (str) Temp directory location (root)
+        :return (str) Directories where Autoreduction should output
+        """
 
         if self.instrument in excitations:
             # Excitations would like to remove the run number folder at the end
-            instrument_output_directory = instrument_output_directory[
-                                          :instrument_output_directory.rfind('/') + 1]
+            no_run_number_directory = instrument_output_directory.rfind('/') + 1
+            instrument_output_directory = instrument_output_directory[:no_run_number_directory]
 
         # Specify directories where autoreduction output will go
         return temporary_directory + instrument_output_directory

--- a/queue_processors/autoreduction_processor/post_process_admin.py
+++ b/queue_processors/autoreduction_processor/post_process_admin.py
@@ -206,7 +206,6 @@ class PostProcessAdmin:
                      self.message.serialize(limit_reduction_script=True))
         self.client.send(ACTIVEMQ_SETTINGS.reduction_started, self.message)
 
-
     def reduce(self):
         """ Start the reduction job.  """
         # pylint: disable=too-many-nested-blocks

--- a/queue_processors/autoreduction_processor/post_process_admin.py
+++ b/queue_processors/autoreduction_processor/post_process_admin.py
@@ -185,7 +185,7 @@ class PostProcessAdmin:
         Specifies instrument directories, including removal of run_number folder
         if excitations instrument
         :param instrument_output_directory: (str) Ceph directory using instrument, proposal, run no
-        :param no_run_number_directory: (bool) Determines whether or not to remove run_number from dir
+        :param no_run_number_directory: (bool) Determine whether or not to remove run no from dir
         :param temporary_directory: (str) Temp directory location (root)
         :return (str) Directories where Autoreduction should output
         """

--- a/queue_processors/autoreduction_processor/post_process_admin.py
+++ b/queue_processors/autoreduction_processor/post_process_admin.py
@@ -188,17 +188,24 @@ class PostProcessAdmin:
                          self.message.serialize(limit_reduction_script=True))
             self.client.send(ACTIVEMQ_SETTINGS.reduction_started, self.message)
 
-            # Specify instrument directory
-            instrument_output_dir = MISC["ceph_directory"] % (self.instrument,
-                                                              self.proposal,
-                                                              self.run_number)
+            def specify_instrument_directories():
+                """Specifies instrument directories, including removal of run_number folder
+                if excitations instrument
+                :return (list) Directories where Autoreduction should output"""
+                # Specify instrument directory
+                instrument_output_dir = MISC["ceph_directory"] % (self.instrument,
+                                                                  self.proposal,
+                                                                  self.run_number)
 
-            if self.instrument in MISC["excitation_instruments"]:
-                # Excitations would like to remove the run number folder at the end
-                instrument_output_dir = instrument_output_dir[:instrument_output_dir.rfind('/') + 1]
+                if self.instrument in MISC["excitation_instruments"]:
+                    # Excitations would like to remove the run number folder at the end
+                    instrument_output_dir = instrument_output_dir[
+                                            :instrument_output_dir.rfind('/') + 1]
 
-            # Specify directories where autoreduction output will go
-            reduce_result_dir = MISC["temp_root_directory"] + instrument_output_dir
+                # Specify directories where autoreduction output will go
+                return MISC["temp_root_directory"] + instrument_output_dir
+
+            reduce_result_dir = specify_instrument_directories()
 
             if self.message.description is not None:
                 logger.info("DESCRIPTION: %s", self.message.description)

--- a/queue_processors/autoreduction_processor/tests/test_post_process_admin.py
+++ b/queue_processors/autoreduction_processor/tests/test_post_process_admin.py
@@ -127,8 +127,7 @@ class TestPostProcessAdmin(unittest.TestCase):
             temporary_directory=MISC["temp_root_directory"])
 
         directory_list = [i for i in actual.split('/') if i]
-        print(actual)
-        print(directory_list)
+
         expected_end = ['reduced-data', 'WISH', 'RB1234', 'autoreduced', '27282']
         expected_start = 'autoreducetmp'
 

--- a/queue_processors/autoreduction_processor/tests/test_post_process_admin.py
+++ b/queue_processors/autoreduction_processor/tests/test_post_process_admin.py
@@ -111,6 +111,31 @@ class TestPostProcessAdmin(unittest.TestCase):
         self.assertEqual(file_path, os.path.join(MISC['scripts_directory'] % 'WISH',
                                                  'reduce.py'))
 
+    def test_specify_instrument_directories(self):
+        """
+        Test: Expected instrument, stripped of run number if excitation returned
+        When: called
+        """
+        ppa = PostProcessAdmin(self.message, None)
+        ppa.instrument = 'WISH'
+        ppa.run_number = 27282
+        actual = ppa.specify_instrument_directories(
+            instrument_output_directory=MISC["ceph_directory"] % (ppa.instrument,
+                                                                  ppa.proposal,
+                                                                  ppa.run_number),
+            excitations=MISC["excitation_instruments"],
+            temporary_directory=MISC["temp_root_directory"])
+
+        directory_list = [i for i in actual.split('/') if i]
+        print(actual)
+        print(directory_list)
+        expected_end = ['reduced-data', 'WISH', 'RB1234', 'autoreduced', '27282']
+        expected_start = 'autoreducetmp'
+
+        self.assertEqual(directory_list[-5:], expected_end)
+        self.assertEqual(directory_list[0], expected_start)
+        self.assertIsInstance(actual, str)
+
     def test_reduction_script_location(self):
         location = PostProcessAdmin._reduction_script_location('WISH')
         self.assertEqual(location, MISC['scripts_directory'] % 'WISH')


### PR DESCRIPTION
### Summary of work
Move processes related to the specifying of instrument directories in relation to starting a reduction job into a sub-method.

This will include the removal of the run number for excitations at the end and the location of output directories.

### How to test your work
This will be hard to test until methods are eventually moved outside of reduce().
* Code review
* Ensure System tests pass

## Additional comments
This will not be a permanent change within the reduce() method. 
It is one of many small incremental changes to compartmentalise different processes before moving outside of the reduce method one by one to add unit tests

Fixes #622 


**Before merging ensure the release notes have been updated**