### PR TITLE
Format plot display

### DIFF
--- a/WebApp/autoreduce_webapp/static/css/base.css
+++ b/WebApp/autoreduce_webapp/static/css/base.css
@@ -277,3 +277,7 @@ search#run_search {
         padding: 2px;
     }
 }
+
+.plot-container {
+    margin: 0.5em;
+}

--- a/WebApp/autoreduce_webapp/templates/run_summary.html
+++ b/WebApp/autoreduce_webapp/templates/run_summary.html
@@ -18,11 +18,15 @@
             </div>
         </div>
         {% if plot_locations %}
+            <div class="row plot-container">
             {% for plot_file in plot_locations %}
-            <div>
-                <img src="{{ plot_file }}">
-            </div>
+                {% if plot_locations|length == 1 %}
+                    <img class="center-block" src="{{ plot_file }}">
+                {%else%}
+                    <img class="col-md-6" src="{{ plot_file }}">
+                {% endif %}
             {% endfor %}
+            </div>
         {% endif %}
         {% if run.message %}
             {% if 'Skipped' in run.message %}


### PR DESCRIPTION
### Summary of work
Centred plot when single plot, alligned for 2. on 2+ it wraps, though I am not sure how often a reduction will have more than 2 plots. Can look at different way to handle that scenario?
Also added a small margin to stop the overlap of the plot onto the border of the summary underneath

#### 1 plot:
![image](https://user-images.githubusercontent.com/44777678/88369351-b63dbd80-cd87-11ea-85db-1822d45e8a98.png)


#### 2 plots:
![image](https://user-images.githubusercontent.com/44777678/88369301-9d350c80-cd87-11ea-9afb-68a0b830f960.png)


#### 3 plots:
![image](https://user-images.githubusercontent.com/44777678/88369248-84c4f200-cd87-11ea-839a-5efdad97f46b.png)


### How to test your work
<!---This can be a link to the---> 
I tested this by first applying the change in #672 , then duplicated the plot for 67282 locally to get the desired amount of plots.
I guess if you know a run that already has multiple graphs, you could use that instead.
Remember to ctrl f5, like i didnt 🤦 


### Additional comments
<!---Anything else: e.g. was the estimate reasonable for this issue?---> 

Fixes #615 


**Before merging ensure the release notes have been updated**