### PR TITLE
Unpin test deps

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,6 @@
-coverage==4.5.4
+# Test Env. Requirements
+
+coverage
 coveralls==1.9.2
 dash
 django-debug-toolbar

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 # Test Env. Requirements
 
 coverage
-coveralls==1.9.2
+coveralls
 dash
 django-debug-toolbar
 django_plotly_dash

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ lxml
 mock
 pandas
 plotly
-pylint==2.4.4
+pylint
 pytest-cov
 python-coveralls
 requests

--- a/scripts/scheduler_ingest.py
+++ b/scripts/scheduler_ingest.py
@@ -176,12 +176,12 @@ class SchedulerDataProcessor:
         if cycle_before:
             cycle_before_string = f"\n\tStart = {cycle_before.start}\n\tEnd = {cycle_before.end}\n"
         else:
-            cycle_before_string = f" NONE (No earlier cycle dates)\n"
+            cycle_before_string = " NONE (No earlier cycle dates)\n"
 
         if cycle_after:
             cycle_after_string = f"\n\tStart = {cycle_after.start}\n\tEnd = {cycle_after.end}\n"
         else:
-            cycle_after_string = f" NONE (No later cycle dates)\n"
+            cycle_after_string = " NONE (No later cycle dates)\n"
 
         print(f"WARNING - Encountered maintenance day outside of cycle dates "
               f"(assuming cycle_data and maintenance_data "

--- a/utils/clients/database_client.py
+++ b/utils/clients/database_client.py
@@ -57,6 +57,7 @@ class DatabaseClient(AbstractClient):
         :return: True if connection is establish
         """
         try:
+            # pylint: disable=no-member
             self._connection.execute('SELECT 1').fetchall()
         # pylint:disable=broad-except
         except Exception as exp:
@@ -79,6 +80,7 @@ class DatabaseClient(AbstractClient):
         """
         Close the connection and reset variables
         """
+        # pylint: disable=no-member
         self._connection.close()
         self._connection = None
         self._meta_data = None


### PR DESCRIPTION
### Summary of work
Drops the test package requirements from pinned to the current stable.

I noticed this whilst adding `pytest-django` to `requirements.txt` in another branch, the majority of the pinning stems from Python 2 support being dropped in our deps

### How to test your work
- CI Tests should pass