### PR TITLE
Fix qp issues

### DIFF
--- a/model/message/validation/process.py
+++ b/model/message/validation/process.py
@@ -35,7 +35,7 @@ def dict_to_string(validity_dict):
     :param validity_dict: (dict) containing the validity checks
     :return: (str) A string to print
     """
-    result_str = ""
+    result_str = "\n"
     for key, value in validity_dict.items():
-        result_str += f"{key} - {value}\n"
+        result_str += f"\t{key} - {value}\n"
     return result_str

--- a/model/message/validation/tests/test_process.py
+++ b/model/message/validation/tests/test_process.py
@@ -56,5 +56,5 @@ class TestProcess(unittest.TestCase):
         Test: An expected string is returned
         When: dict_to_string is called with a valid dict
         """
-        expected = "check_1 - True\ncheck_2 - True\n"
+        expected = "\n\tcheck_1 - True\n\tcheck_2 - True\n"
         self.assertEqual(process.dict_to_string(self.true_validity_dict), expected)

--- a/queue_processors/queue_processor/handle_message.py
+++ b/queue_processors/queue_processor/handle_message.py
@@ -135,7 +135,12 @@ class HandleMessage:
         message.reduction_arguments = arguments
 
         # Make sure the RB number is valid
-        message.validate("/queue/DataReady")
+        try:
+            message.validate("/queue/DataReady")
+        except RuntimeError as validation_err:
+            self._logger.error("Validation error from handler: %s", str(validation_err))
+            self._client.send_message('/queue/ReductionSkipped', message)
+            return
 
         if instrument.is_paused:
             self._logger.info("Run %s has been skipped",

--- a/queue_processors/queue_processor/handle_message.py
+++ b/queue_processors/queue_processor/handle_message.py
@@ -19,6 +19,8 @@ import traceback
 from model.database import access as db_access
 import model.database.records as db_records
 from model.message.message import Message
+from model.message.validation.validators import validate_rb_number
+
 from queue_processors.queue_processor._utils_classes import _UtilsClasses
 from queue_processors.queue_processor.handling_exceptions import \
     MissingReductionRunRecord, InvalidStateException, MissingExperimentRecord
@@ -67,6 +69,14 @@ class HandleMessage:
         """
         self._logger.info("Data ready for processing run %s on %s",
                           message.run_number, message.instrument)
+        if not validate_rb_number(message.rb_number):
+            # rb_number is invalid so send message to skip queue and early return
+            message.message = f"Found non-integer RB number: {message.rb_number}"
+            self._logger.warning("%s. Skipping %s%s.", message.message,
+                                 message.instrument, message.run_number)
+            message.rb_number = 0
+
+
         run_no = str(message.run_number)
         instrument = self._get_and_activate_db_inst(message.instrument)
 

--- a/scripts/manual_operations/manual_submission.py
+++ b/scripts/manual_operations/manual_submission.py
@@ -200,7 +200,7 @@ def main(instrument, first_run, last_run=None):
 
     for run in run_numbers:
         location, rb_num = get_location_and_rb(database_client, icat_client, instrument, run, "nxs")
-        if location and rb_num:
+        if location and rb_num is not None:
             submit_run(activemq_client, rb_num, instrument, location, run)
         else:
             print("Unable to find rb number and location for {}{}".format(instrument, run))


### PR DESCRIPTION
### Summary of work
* This fixes this issue with invalid runs breaking the consumers and forcing them to disconnect
* Enables str RB's to be properly processed


### How to test your work
* Manually submit a str RB e.g. `MARI 27252` - This should be skipped and assigned to RB0
* Manually submit a normal RB e.g. `MARI 27037` - This should complete with no issue
* Manually submit a RB 0 e.g. `MARI 26920` - This should be skipped and assigned to RB0


Fixes #673 & Fixes #614 


**Before merging ensure the release notes have been updated**