### PR TITLE
Add allowed status fields to access.get_status

### DIFF
--- a/model/database/access.py
+++ b/model/database/access.py
@@ -45,6 +45,9 @@ def get_status(status_value, create=False):
     :param create: (bool) If True, then create the record if it does not exist
     :return: (Status) The Status object from the database
     """
+    if status_value not in ["Error", "Queued", "Processing", "Completed", "Skipped"]:
+        raise ValueError("Invalid status value passed")
+
     database = start_database()
     status_record = database.data_model.Status.objects.filter(value=status_value).first()
     if not status_record and create:

--- a/model/database/access.py
+++ b/model/database/access.py
@@ -44,6 +44,7 @@ def get_status(status_value, create=False):
     :param status_value: (str) The value of the status record e.g. 'Completed'
     :param create: (bool) If True, then create the record if it does not exist
     :return: (Status) The Status object from the database
+    :raises: (ValueError): If status_value is not: Error, Queued, Processing, Completed or Skipped
     """
     if status_value not in ["Error", "Queued", "Processing", "Completed", "Skipped"]:
         raise ValueError("Invalid status value passed")

--- a/model/database/tests/test_access.py
+++ b/model/database/tests/test_access.py
@@ -167,3 +167,10 @@ class TestAccess(unittest.TestCase):
         mock_record = Mock()
         access.save_record(mock_record)
         mock_record.save.assert_called_once()
+
+    def test_get_status_with_invalid_status_value(self):
+        """
+        Test: When access.get_status is called with an invalid status_value a ValueError is raised
+        When: Calling access.get_status()
+        """
+        self.assertRaises(ValueError, access.get_status, "test")

--- a/queue_processors/queue_processor/queueproc_utils/tests/test_status_utils.py
+++ b/queue_processors/queue_processor/queueproc_utils/tests/test_status_utils.py
@@ -57,6 +57,6 @@ class TestStatusUtils(unittest.TestCase):
         Note: we are mocking the database return to ensure it does exist
         """
         # pylint:disable=protected-access
-        actual = self.status_utils._get_status('valid')
+        actual = self.status_utils._get_status('Completed')
         self.assertIsNotNone(actual)
         self.assertIsInstance(actual, self.status_type)


### PR DESCRIPTION
### Summary of work
- `models.database.access.get_status` now raises a ValueError when called with an invalid status_value.
- Added new test in `models/database/access/tests/test_access.py` to test if passing an invalid `status_value` to `access.get_status` raises a `ValueError`.

### How to test your work
* Code review to ensure that the unit test is properly formed
* Ensure the unit test passes on Travis


Fixes #606