### PR TITLE
Check local storage for graphs

### DIFF
--- a/plotting/plot_handler.py
+++ b/plotting/plot_handler.py
@@ -64,10 +64,7 @@ class PlotHandler:
         .png, .gif and .jpg: The returned value would be (png|gif|jpg)
         :return: (str) expression pattern matching the file extensions of the plot handler
         """
-        _extension_regex = '('
-        for extension in self.file_extensions:
-            _extension_regex += f'{extension}|'
-        return _extension_regex[:-1] + ')'
+        return f"({','.join(self.file_extensions).replace(',','|')})"
 
     def _get_plot_files_locally(self):
         """

--- a/plotting/plot_handler.py
+++ b/plotting/plot_handler.py
@@ -56,6 +56,17 @@ class PlotHandler:
             LOGGER.info("The instrument name is not recognised")
             return None
 
+    def _generate_file_extension_regex(self):
+        """
+        Generates the file extension part of the file regex. For example if the file extensions were
+        .png, .gif and .jpg: The returned value would be (png|gif|jpg)
+        :return: (str) expression pattern matching the file extensions of the plot handler
+        """
+        _extension_regex = '('
+        for extension in self.file_extensions:
+            _extension_regex += f'{extension}|'
+        return _extension_regex[:-1] + ')'
+
     def _check_for_plot_files(self):
         """
         Searches the server directory for existing plot files using the directory specified.

--- a/plotting/plot_handler.py
+++ b/plotting/plot_handler.py
@@ -104,6 +104,10 @@ class PlotHandler:
         but will only copy over one.
         :return: (str) local path to downloaded files OR None if no files found
         """
+        _existing_plot_files = self._get_plot_files_locally()
+        if _existing_plot_files:
+            return _existing_plot_files
+
         _existing_plot_files = self._check_for_plot_files()
         local_plot_paths = []
         if _existing_plot_files:

--- a/plotting/plot_handler.py
+++ b/plotting/plot_handler.py
@@ -42,16 +42,16 @@ class PlotHandler:
                                              'autoreduce_webapp', 'static',
                                              'graphs')
 
-    def _generate_file_name_regex(self, plot_type):
+    def _generate_file_name_regex(self):
         """
         Regular expression used for looking for plot files.
         This assumes that the file names follow the convention:
         <instrument_abbreviation><run_number>*<.png or other extension>
-        :param plot_type: (str) the type of file to be searched for, e.g. "png"
         """
         try:
             _inst_regex = INSTRUMENT_REGEX_MAP[self.instrument_name]
-            return f'{_inst_regex}{self.run_number}.*.{plot_type}'
+            _file_extension_regex = self._generate_file_extension_regex()
+            return f'{_inst_regex}{self.run_number}.*.{_file_extension_regex}'
         except KeyError:  # Instrument name does not appear in dictionary of known instruments
             LOGGER.info("The instrument name is not recognised")
             return None
@@ -76,15 +76,14 @@ class PlotHandler:
         client = SFTPClient()
         # initialise list to store names of existing files matching the search
         _found_files = []
-        for plot_type in self.file_extensions:
-            # regular expression for plot file name(s)
-            file_regex = self._generate_file_name_regex(plot_type=plot_type)
-            if file_regex:
-                # Add files that match regex to the list of files found
-                _found_files.extend(client.get_filenames(server_dir_path=self.server_dir,
-                                                         regex=file_regex))
-            else:
-                return None
+        # regular expression for plot file name(s)
+        file_regex = self._generate_file_name_regex()
+        if file_regex:
+            # Add files that match regex to the list of files found
+            _found_files.extend(client.get_filenames(server_dir_path=self.server_dir,
+                                                     regex=file_regex))
+        else:
+            return None
         return _found_files
 
     def get_plot_file(self):

--- a/plotting/plot_handler.py
+++ b/plotting/plot_handler.py
@@ -11,8 +11,10 @@ Searching for and retrieving an existing plotting file via the SFTP client
 Getting the associated plotting meta data file
 Instructing the Plotting factory to build an IFrame based on the above
 """
-import os
 import logging
+import os
+import re
+
 from utils.clients.sftp_client import SFTPClient
 from utils.project.structure import get_project_root
 
@@ -66,6 +68,15 @@ class PlotHandler:
         for extension in self.file_extensions:
             _extension_regex += f'{extension}|'
         return _extension_regex[:-1] + ')'
+
+    def _get_plot_files_locally(self):
+        """
+        Searches the local graph folder for files matching the generated file name regex and returns
+        a list of matching paths
+        :return: (list) - The list of matching file paths.
+        """
+        return [f'/static/graphs/{file}' for file in os.listdir(self.static_graph_dir)
+                if re.match(self._generate_file_name_regex(), file)]
 
     def _check_for_plot_files(self):
         """

--- a/plotting/tests/test_plot_handler.py
+++ b/plotting/tests/test_plot_handler.py
@@ -31,6 +31,8 @@ class TestPlotHandler(unittest.TestCase):
         """
         self.expected_file_extension_regex = '(png|jpg|bmp|gif|tiff)'
         self.expected_mari_file_regex = f'MAR(I)?1234.*.{self.expected_file_extension_regex}'
+        self.expected_wish_file_regex = f"WISH1234.*.{self.expected_file_extension_regex}"
+        self.expected_wish_instrument_name = "WISH"
         self.expected_mari_instrument_name = "MARI"
         self.expected_mari_rb_number = 12345678
         self.expected_mari_run_number = 1234
@@ -63,10 +65,9 @@ class TestPlotHandler(unittest.TestCase):
         """
         actual = self.test_plot_handler._generate_file_name_regex()
         self.assertEqual(self.expected_mari_file_regex, actual)
-        expected_wish = f"WISH1234.*.{self.expected_file_extension_regex}"
-        self.test_plot_handler.instrument_name = "WISH"
+        self.test_plot_handler.instrument_name = self.expected_wish_instrument_name
         actual = self.test_plot_handler._generate_file_name_regex()
-        self.assertEqual(expected_wish, actual)
+        self.assertEqual(self.expected_wish_file_regex, actual)
 
     def test_generate_file_extension_regex(self):
         """

--- a/plotting/tests/test_plot_handler.py
+++ b/plotting/tests/test_plot_handler.py
@@ -90,6 +90,54 @@ class TestPlotHandler(unittest.TestCase):
         self.test_plot_handler.instrument_name = "Not instrument"
         self.assertIsNone(self.test_plot_handler._generate_file_name_regex())
 
+    @patch("os.listdir", return_value=["MAR1234_123.456.png", "MAR1234_124.png", "MAR123.nxs"])
+    @patch("plotting.plot_handler.PlotHandler._generate_file_name_regex")
+    def test_get_plot_files_locally_files_exist_returns_list(self, mock_gfn_regex, mock_listdir):
+        """
+        Test: Correct file paths are returned
+        When: Multiple matching files exist
+        """
+        mock_gfn_regex.return_value = self.expected_mari_file_regex
+
+        expected_files = ["/static/graphs/MAR1234_123.456.png", "/static/graphs/MAR1234_124.png"]
+        actual = self.test_plot_handler._get_plot_files_locally()
+        self.assertEqual(expected_files, actual)
+
+        mock_listdir.assert_called()
+        mock_gfn_regex.assert_called()
+
+    @patch("os.listdir", return_value=["MAR1234.png"])
+    @patch("plotting.plot_handler.PlotHandler._generate_file_name_regex")
+    def test_get_plot_files_locally_single_file_returns_list(self, mock_gfn_regex, mock_listdir):
+        """
+        Test: Correct file path is returned
+        When: Single matching file exists
+        """
+        mock_gfn_regex.return_value = self.expected_mari_file_regex
+
+        expected_files = ["/static/graphs/MAR1234.png"]
+        actual = self.test_plot_handler._get_plot_files_locally()
+        self.assertEqual(expected_files, actual)
+
+        mock_listdir.assert_called()
+        mock_gfn_regex.assert_called()
+
+    @patch("os.listdir", return_value=["MAR1234.nxs"])
+    @patch("plotting.plot_handler.PlotHandler._generate_file_name_regex")
+    def test_get_plot_files_no_matching_file_returns_empty_list(self, mock_gfn_regex, mock_listdir):
+        """
+        Test: Empty list is returned
+        When: No matching file exists
+        """
+        mock_gfn_regex.return_value=self.expected_mari_file_regex
+
+        expected_files = []
+        actual = self.test_plot_handler._get_plot_files_locally()
+        self.assertEqual(expected_files, actual)
+
+        mock_listdir.assert_called()
+        mock_gfn_regex.assert_called()
+
     @patch('utils.clients.sftp_client.SFTPClient.__init__', return_value=None)
     @patch('utils.clients.sftp_client.SFTPClient.get_filenames')
     def test_check_for_plot_files(self, mock_get_filenames, mock_client_init):

--- a/plotting/tests/test_plot_handler.py
+++ b/plotting/tests/test_plot_handler.py
@@ -67,6 +67,20 @@ class TestPlotHandler(unittest.TestCase):
         actual = self.test_plot_handler._generate_file_name_regex('tiff')
         self.assertEqual(expected_wish, actual)
 
+    def test_generate_file_extension_regex(self):
+        """
+        Test: Correct file extension pattern is generated
+        When: _generate_file_extension_pattern() is called
+        """
+        expected_pattern = '(png|jpg|bmp|gif|tiff)'
+        actual_pattern = self.test_plot_handler._generate_file_extension_regex()
+        self.assertEqual(expected_pattern, actual_pattern)
+
+        self.test_plot_handler.file_extensions.append('txt')
+        expected_pattern = '(png|jpg|bmp|gif|tiff|txt)'
+        actual_pattern = self.test_plot_handler._generate_file_extension_regex()
+        self.assertEqual(expected_pattern, actual_pattern)
+
     def test_generate_file_name_regex_invalid(self):
         """
         Test: Assert None is returned


### PR DESCRIPTION
### Summary of work
<!---The changes you have made--->
Probably easiest to review commit by commit in order, instead of all at once.

Added a method to check the local storage for a graph before searching server.

I also added a method to generate the file extension part of the filename regex pattern. This moves 1 existing for loop and meant another wouldn't have to be introduced.

Test names maybe aren't great

### How to test your work
<!---This can be a link to the---> 
I tested this by loading a reduction that produced a graph (MARI 27282) Then I commented out the code to search remotely for the image and restarted the server and made sure the graph was then reloaded when I reopened that reduction.

### Additional comments
<!---Anything else: e.g. was the estimate reasonable for this issue?---> 

Fixes #618


**Before merging ensure the release notes have been updated**