### PR TITLE
Help pages search filter

### DIFF
--- a/WebApp/autoreduce_webapp/static/css/base.css
+++ b/WebApp/autoreduce_webapp/static/css/base.css
@@ -281,3 +281,7 @@ search#run_search {
 .plot-container {
     margin: 0.5em;
 }
+
+#category-filter * {
+    background-color: #f5f5f5;
+}

--- a/WebApp/autoreduce_webapp/static/javascript/help.js
+++ b/WebApp/autoreduce_webapp/static/javascript/help.js
@@ -1,13 +1,16 @@
 (function () {
 
+    // Search all topics and filter them according to search terms and a category
     var searchFilter = function filterHelpTopics(searchTerms, category) {
-        $('section.help-topic,.no-results').hide();
+        $('section.help-topic, .no-results').hide();
 
         var i, searchTerm;
         if (searchTerms.length > 0) {
+            // Show all topics that match the category and the search term
             for (i = 0; i < searchTerms.length; i++) {
                 searchTerm = searchTerms[i].toLowerCase();
                 if (category === 'all') {
+                    // Category is irrelevant here
                     $('section.help-topic[data-topics*="' + searchTerm + '"]').show();
                 } else {
                     $('section.help-topic[data-category*="' + category + '"]' +
@@ -15,12 +18,13 @@
                 }
             }
 
+            // If no help topics found show "no results" element
             if ($('section.help-topic:visible').length === 0) {
                 $('.no-results').show();
             } else {
                 $('.no-results').hide();
             }
-        } else {
+        } else { // no search string entered
             if (category === "all") {
                 $('section.help-topic').show();
             } else {
@@ -34,6 +38,7 @@
         $('#help_search').data('placement', 'top');
     };
 
+    // Plain text input => array of terms
     var stringToSearchTerms = function stringToSearchTerms(string) {
         return string.trim() && string.trim().split(' ');
     };
@@ -44,6 +49,7 @@
         }
 
         $('#help_search').on('keyup', function (event) {
+            // Ignore pressing enter
             if ((event.keyCode || event.which || event.charCode) === 13) {
                 event.preventDefault();
                 return;
@@ -54,10 +60,8 @@
         }).popover();
 
         $('#category-filter .btn').on('click', function () {
-            var helpSearch = $('#help_search');
-            searchFilter(stringToSearchTerms(helpSearch.val()), $(this).data("category"));
+            searchFilter(stringToSearchTerms($('#help_search').val()), $(this).data("category"));
         });
-
     };
 
     init();

--- a/WebApp/autoreduce_webapp/static/javascript/help.js
+++ b/WebApp/autoreduce_webapp/static/javascript/help.js
@@ -1,35 +1,62 @@
-(function(){
+(function () {
 
-    var filterHelpTopics = function filterHelpTopics(event){
-        if((event.keyCode || event.which || event.charCode) === 13){
-            event.preventDefault();
-            return;
-        }
-        var searchTerms = $(this).val().trim() && $(this).val().trim().split(' ');
+    var searchFilter = function filterHelpTopics(searchTerms, category) {
+        $('section.help-topic,.no-results').hide();
+
         var i, searchTerm;
-        if(searchTerms.length>0){
-            for(i=0;i<searchTerms.length;i++){
+        if (searchTerms.length > 0) {
+            for (i = 0; i < searchTerms.length; i++) {
                 searchTerm = searchTerms[i].toLowerCase();
-                $('section.help-topic,.no-results').hide();
-                $('section.help-topic[data-topics*="'+searchTerm+'"').show();
-                if($('section.help-topic:visible').length===0){
-                    $('.no-results').show();
+                if (category === 'all') {
+                    $('section.help-topic[data-topics*="' + searchTerm + '"]').show();
+                } else {
+                    $('section.help-topic[data-category*="' + category + '"]' +
+                        '[data-topics*="' + searchTerm + '"]').show();
                 }
             }
-        }else{
-            $('section.help-topic').show();
+
+            if ($('section.help-topic:visible').length === 0) {
+                $('.no-results').show();
+            } else {
+                $('.no-results').hide();
+            }
+        } else {
+            if (category === "all") {
+                $('section.help-topic').show();
+            } else {
+                $('section.help-topic[data-category*="' + category + '"').show();
+            }
+
         }
     };
 
-    var mobileOnly = function mobileOnly(){
+    var mobileOnly = function mobileOnly() {
         $('#help_search').data('placement', 'top');
     };
 
-    var init = function init(){
-        if(Math.max(document.documentElement.clientWidth, window.innerWidth || 0) < 767){
+    var stringToSearchTerms = function stringToSearchTerms(string) {
+        return string.trim() && string.trim().split(' ');
+    };
+
+    var init = function init() {
+        if (Math.max(document.documentElement.clientWidth, window.innerWidth || 0) < 767) {
             mobileOnly();
         }
-        $('#help_search').on('keyup', filterHelpTopics).popover();
+
+        $('#help_search').on('keyup', function (event) {
+            if ((event.keyCode || event.which || event.charCode) === 13) {
+                event.preventDefault();
+                return;
+            }
+
+            searchFilter(stringToSearchTerms($(this).val()),
+                $('#category-filter > .btn.active').data("category"));
+        }).popover();
+
+        $('#category-filter .btn').on('click', function () {
+            var helpSearch = $('#help_search');
+            searchFilter(stringToSearchTerms(helpSearch.val()), $(this).data("category"));
+        });
 
     };
 

--- a/WebApp/autoreduce_webapp/templates/help.html
+++ b/WebApp/autoreduce_webapp/templates/help.html
@@ -9,15 +9,29 @@
         </div>
     </div>
     <div class="row">
-        <div class="col-md-12">
+        <div class="col-md-9">
             <div class="form-group">
                 <label for="help_search" class="screenreader-only">Search</label>
                 <input type="search" placeholder="Search" name="help_search" id="help_search" class="form-control" autocomplete="off" data-toggle="popover" data-trigger="focus" data-content="Try entering a keyword to filter help topics." data-placement="top">
             </div>
         </div>
+        <div class="col-md-3">
+            <div id="category-filter" class="btn-group btn-group-toggle" data-toggle="buttons">
+                <label class="btn btn-secondary active" data-category="all">
+                    <input type="radio" name="options" id="option1" autocomplete="off" checked>
+                    All
+                </label>
+                <label class="btn btn-secondary" data-category="usage">
+                    <input type="radio" name="options" id="option2" autocomplete="off"> Usage
+                </label>
+                <label class="btn btn-secondary" data-category="question">
+                    <input type="radio" name="options" id="option3" autocomplete="off"> Questions
+                </label>
+            </div>
+        </div>
     </div>
 
-    <section class="help-topic panel panel-default" data-topics="link reduced data">
+    <section class="help-topic panel panel-default" data-category="question" data-topics="link reduced data">
         <div class="panel-heading">
             <h4>How do I access my reduced data?</h4>
         </div>
@@ -62,7 +76,7 @@
             </p>
         </div>
     </section>
-    <section class="help-topic panel panel-default" data-topics="instrument variables change new">
+    <section class="help-topic panel panel-default" data-category="usage" data-topics="instrument variables change new">
         <div class="panel-heading">
             <h4>How do I add new instrument variables?</h4>
         </div>

--- a/WebApp/autoreduce_webapp/templates/help.html
+++ b/WebApp/autoreduce_webapp/templates/help.html
@@ -36,6 +36,53 @@
         </div>
     </div>
 
+    <section class="help-topic panel panel-default" data-category="question" data-topics="link reduced data">
+        <div class="panel-heading">
+            <h4>How do I access my reduced data?</h4>
+        </div>
+        <div class="panel-body">
+            <p>
+                In order to copy reduced data from CEPH to your local machine, you will need to download an SFTP client.
+                We recommend <a href="https://winscp.net/eng/download.php">WinSCP</a> if you are using a windows operating system.
+                The steps below are based on WinSCP as the <code>SFTP Client</code> and assume you have downloaded and installed it.
+                Note that you can only access your data if you are on site, or using the VPN.
+            </p>
+            <h2>IDAaaS</h2>
+            <ol>
+                <li>Visit the IDAaaS page <a href="https://isis.analysis.stfc.ac.uk">https://isis.analysis.stfc.ac.uk</a></li>
+                <li>Create a new IDAaaS instance for your instrument / technique.</li>
+                <li>Follow the instructions on the <a href="https://isis.analysis.stfc.ac.uk/#/help">IDAaaS help page</a>
+                    under the <em>Download/Upload Files</em> section that will walk you through the SFTP process </li>
+            </ol>
+            <h2>ISIS Compute</h2>
+            If you do not currently have your instrument supported by IDAaaS, you should use the ISIS Compute service.
+            <ol>
+                <li>Open your SFTP client</li>
+                <li>Host name: <strong>isiscompute.nd.rl.ac.uk</strong></li>
+                <li>Port: <strong>22</strong></li>
+                <li>Enter your federal ID and password</li>
+                <ul>
+                    <li>To avoid repeating these steps in the future, click save and fill in the save dialog box that opens</li>
+                </ul>
+                <li>Click Login</li>
+                <ul>
+                    <li>You may get a warning message about a potential security breach.
+                        This is nothing to worry about and is common, especially if it's your first time accessing the server in a while.
+                        Simply click <strong>Update</strong> to continue.</li>
+                </ul>
+                <li>Once the client has connected to the server, you will see your files (default on the left) and the server files (default on the right)</li>
+                <li>From here you can now copy and paste between your local files and those on CEPH.</li>
+                <li>You can find the CEPH data at /instrument. See <a href="#reduction_data_location">Where does my reduced data go?</a> for more details.</li>
+            </ol>
+            <p>
+                If you follow the instructions above and still can't access your reduced data, it
+                may be that you don't have permission to access the experiment's reduced data
+                directory. Email <a href="mailto:isisreduce@stfc.ac.uk">isisreduce@stfc.ac.uk</a>
+                and state the experiment RB number you are trying to access.
+            </p>
+        </div>
+    </section>
+
     <section class="help-topic panel panel-default" data-category="usage" data-topics="instrument variables change new">
         <div class="panel-heading">
             <h4>How do I add new instrument variables?</h4>

--- a/WebApp/autoreduce_webapp/templates/help.html
+++ b/WebApp/autoreduce_webapp/templates/help.html
@@ -9,24 +9,29 @@
         </div>
     </div>
     <div class="row">
-        <div class="col-md-9">
+        <div class="col-md-8">
             <div class="form-group">
                 <label for="help_search" class="screenreader-only">Search</label>
                 <input type="search" placeholder="Search" name="help_search" id="help_search" class="form-control" autocomplete="off" data-toggle="popover" data-trigger="focus" data-content="Try entering a keyword to filter help topics." data-placement="top">
             </div>
         </div>
-        <div class="col-md-3">
-            <div id="category-filter" class="btn-group btn-group-toggle" data-toggle="buttons">
-                <label class="btn btn-secondary active" data-category="all">
-                    <input type="radio" name="options" id="option1" autocomplete="off" checked>
-                    All
-                </label>
-                <label class="btn btn-secondary" data-category="usage">
-                    <input type="radio" name="options" id="option2" autocomplete="off"> Usage
-                </label>
-                <label class="btn btn-secondary" data-category="question">
-                    <input type="radio" name="options" id="option3" autocomplete="off"> Questions
-                </label>
+        <div class="col-md-4 text-center">
+            <div class="form-group">
+                <span>Category: </span>
+                <div id="category-filter" class="btn-group btn-group-toggle" data-toggle="buttons">
+                    <label class="btn btn-secondary active" data-category="all">
+                        <input type="radio" name="categories" id="category-all" checked>
+                        All
+                    </label>
+                    <label class="btn btn-secondary" data-category="usage">
+                        <input type="radio" name="categories" id="category-usage">
+                        Usage
+                    </label>
+                    <label class="btn btn-secondary" data-category="question">
+                        <input type="radio" name="categories" id="category-question">
+                        Questions
+                    </label>
+                </div>
             </div>
         </div>
     </div>
@@ -86,7 +91,7 @@
             </p>
         </div>
     </section>
-    <section class="help-topic panel panel-default" data-topics="invalid variables wrong error value">
+    <section class="help-topic panel panel-default" data-category="question" data-topics="invalid variables wrong error value">
         <div class="panel-heading">
             <h4>When changing variables why is value X invalid for variable Y?</h4>
         </div>
@@ -99,7 +104,7 @@
             {% endif %}
         </div>
     </section>
-    <section class="help-topic panel panel-default" data-topics="reduction data file location directory output reduced">
+    <section class="help-topic panel panel-default" data-category="question" data-topics="reduction data file location directory output reduced">
         <div class="panel-heading">
             <h4>I've modified my reduction scripts, why aren't my new runs using it?</h4>
         </div>
@@ -118,7 +123,7 @@
             </p>
         </div>
     </section>
-        <section class="help-topic panel panel-default" data-topics="script compatible work">
+        <section class="help-topic panel panel-default" data-category="question" data-topics="script compatible work">
             <div class="panel-heading">
                 <h4>How can I make a reduction script compatible with autoreduction?</h4>
             </div>
@@ -134,7 +139,7 @@
                 {% endif %}
             </div>
         </section>
-        <section class="help-topic panel panel-default" data-topics="reduction script file location directory">
+        <section class="help-topic panel panel-default" data-category="question" data-topics="reduction script file location directory">
             <div class="panel-heading">
                 <h4>Where should I put reduction scripts?</h4>
             </div>
@@ -150,7 +155,7 @@
                 </p>
             </div>
         </section>
-        <section class="help-topic panel panel-default" data-topics="reduction data file location directory output reduced">
+        <section class="help-topic panel panel-default" data-category="question" data-topics="reduction data file location directory output reduced">
             <div class="panel-heading">
                 <h4>Where does my reduced data go?</h4>
             </div>


### PR DESCRIPTION
### Summary of work
Implemented a toggle button that filters help topics by a specified category (currently "Usage" and "Questions").

![image](https://user-images.githubusercontent.com/5902731/89435393-b3a27700-d73c-11ea-82ce-386844da352c.png)

### How to test your work
* Code review
* Open the help page then:
  * Click on the categories to the right of the search bar to see if help topics for that category appear below.
  * Try different combinations of search terms and categories to see if the correct help topics appear.
  * Note that "How do I add new instrument variables?" is the only topic in "Usage", the rest are in "Questions". This should be changed before merging.

### Additional comments
I wasn't sure which topics, if any, would be considered a question or a usage category.

Fixes #676


**Before merging ensure the release notes have been updated**