### PR TITLE
Pull out some validation from manual_operations into util.py

### DIFF
--- a/scripts/manual_operations/manual_remove.py
+++ b/scripts/manual_operations/manual_remove.py
@@ -13,6 +13,7 @@ import sys
 
 import fire
 
+from scripts.manual_operations.util import get_run_range
 from utils.clients.django_database_client import DatabaseClient
 from model.database import access as db
 
@@ -220,12 +221,7 @@ def main(instrument: str, first_run: int, last_run: int = None):
     :param first_run: (int) First run to be removed
     :param last_run: (int) Optional last run to be removed
     """
-    run_numbers = [first_run]
-
-    if last_run:
-        if last_run < first_run:
-            raise ValueError(f"last run: {last_run} was smaller than first run: {first_run}")
-        run_numbers = range(first_run, last_run + 1)
+    run_numbers = get_run_range(first_run, last_run=last_run)
 
     instrument = instrument.upper()
 

--- a/scripts/manual_operations/manual_submission.py
+++ b/scripts/manual_operations/manual_submission.py
@@ -15,6 +15,7 @@ import fire
 
 from model.database import access as db
 from model.message.message import Message
+from scripts.manual_operations.util import get_run_range
 
 from utils.clients.connection_exception import ConnectionException
 from utils.clients.icat_client import ICATClient
@@ -189,13 +190,8 @@ def main(instrument, first_run, last_run=None):
     :param first_run: (int) The first run to be submitted
     :param last_run: (int) The last run to be submitted
     """
-    if last_run:
-        if int(last_run) > int(first_run):
-            run_numbers = list(range(first_run, last_run))
-        else:
-            raise ValueError(f"last run ({last_run}) must be more than first run ({first_run})")
-    else:
-        run_numbers = [first_run]
+    run_numbers = get_run_range(first_run, last_run=last_run)
+
     instrument = instrument.upper()
     icat_client = login_icat()
     database_client = login_database()

--- a/scripts/manual_operations/tests/test_manual_remove.py
+++ b/scripts/manual_operations/tests/test_manual_remove.py
@@ -203,8 +203,7 @@ class TestManualRemove(unittest.TestCase):
         mock_process.assert_called_once()
         mock_delete.assert_called_once()
 
-    # pylint:disable=no-self-use
-    # pylint:disable=too-many-arguments
+    # pylint:disable=no-self-use, too-many-arguments
     @patch('scripts.manual_operations.manual_remove.ManualRemove.find_runs_in_database')
     @patch('scripts.manual_operations.manual_remove.ManualRemove.process_results')
     @patch('scripts.manual_operations.manual_remove.ManualRemove.delete_records')

--- a/scripts/manual_operations/tests/test_manual_remove.py
+++ b/scripts/manual_operations/tests/test_manual_remove.py
@@ -191,27 +191,33 @@ class TestManualRemove(unittest.TestCase):
     @patch('scripts.manual_operations.manual_remove.ManualRemove.find_runs_in_database')
     @patch('scripts.manual_operations.manual_remove.ManualRemove.process_results')
     @patch('scripts.manual_operations.manual_remove.ManualRemove.delete_records')
-    def test_main(self, mock_delete, mock_process, mock_find):
+    @patch('scripts.manual_operations.manual_remove.get_run_range', return_value=range(1, 2))
+    def test_main(self, mock_get_run_range, mock_delete, mock_process, mock_find):
         """
         Test: The correct control functions are called
         When: The main() function is called
         """
         main(instrument='GEM', first_run=1)
+        mock_get_run_range.assert_called_once_with(1, last_run=None)
         mock_find.assert_called_once_with(1)
         mock_process.assert_called_once()
         mock_delete.assert_called_once()
 
     # pylint:disable=no-self-use
+    # pylint:disable=too-many-arguments
     @patch('scripts.manual_operations.manual_remove.ManualRemove.find_runs_in_database')
     @patch('scripts.manual_operations.manual_remove.ManualRemove.process_results')
     @patch('scripts.manual_operations.manual_remove.ManualRemove.delete_records')
     @patch('scripts.manual_operations.manual_remove.user_input_check')
-    def test_main_range_greater_than_ten(self, mock_uic, mock_delete, mock_process, mock_find):
+    @patch('scripts.manual_operations.manual_remove.get_run_range', return_value=range(1, 12))
+    def test_main_range_greater_than_ten(self, mock_get_run_range, mock_uic, mock_delete,
+                                         mock_process, mock_find):
         """
         Test: The correct control functions are called including handle_input for many runs
         When: The main() function is called
         """
         main(instrument='GEM', first_run=1, last_run=11)
+        mock_get_run_range.assert_called_with(1, last_run=11)
         mock_uic.assert_called_with("GEM", range(1, 12))
         mock_find.assert_called()
         mock_process.assert_called()
@@ -221,23 +227,18 @@ class TestManualRemove(unittest.TestCase):
     @patch('scripts.manual_operations.manual_remove.ManualRemove.find_runs_in_database')
     @patch('scripts.manual_operations.manual_remove.ManualRemove.process_results')
     @patch('scripts.manual_operations.manual_remove.ManualRemove.delete_records')
-    def test_main_range_less_than_ten(self, mock_delete, mock_process, mock_find):
+    @patch('scripts.manual_operations.manual_remove.get_run_range', return_value=range(1, 10))
+    def test_main_range_less_than_ten(self, mock_get_run_range, mock_delete, mock_process,
+                                      mock_find):
         """
         Test: The correct control functions are called including handle_input for many runs
         When: The main() function is called
         """
         main(instrument='GEM', first_run=1, last_run=9)
+        mock_get_run_range.assert_called_with(1, last_run=9)
         mock_find.assert_called()
         mock_process.assert_called()
         mock_delete.assert_called()
-
-    def test_main_last_run_smaller_than_first_run_raises_value_error(self):
-        """
-        Test: ValueError is raised when first run is larger then last run
-        When: The main() function is called
-        """
-        with self.assertRaises(ValueError):
-            main(instrument='GEM', first_run=10, last_run=1)
 
     # pylint:disable=no-self-use
     @patch('scripts.manual_operations.manual_remove.ManualRemove.find_runs_in_database')

--- a/scripts/manual_operations/tests/test_manual_submission.py
+++ b/scripts/manual_operations/tests/test_manual_submission.py
@@ -258,12 +258,15 @@ class TestManualSubmission(unittest.TestCase):
     @patch('scripts.manual_operations.manual_submission.login_queue')
     @patch('scripts.manual_operations.manual_submission.get_location_and_rb')
     @patch('scripts.manual_operations.manual_submission.submit_run')
-    def test_main_valid(self, mock_submit, mock_get_loc,
+    @patch('scripts.manual_operations.manual_submission.get_run_range')
+    def test_main_valid(self, mock_run_range, mock_submit, mock_get_loc,
                         mock_queue, mock_database, mock_icat):
         """
         Test: The control methods are called in the correct order
         When: main is called and the environment (client settings, input, etc.) is valid
         """
+        mock_run_range.return_value = range(1111, 1112)
+
         # Setup Mock clients
         mock_db_client = Mock()
         mock_icat_client = Mock()
@@ -279,6 +282,7 @@ class TestManualSubmission(unittest.TestCase):
         ms.main(instrument='TEST', first_run=1111)
 
         # Assert
+        mock_run_range.assert_called_with(1111, last_run=None)
         mock_icat.assert_called_once()
         mock_database.assert_called_once()
         mock_queue.assert_called_once()
@@ -287,13 +291,16 @@ class TestManualSubmission(unittest.TestCase):
 
     @patch('scripts.manual_operations.manual_submission.login_icat')
     @patch('scripts.manual_operations.manual_submission.login_database')
-    def test_main_bad_client(self, mock_db, mock_icat):
+    @patch('scripts.manual_operations.manual_submission.get_run_range')
+    def test_main_bad_client(self, mock_get_run_range, mock_db, mock_icat):
         """
         Test: A RuntimeError is raised
         When: Neither ICAT or Database connections can be established
         """
+        mock_get_run_range.return_value = range(1111, 1112)
         mock_db.return_value = None
         mock_icat.return_value = None
         self.assertRaises(RuntimeError, ms.main, 'TEST', 1111)
+        mock_get_run_range.assert_called_with(1111, last_run=None)
         mock_db.asert_called_once()
         mock_icat.assert_called_once()

--- a/scripts/manual_operations/tests/test_util.py
+++ b/scripts/manual_operations/tests/test_util.py
@@ -6,7 +6,7 @@
 # ############################################################################### #
 
 """
-Test cases for util functions
+Unit tests for manual submission utility functions
 """
 
 from unittest import TestCase
@@ -31,7 +31,7 @@ class TestUtil(TestCase):
         Test: Correct range is returned
         When: second_run is provided
         """
-        self.assertEqual(range(1, 5), get_run_range(1, last_run=4))
+        self.assertEqual(range(1, 5), get_run_range(first_run=1, last_run=4))
 
     def test_get_run_numbers_invalid_input_raises_value_error(self):
         """
@@ -39,4 +39,4 @@ class TestUtil(TestCase):
         When: first_run is greater than last_run
         """
         with self.assertRaises(ValueError):
-            get_run_range(5, last_run=2)
+            get_run_range(first_run=5, last_run=2)

--- a/scripts/manual_operations/tests/test_util.py
+++ b/scripts/manual_operations/tests/test_util.py
@@ -1,0 +1,42 @@
+# ############################################################################### #
+# Autoreduction Repository : https://github.com/ISISScientificComputing/autoreduce
+#
+# Copyright &copy; 2020 ISIS Rutherford Appleton Laboratory UKRI
+# SPDX - License - Identifier: GPL-3.0-or-later
+# ############################################################################### #
+
+"""
+Test cases for util functions
+"""
+
+from unittest import TestCase
+
+from scripts.manual_operations.util import get_run_range
+
+
+class TestUtil(TestCase):
+    """
+    Test util.py
+    """
+
+    def test_get_run_numbers_one_run_returns_correct_range(self):
+        """
+        Test: Correct range is returned
+        When: second_run is None
+        """
+        self.assertEqual(range(1, 2), get_run_range(1))
+
+    def test_get_run_numbers_valid_input_returns_valid_range(self):
+        """
+        Test: Correct range is returned
+        When: second_run is provided
+        """
+        self.assertEqual(range(1, 5), get_run_range(1, last_run=4))
+
+    def test_get_run_numbers_invalid_input_raises_value_error(self):
+        """
+        Test: ValueError is raised
+        When: first_run is greater than last_run
+        """
+        with self.assertRaises(ValueError):
+            get_run_range(5, last_run=2)

--- a/scripts/manual_operations/util.py
+++ b/scripts/manual_operations/util.py
@@ -1,0 +1,25 @@
+# ############################################################################### #
+# Autoreduction Repository : https://github.com/ISISScientificComputing/autoreduce
+#
+# Copyright &copy; 2020 ISIS Rutherford Appleton Laboratory UKRI
+# SPDX - License - Identifier: GPL-3.0-or-later
+# ############################################################################### #
+
+"""
+utility functions used in manual operations scripts
+"""
+
+
+def get_run_range(first_run, last_run=None):
+    """
+    Given a first_run number and optionally, a last run number return the range of runs including
+    and between the run numbers. If last_run is not provided then the range will only include the
+    first run
+    :param first_run: (int) the first number
+    :param last_run: (int) optional the second run number
+    :return: (range) the range of runs including and between the first run
+    """
+    last_run = first_run if last_run is None else last_run
+    if first_run > last_run:
+        raise ValueError(f"first run: {first_run} is greater than last run: {last_run}")
+    return range(first_run, last_run + 1)


### PR DESCRIPTION
### Summary of work
<!---The changes you have made--->
Pulled out the validation on run numbers. This also removed the discrepancy where `manual_submission` would not include the `last_run` and `manual_removal` would. 

@JackEAllen I agree with you, that these 2 scripts could easily be combined and be cleaner overall.


### How to test your work
<!---This can be a link to the---> 

### Additional comments
<!---Anything else: e.g. was the estimate reasonable for this issue?---> 

Fixes #607


**Before merging ensure the release notes have been updated**