### PR TITLE
630 display reduction software in run summary

### DIFF
--- a/WebApp/autoreduce_webapp/templates/run_summary.html
+++ b/WebApp/autoreduce_webapp/templates/run_summary.html
@@ -103,9 +103,11 @@
                                     {% endif %}
                                 </div>
                                 <div>
+                                    <strong>Software used:</strong>
                                     {% if run.software is not null %}
-                                        <strong>Software used:</strong>
                                         {{ run.software.name }} - {{ run.software.version }}
+                                    {% else %}
+                                        <em>No software data found</em>
                                     {% endif %}
                                 </div>
                             </div>

--- a/WebApp/autoreduce_webapp/templates/run_summary.html
+++ b/WebApp/autoreduce_webapp/templates/run_summary.html
@@ -102,6 +102,12 @@
                                         <em>Not yet finished</em>
                                     {% endif %}
                                 </div>
+                                <div>
+                                    {% if run.software is not null %}
+                                        <strong>Software used:</strong>
+                                        {{ run.software.name }} - {{ run.software.version }}
+                                    {% endif %}
+                                </div>
                             </div>
                         </div>
                         <div class="row">


### PR DESCRIPTION
### Summary of work
Added software name - version to run_summary.html below Retrying.

### How to test your work
* Code review
* Load the webapp and navigate to a run where there's an entry for that run in the software table.
* Then see that the software name - version is being displayed.
* Also navigate to a run without a software entry and see that "No software data found" is displayed.

Fixes #630 


**Before merging ensure the release notes have been updated**