### PR TITLE
Fixes to allow successful execution of tests on Ubuntu 18.04

### DIFF
--- a/build/commands/database.py
+++ b/build/commands/database.py
@@ -11,8 +11,7 @@ import os
 # pylint:disable=no-name-in-module,import-error
 from distutils.core import Command
 
-from build.database.generate_database import (get_sql_from_file, get_test_user_sql,
-                                              run_sql, generate_schema)
+from build.database.generate_database import (get_sql_from_file, run_sql, generate_schema)
 from build.utils.common import BUILD_LOGGER, ROOT_DIR
 
 
@@ -44,16 +43,6 @@ class InitialiseTestDatabase(Command):
         local_db_connection = DatabaseClient(LOCAL_MYSQL_SETTINGS).connect()
 
         BUILD_LOGGER.print_and_log("==================== Building Database ======================")
-        BUILD_LOGGER.print_and_log("DROPPING and creating Autoreduction table")
-        if run_sql(connection=local_db_connection,
-                   sql=get_sql_from_file(self.setup_sql_path),
-                   logger=BUILD_LOGGER.logger) is False:
-            return
-        BUILD_LOGGER.print_and_log("Adding test user from settings")
-        if run_sql(connection=local_db_connection,
-                   sql=get_test_user_sql(),
-                   logger=BUILD_LOGGER.logger) is False:
-            return
         BUILD_LOGGER.print_and_log("Migrating databases from django model")
         if generate_schema(ROOT_DIR, BUILD_LOGGER.logger) is False:
             return

--- a/build/commands/migrate_settings.py
+++ b/build/commands/migrate_settings.py
@@ -56,17 +56,17 @@ class MigrateTestSettings(Command):
         :param all_paths: All directories containing test_settings.py
         """
         try:
-            for path_to_dir in all_paths:
-                test_settings_path = os.path.join(path_to_dir, 'test_settings.py')
-                settings_path = os.path.join(path_to_dir, 'settings.py')
-                copyfile(test_settings_path, settings_path)
+            test_credentials_path = os.path.join(utils_path, 'test_credentials.ini')
+            credentials_path = os.path.join(utils_path, 'credentials.ini')
+            copyfile(test_credentials_path, credentials_path)
         except OSError as error:
             BUILD_LOGGER.logger.error(error)
             raise
         try:
-            test_credentials_path = os.path.join(utils_path, 'test_credentials.ini')
-            credentials_path = os.path.join(utils_path, 'credentials.ini')
-            copyfile(test_credentials_path, credentials_path)
+            for path_to_dir in all_paths:
+                test_settings_path = os.path.join(path_to_dir, 'test_settings.py')
+                settings_path = os.path.join(path_to_dir, 'settings.py')
+                copyfile(test_settings_path, settings_path)
         except OSError as error:
             BUILD_LOGGER.logger.error(error)
             raise

--- a/build/test_settings.py
+++ b/build/test_settings.py
@@ -26,8 +26,6 @@ else:
     }
     # 7Zip not required on linux
 
-DB_ROOT_PASSWORD = ''
-
 # Note the apache-activemq version number in path joined below, must match that in
 # build/install/activemq.sh (and activemq.bat), which by default should be true 
 ACTIVEMQ_EXECUTABLE = os.path.join(INSTALL_DIRS['activemq'],

--- a/utils/test_settings.py
+++ b/utils/test_settings.py
@@ -51,10 +51,10 @@ ACTIVEMQ_SETTINGS = SETTINGS_FACTORY.create('queue',
                                             port=get_str('QUEUE', 'port'))
 
 LOCAL_MYSQL_SETTINGS = SETTINGS_FACTORY.create('database',
-                                               username='root',
-                                               password='',
-                                               host='localhost',
-                                               port='3306')
+                                               username=get_str('DATABASE','user'),
+                                               password=get_str('DATABASE','password'),
+                                               host=get_str('DATABASE','host'),
+                                               port=get_str('DATABASE','port'))
 
 SFTP_SETTINGS = SETTINGS_FACTORY.create('sftp',
                                         username=get_str('SFTP', 'user'),


### PR DESCRIPTION
### Summary of work
- Uses the DB configuration from the generated `credentials.ini`
- Moves the credential generation to happen before the DB config tries to read the generated file
- Removes database-generating commands that require ROOT privileges 
  - These seemed to just be duplicating the `mysql < build/database/reset_autoreduction_db.sql` command.
  - Locally, they were failing as MySQL does not allow using the `root` user without `sudo`. And I could not find a way to force MySQL to allow that

### How to test your work
- Tests should pass
- Check that the following commands execute OK locally 
  - python3 setup.py test_settings
  - python3 setup.py database 
- Run all tests

### Additional comments
I also had to manually run `activemq` on Ubuntu, not sure how that is passing on Travis as I don't see it being manually started from the `.travil.yml`

What worries me is that this PR pretty much undoes some of the work added in these commits:
- 082598b3a9e8cf8ef7a184b14ad6f0f36453e071 (just a rename/re-order)
- 38146a03b4a887ae58fcf293099c342e7d47c0d7 adds set-up user

but I can't see a reason _now_ that we would want to reset the whole database twice before even adding the django tables

No related issue

**Before merging ensure the release notes have been updated**