### PR TITLE
643 fire cli for manual remove

### DIFF
--- a/scripts/manual_operations/manual_remove.py
+++ b/scripts/manual_operations/manual_remove.py
@@ -216,6 +216,9 @@ def user_input_check(instrument, run_numbers):
 def main(instrument, first_run, last_run=None):
     """
     Parse user input and run the script to remove runs for a given instrument
+    :param instrument: Instrument to run on
+    :param first_run: First run to be removed
+    :param last_run: Optional last run to be removed
     """
     run_numbers = [first_run]
 

--- a/scripts/manual_operations/manual_remove.py
+++ b/scripts/manual_operations/manual_remove.py
@@ -213,7 +213,7 @@ def user_input_check(instrument, run_numbers):
     return user_input
 
 
-def main(instrument, first_run, last_run=None):
+def main(instrument: str, first_run: int, last_run: int = None):
     """
     Parse user input and run the script to remove runs for a given instrument
     :param instrument: Instrument to run on

--- a/scripts/manual_operations/manual_remove.py
+++ b/scripts/manual_operations/manual_remove.py
@@ -225,8 +225,7 @@ def main(instrument, first_run, last_run=None):
     if last_run:
         if last_run < first_run:
             print(f"last run {last_run} must be greater than first run {first_run}")
-            print("e.g ./manual_remove.py GEM 83880 83882")
-            sys.exit(1)
+            raise ValueError(f"last run: {last_run} was smaller than first run: {first_run}")
         run_numbers = range(first_run, last_run + 1)
 
     instrument = instrument.upper()

--- a/scripts/manual_operations/manual_remove.py
+++ b/scripts/manual_operations/manual_remove.py
@@ -216,9 +216,9 @@ def user_input_check(instrument, run_numbers):
 def main(instrument: str, first_run: int, last_run: int = None):
     """
     Parse user input and run the script to remove runs for a given instrument
-    :param instrument: Instrument to run on
-    :param first_run: First run to be removed
-    :param last_run: Optional last run to be removed
+    :param instrument: (str) Instrument to run on
+    :param first_run: (int) First run to be removed
+    :param last_run: (int) Optional last run to be removed
     """
     run_numbers = [first_run]
 

--- a/scripts/manual_operations/manual_remove.py
+++ b/scripts/manual_operations/manual_remove.py
@@ -224,7 +224,6 @@ def main(instrument: str, first_run: int, last_run: int = None):
 
     if last_run:
         if last_run < first_run:
-            print(f"last run {last_run} must be greater than first run {first_run}")
             raise ValueError(f"last run: {last_run} was smaller than first run: {first_run}")
         run_numbers = range(first_run, last_run + 1)
 

--- a/scripts/manual_operations/manual_remove.py
+++ b/scripts/manual_operations/manual_remove.py
@@ -10,7 +10,8 @@ Functionality to remove a reduction run from the database
 from __future__ import print_function
 
 import sys
-import argparse
+
+import fire
 
 from utils.clients.django_database_client import DatabaseClient
 from model.database import access as db
@@ -192,36 +193,6 @@ def remove(instrument, run_number):
     manual_remove.delete_records()
 
 
-def handle_input():
-    """Handles input from users via the command line
-    :return (list) run numbers to remove, (str) name of instruments associated to runs
-    """
-    parser = argparse.ArgumentParser(description='Remove a run from the autoreduction service.',
-                                     epilog='./manual_remove.py GEM 83880')
-    parser.add_argument('instrument', metavar='instrument', type=str,
-                        help='a string of the instrument name e.g "GEM"')
-    parser.add_argument('-e', metavar='end_run_number', nargs='?', type=int,
-                        help='if submitting a range, the end run number e.g. "83882"')
-    parser.add_argument('start_run_number', metavar='start_run_number', type=int,
-                        help='the start run number e.g. "83880"')
-
-    args = parser.parse_args()
-
-    run_numbers = [args.start_run_number]
-
-    if args.e:
-        # Range submission
-        if not args.e > args.start_run_number:
-            print("'end_run_number' must be greater than 'start_run_number'.")
-            print("e.g './manual_remove.py GEM 83880 -e 83882'")
-            sys.exit(1)
-        run_numbers = range(args.start_run_number, args.e + 1)
-
-    instrument = args.instrument.upper()
-
-    return run_numbers, instrument
-
-
 def user_input_check(instrument, run_numbers):
     """
     User prompt for boolean value to to assert if user really wants to remove N runs
@@ -242,11 +213,21 @@ def user_input_check(instrument, run_numbers):
     return user_input
 
 
-def main():
+def main(instrument, first_run, last_run=None):
     """
     Parse user input and run the script to remove runs for a given instrument
     """
-    run_numbers, instrument = handle_input()
+    run_numbers = [first_run]
+
+    if last_run:
+        if last_run < first_run:
+            print(f"last run {last_run} must be greater than first run {first_run}")
+            print("e.g ./manual_remove.py GEM 83880 83882")
+            sys.exit(1)
+        run_numbers = range(first_run, last_run + 1)
+
+    instrument = instrument.upper()
+
     if len(run_numbers) >= 10:
         user_input = user_input_check(instrument, run_numbers)
         if not user_input:
@@ -257,4 +238,4 @@ def main():
 
 
 if __name__ == "__main__":  # pragma: no cover
-    main()
+    fire.Fire(main)

--- a/scripts/manual_operations/tests/test_manual_remove.py
+++ b/scripts/manual_operations/tests/test_manual_remove.py
@@ -236,12 +236,20 @@ class TestManualRemove(unittest.TestCase):
     @patch('scripts.manual_operations.manual_remove.ManualRemove.process_results')
     @patch('scripts.manual_operations.manual_remove.ManualRemove.delete_records')
     def test_main_single_run(self, mock_delete, mock_process, mock_find):
+        """
+        Test: The correct control functions are called for a single run
+        When: The main() function is called
+        """
         main(instrument='GEM', first_run=1)
         mock_find.assert_called()
         mock_process.assert_called()
         mock_delete.assert_called()
 
     def test_main_last_run_smaller_than_first_run_raises_value_error(self):
+        """
+        Test: ValueError is raised when first run is larger then last run
+        When: The main() function is called
+        """
         with self.assertRaises(ValueError):
             main(instrument='GEM', first_run=10, last_run=1)
 

--- a/scripts/manual_operations/tests/test_manual_remove.py
+++ b/scripts/manual_operations/tests/test_manual_remove.py
@@ -206,7 +206,7 @@ class TestManualRemove(unittest.TestCase):
     @patch('scripts.manual_operations.manual_remove.ManualRemove.process_results')
     @patch('scripts.manual_operations.manual_remove.ManualRemove.delete_records')
     @patch('scripts.manual_operations.manual_remove.user_input_check')
-    def test_main_range(self, mock_delete, mock_process, mock_find, mock_uic):
+    def test_main_range_greater_than_ten(self, mock_uic, mock_delete, mock_process, mock_find):
         """
         Test: The correct control functions are called including handle_input for many runs
         When: The main() function is called
@@ -216,6 +216,34 @@ class TestManualRemove(unittest.TestCase):
         mock_find.assert_called()
         mock_process.assert_called()
         mock_delete.assert_called()
+
+    # pylint:disable=no-self-use
+    @patch('scripts.manual_operations.manual_remove.ManualRemove.find_runs_in_database')
+    @patch('scripts.manual_operations.manual_remove.ManualRemove.process_results')
+    @patch('scripts.manual_operations.manual_remove.ManualRemove.delete_records')
+    def test_main_range_less_than_ten(self, mock_delete, mock_process, mock_find):
+        """
+        Test: The correct control functions are called including handle_input for many runs
+        When: The main() function is called
+        """
+        main(instrument='GEM', first_run=1, last_run=9)
+        mock_find.assert_called()
+        mock_process.assert_called()
+        mock_delete.assert_called()
+
+    # pylint:disable=no-self-use
+    @patch('scripts.manual_operations.manual_remove.ManualRemove.find_runs_in_database')
+    @patch('scripts.manual_operations.manual_remove.ManualRemove.process_results')
+    @patch('scripts.manual_operations.manual_remove.ManualRemove.delete_records')
+    def test_main_single_run(self, mock_delete, mock_process, mock_find):
+        main(instrument='GEM', first_run=1)
+        mock_find.assert_called()
+        mock_process.assert_called()
+        mock_delete.assert_called()
+
+    def test_main_last_run_smaller_than_first_run_raises_value_error(self):
+        with self.assertRaises(ValueError):
+            main(instrument='GEM', first_run=10, last_run=1)
 
     # pylint:disable=no-self-use
     @patch('scripts.manual_operations.manual_remove.ManualRemove.find_runs_in_database')

--- a/scripts/manual_operations/tests/test_manual_remove.py
+++ b/scripts/manual_operations/tests/test_manual_remove.py
@@ -231,20 +231,6 @@ class TestManualRemove(unittest.TestCase):
         mock_process.assert_called()
         mock_delete.assert_called()
 
-    # pylint:disable=no-self-use
-    @patch('scripts.manual_operations.manual_remove.ManualRemove.find_runs_in_database')
-    @patch('scripts.manual_operations.manual_remove.ManualRemove.process_results')
-    @patch('scripts.manual_operations.manual_remove.ManualRemove.delete_records')
-    def test_main_single_run(self, mock_delete, mock_process, mock_find):
-        """
-        Test: The correct control functions are called for a single run
-        When: The main() function is called
-        """
-        main(instrument='GEM', first_run=1)
-        mock_find.assert_called()
-        mock_process.assert_called()
-        mock_delete.assert_called()
-
     def test_main_last_run_smaller_than_first_run_raises_value_error(self):
         """
         Test: ValueError is raised when first run is larger then last run

--- a/scripts/manual_operations/tests/test_manual_remove.py
+++ b/scripts/manual_operations/tests/test_manual_remove.py
@@ -212,7 +212,7 @@ class TestManualRemove(unittest.TestCase):
         When: The main() function is called
         """
         main(instrument='GEM', first_run=1, last_run=11)
-        mock_uic.assert_called()
+        mock_uic.assert_called_with("GEM", range(1, 12))
         mock_find.assert_called()
         mock_process.assert_called()
         mock_delete.assert_called()


### PR DESCRIPTION
### Summary of work
<!---The changes you have made--->
Used #637 as a guide. Not sure if I should be adding any labels, so please let me know :)

I added mocking for `user_input_check` as without it the test would hang until y/n was entered. (I don't understand why this wasn't happening previously)

I didn't add any type casting as from the docs https://google.github.io/python-fire/guide/#argument-parsing this should be automatic.

### How to test your work
<!---This can be a link to the---> 
The only test failing is `test_find_run` though this was failing already due to my sub optimal setup.
### Additional comments
<!---Anything else: e.g. was the estimate reasonable for this issue?---> 

closes #643 


**Before merging ensure the release notes have been updated**