### PR TITLE
Cache plots

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,6 @@ webtests/screenshots
 webtests/config.json
 
 data-archive/
+
+#Ignore django cache files
+*.djcache

--- a/WebApp/autoreduce_webapp/autoreduce_webapp/settings.py
+++ b/WebApp/autoreduce_webapp/autoreduce_webapp/settings.py
@@ -101,6 +101,17 @@ ROOT_URLCONF = 'autoreduce_webapp.urls'
 
 WSGI_APPLICATION = 'autoreduce_webapp.wsgi.application'
 
+#Caches
+CACHES = {
+    'default': {
+        'BACKEND': 'django.core.cache.backends.locmem.LocMemCache'
+    },
+    'plot': {
+        'BACKEND': 'plotting.plot_cache.PlotCache',
+        'LOCATION': 'WebApp/autoreduce_webapp/static/cache'
+    }
+}
+
 # Database
 # https://docs.djangoproject.com/en/dev/ref/settings/#databases
 

--- a/plotting/plot_cache.py
+++ b/plotting/plot_cache.py
@@ -1,0 +1,56 @@
+#  Autoreduction Repository : https://github.com/ISISScientificComputing/autoreduce
+#
+#  Copyright &copy; 2020 ISIS Rutherford Appleton Laboratory UKRI
+#  SPDX - License - Identifier: GPL-3.0-or-later
+#
+
+"""
+Implementation of PlotCache class which extends the django native FileBasedCache
+
+"""
+import os
+import pickle
+import time
+import zlib
+
+from django.core.cache.backends.filebased import FileBasedCache
+
+
+class PlotCache(FileBasedCache):
+    """
+    Custom Django cache backend extended from the existing django FileBasedCache
+    The cache holds reference to plot files that exist locally, and will expire them after the
+    timeout. The key for a plot is the regular expression pattern that was used to find it remotely.
+    Usage of the cache is handled by django
+    """
+
+    #pylint:disable=no-self-use
+    def _delete_plot(self, plot_path):
+        """
+        Given the path of a plot, delete it
+        :param plot_path: The path of the plot to be deleted
+        """
+        try:
+            os.remove(plot_path)
+        except OSError:
+            pass
+
+    def _is_expired(self, f):
+        """
+        Based on the django implementation of the FileBasedCache, Checks if cache entry is expired
+        and if it is, deletes it and its corresponding plots
+        will delete the plot if it is
+        :param f: the opened cache file
+        :return: True if the plot is expired else False
+        """
+        try:
+            exp = pickle.load(f)
+        except EOFError:
+            exp = 0
+        if exp is not None and exp < time.time():
+            for path in pickle.loads(zlib.decompress(f.read())):
+                self._delete_plot(path)
+            f.close()
+            self._delete(f.name)
+            return True
+        return False

--- a/plotting/plot_cache.py
+++ b/plotting/plot_cache.py
@@ -48,8 +48,9 @@ class PlotCache(FileBasedCache):
         except EOFError:
             exp = 0
         if exp is not None and exp < time.time():
-            for path in pickle.loads(zlib.decompress(f.read())):
-                self._delete_plot(path)
+            if exp: # We only want to attempt to delete paths if the cache file isn't empty
+                for path in pickle.loads(zlib.decompress(f.read())):
+                    self._delete_plot(path)
             f.close()
             self._delete(f.name)
             return True

--- a/plotting/plot_handler.py
+++ b/plotting/plot_handler.py
@@ -79,6 +79,14 @@ class PlotHandler:
         return [f'/static/graphs/{file}' for file in os.listdir(self.static_graph_dir) if
                 re.match(file_name_regex, file)]
 
+    def _cache_plots(self, plot_paths):
+        """
+        Given a list of plots, add them to the plot cache, with the regex pattern as the key
+        :param plot_paths: The list of paths to be added
+        """
+        plot_cache = caches['plot']
+        plot_cache.add(self.file_regex, plot_paths)
+
     def _check_for_plot_files(self):
         """
         Searches the server directory for existing plot files using the directory specified.

--- a/plotting/plot_handler.py
+++ b/plotting/plot_handler.py
@@ -15,6 +15,9 @@ import logging
 import os
 import re
 from typing import List
+
+from django.core.cache import caches
+
 from utils.clients.sftp_client import SFTPClient
 from utils.project.structure import get_project_root
 
@@ -35,9 +38,7 @@ class PlotHandler:
         self.server_dir = server_dir
         self.file_extensions = ["png", "jpg", "bmp", "gif", "tiff"]
         # Directory to place fetched data files / images
-        self.static_graph_dir = os.path.join(get_project_root(), 'WebApp',
-                                             'autoreduce_webapp', 'static',
-                                             'graphs')
+        self.static_graph_dir = os.path.join(get_project_root(), 'WebApp', 'autoreduce_webapp', 'static', 'graphs')
 
     @staticmethod
     def _get_only_data_file_name(data_filepath: str) -> str:
@@ -76,8 +77,9 @@ class PlotHandler:
         :return: (list) - The list of matching file paths.
         """
         file_name_regex = self._generate_file_name_regex()
-        return [f'/static/graphs/{file}' for file in os.listdir(self.static_graph_dir) if
-                re.match(file_name_regex, file)]
+        return [
+            f'/static/graphs/{file}' for file in os.listdir(self.static_graph_dir) if re.match(file_name_regex, file)
+        ]
 
     def _cache_plots(self, plot_paths):
         """
@@ -100,8 +102,7 @@ class PlotHandler:
         file_regex = self._generate_file_name_regex()
         if file_regex:
             # Add files that match regex to the list of files found
-            _found_files.extend(client.get_filenames(server_dir_path=self.server_dir,
-                                                     regex=file_regex))
+            _found_files.extend(client.get_filenames(server_dir_path=self.server_dir, regex=file_regex))
         else:
             return None
         return _found_files
@@ -127,9 +128,7 @@ class PlotHandler:
                 _local_path = os.path.join(self.static_graph_dir, plot_file)
 
                 try:
-                    client.retrieve(server_file_path=_server_path,
-                                    local_file_path=_local_path,
-                                    override=True)
+                    client.retrieve(server_file_path=_server_path, local_file_path=_local_path, override=True)
                     LOGGER.info('File \'%s\' found and saved to %s', _server_path, _local_path)
                 except RuntimeError:
                     LOGGER.error("File \'%s\' does not exist", _server_path)

--- a/plotting/plot_handler.py
+++ b/plotting/plot_handler.py
@@ -73,14 +73,11 @@ class PlotHandler:
 
     def _get_plot_files_locally(self) -> List[str]:
         """
-        Searches the local graph folder for files matching the generated file name regex and returns
-        a list of matching paths
+        Searches the plot cache for matching plots
         :return: (list) - The list of matching file paths.
         """
-        file_name_regex = self._generate_file_name_regex()
-        return [
-            f'/static/graphs/{file}' for file in os.listdir(self.static_graph_dir) if re.match(file_name_regex, file)
-        ]
+        plot_cache = caches['plot']
+        return plot_cache.get(self.file_regex)
 
     def _cache_plots(self, plot_paths):
         """

--- a/plotting/plot_handler.py
+++ b/plotting/plot_handler.py
@@ -104,9 +104,11 @@ class PlotHandler:
             except RuntimeError:
                 LOGGER.error(f'File does not exist: {server_path}')
                 continue
-            local_plot_paths.append(os.path.join(self.static_graph_dir, file))
+            local_plot_paths.append(local_path)
 
-        self._cache_plots(local_plot_paths)
+        if local_plot_paths:
+            self._cache_plots(local_plot_paths)
+
         return local_plot_paths
 
     def _check_for_plot_files(self):

--- a/plotting/plot_handler.py
+++ b/plotting/plot_handler.py
@@ -99,9 +99,7 @@ class PlotHandler:
             server_path = self.server_dir + file
             local_path = os.path.join(self.static_graph_dir, file)
             try:
-                client.retrieve(server_file_path=server_path,
-                                local_file_path=local_path,
-                                override=True)
+                client.retrieve(server_file_path=server_path, local_file_path=local_path, override=True)
                 LOGGER.info(f'File {server_path} found and saved to {local_path}')
             except RuntimeError:
                 LOGGER.error(f'File does not exist: {server_path}')
@@ -116,17 +114,11 @@ class PlotHandler:
         Searches the server directory for existing plot files using the directory specified.
         :return: (list) files on the server path that match regex
         """
-        # start sftpclient
         client = SFTPClient()
-        # initialise list to store names of existing files matching the search
         _found_files = []
-        # regular expression for plot file name(s)
-        file_regex = self._generate_file_name_regex()
-        if file_regex:
+        if self.file_regex:
             # Add files that match regex to the list of files found
             _found_files.extend(client.get_filenames(server_dir_path=self.server_dir, regex=file_regex))
-        else:
-            return None
         return _found_files
 
     def get_plot_file(self):

--- a/plotting/plot_handler.py
+++ b/plotting/plot_handler.py
@@ -100,9 +100,9 @@ class PlotHandler:
             local_path = os.path.join(self.static_graph_dir, file)
             try:
                 client.retrieve(server_file_path=server_path, local_file_path=local_path, override=True)
-                LOGGER.info(f'File {server_path} found and saved to {local_path}')
+                LOGGER.info('File %s found and saved to %s', server_path, local_path)
             except RuntimeError:
-                LOGGER.error(f'File does not exist: {server_path}')
+                LOGGER.error('File does not exist: %s', server_path)
                 continue
             local_plot_paths.append(local_path)
 

--- a/plotting/plot_handler.py
+++ b/plotting/plot_handler.py
@@ -118,36 +118,16 @@ class PlotHandler:
         _found_files = []
         if self.file_regex:
             # Add files that match regex to the list of files found
-            _found_files.extend(client.get_filenames(server_dir_path=self.server_dir, regex=file_regex))
+            _found_files.extend(client.get_filenames(server_dir_path=self.server_dir, regex=self.file_regex))
         return _found_files
 
     def get_plot_file(self):
         """
-        Searches for and retrieves a plot file from CEPH.
-        Might find multiple files (e.g. if more than one plot_type is specified),
-        but will only copy over one.
-        :return: (str) local path to downloaded files OR None if no files found
+        Attempts to retrieve plot files, first from the plot cache, and then from CEPH
+        :return: (list) local path to downloaded files OR None if no files found
         """
         _existing_plot_files = self._get_plot_files_locally()
         if _existing_plot_files:
             return _existing_plot_files
-
         _existing_plot_files = self._check_for_plot_files()
-        local_plot_paths = []
-        if _existing_plot_files:
-            client = SFTPClient()
-            for plot_file in _existing_plot_files:
-                # Generate paths to data on server and destination on local machine
-                _server_path = f"{self.server_dir}/{plot_file}"
-                _local_path = os.path.join(self.static_graph_dir, plot_file)
-
-                try:
-                    client.retrieve(server_file_path=_server_path, local_file_path=_local_path, override=True)
-                    LOGGER.info('File \'%s\' found and saved to %s', _server_path, _local_path)
-                except RuntimeError:
-                    LOGGER.error("File \'%s\' does not exist", _server_path)
-                    return None
-                local_plot_paths.append(f'/static/graphs/{plot_file}')  # shortcut to static dir
-            return local_plot_paths
-        # No files found
-        return None
+        return self._get_plot_files_remotely(_existing_plot_files)

--- a/plotting/plot_handler.py
+++ b/plotting/plot_handler.py
@@ -82,7 +82,7 @@ class PlotHandler:
     def _cache_plots(self, plot_paths):
         """
         Given a list of plots, add them to the plot cache, with the regex pattern as the key
-        :param plot_paths: The list of paths to be added
+        :param plot_paths: (list) The list of paths to be added
         """
         plot_cache = caches['plot']
         plot_cache.add(self.file_regex, plot_paths)

--- a/plotting/plot_handler.py
+++ b/plotting/plot_handler.py
@@ -39,6 +39,7 @@ class PlotHandler:
         self.file_extensions = ["png", "jpg", "bmp", "gif", "tiff"]
         # Directory to place fetched data files / images
         self.static_graph_dir = os.path.join(get_project_root(), 'WebApp', 'autoreduce_webapp', 'static', 'graphs')
+        self.file_regex = self._generate_file_name_regex()
 
     @staticmethod
     def _get_only_data_file_name(data_filepath: str) -> str:

--- a/plotting/tests/test_plot_cache.py
+++ b/plotting/tests/test_plot_cache.py
@@ -4,13 +4,12 @@
 #  Copyright &copy; 2020 ISIS Rutherford Appleton Laboratory UKRI
 #  SPDX - License - Identifier: GPL-3.0-or-later
 # ############################################################################### #
-
 """
 Tests for the PlotCache class
 """
 from unittest import TestCase
 
-from mock import patch, MagicMock, call
+from unittest.mock import patch, MagicMock, call
 
 from plotting.plot_cache import PlotCache
 
@@ -28,7 +27,6 @@ class TestPlotCache(TestCase):
         params = MagicMock()
         self.cache = PlotCache(dir_, params)
         self.openened_cache_file = MagicMock()
-
 
     @patch('os.remove')
     def test__delete_plot_removes_plot(self, mock_os_remove):
@@ -51,9 +49,7 @@ class TestPlotCache(TestCase):
     @patch('pickle.load', side_effect=EOFError)
     @patch('time.time', return_value=100.1)
     @patch('plotting.plot_cache.PlotCache._delete')
-    def test__is_expired_eof_error_and_expired_returns_true(self, mock_delete,
-                                                            mock_time_time,
-                                                            mock_pickle_load):
+    def test__is_expired_eof_error_and_expired_returns_true(self, mock_delete, mock_time_time, mock_pickle_load):
         """
         Test: _is_expired returns true
         When: The cache file is empty
@@ -74,12 +70,8 @@ class TestPlotCache(TestCase):
     @patch('zlib.decompress')
     @patch('plotting.plot_cache.PlotCache._delete_plot')
     @patch('plotting.plot_cache.PlotCache._delete')
-    def test__is_expired_is_expired_returns_true(self, mock_delete,
-                                                 mock_plot_delete,
-                                                 mock_zlib_decompress,
-                                                 mock_pickle_loads,
-                                                 mock_time_time,
-                                                 mock_pickle_load):
+    def test__is_expired_is_expired_returns_true(self, mock_delete, mock_plot_delete, mock_zlib_decompress,
+                                                 mock_pickle_loads, mock_time_time, mock_pickle_load):
         """
         Test: _is_expired returns true and cache entry and plot are deleted
         When: When the cache entry has expired

--- a/plotting/tests/test_plot_cache.py
+++ b/plotting/tests/test_plot_cache.py
@@ -1,0 +1,114 @@
+# ############################################################################### #
+#  Autoreduction Repository : https://github.com/ISISScientificComputing/autoreduce
+#
+#  Copyright &copy; 2020 ISIS Rutherford Appleton Laboratory UKRI
+#  SPDX - License - Identifier: GPL-3.0-or-later
+# ############################################################################### #
+
+"""
+Tests for the PlotCache class
+"""
+from unittest import TestCase
+
+from mock import patch, MagicMock, call
+
+from plotting.plot_cache import PlotCache
+
+
+# pylint:disable=protected-access
+class TestPlotCache(TestCase):
+    """Tests the functionality of the PlotCache"""
+    PLOT_PATH = "path"
+
+    def setUp(self):
+        """
+        Setup the plot cache and the opened cache file mock
+        """
+        dir_ = MagicMock()
+        params = MagicMock()
+        self.cache = PlotCache(dir_, params)
+        self.openened_cache_file = MagicMock()
+
+
+    @patch('os.remove')
+    def test__delete_plot_removes_plot(self, mock_os_remove):
+        """
+        Test: os.remove is called
+        When: _delete_plot is called
+        """
+        self.cache._delete_plot(TestPlotCache.PLOT_PATH)
+        mock_os_remove.assert_called_once_with(TestPlotCache.PLOT_PATH)
+
+    # pylint:disable=unused-argument
+    @patch('os.remove', side_effect=OSError)
+    def test__delete_plot_no_plot_passes(self, mock_os_remove):
+        """
+        Test: Exception caught and method passes
+        When: Plot file does not exist
+        """
+        self.cache._delete_plot(TestPlotCache.PLOT_PATH)
+
+    @patch('pickle.load', side_effect=EOFError)
+    @patch('time.time', return_value=100.1)
+    @patch('plotting.plot_cache.PlotCache._delete')
+    def test__is_expired_eof_error_and_expired_returns_true(self, mock_delete,
+                                                            mock_time_time,
+                                                            mock_pickle_load):
+        """
+        Test: _is_expired returns true
+        When: The cache file is empty
+        """
+        result = self.cache._is_expired(self.openened_cache_file)
+
+        mock_pickle_load.assert_called_with(self.openened_cache_file)
+        mock_time_time.assert_called_once()
+        self.openened_cache_file.close.assert_called_once()
+        mock_delete.assert_called_with(self.openened_cache_file.name)
+
+        self.assertTrue(result)
+
+    # pylint:disable=too-many-arguments
+    @patch('pickle.load', return_value=100.123)
+    @patch('time.time', return_value=101.123)
+    @patch('pickle.loads', return_value=["path1", "path2"])
+    @patch('zlib.decompress')
+    @patch('plotting.plot_cache.PlotCache._delete_plot')
+    @patch('plotting.plot_cache.PlotCache._delete')
+    def test__is_expired_is_expired_returns_true(self, mock_delete,
+                                                 mock_plot_delete,
+                                                 mock_zlib_decompress,
+                                                 mock_pickle_loads,
+                                                 mock_time_time,
+                                                 mock_pickle_load):
+        """
+        Test: _is_expired returns true and cache entry and plot are deleted
+        When: When the cache entry has expired
+
+        """
+        result = self.cache._is_expired(self.openened_cache_file)
+
+        mock_pickle_load.assert_called_with(self.openened_cache_file)
+        mock_time_time.assert_called_once()
+        self.openened_cache_file.read.assert_called_once()
+        mock_zlib_decompress.assert_called_with(self.openened_cache_file.read())
+        mock_pickle_loads.assert_called_with(mock_zlib_decompress())
+        calls = [call("path1"), call("path2")]
+        mock_plot_delete.assert_has_calls(calls)
+        self.openened_cache_file.close.assert_called_once()
+        mock_delete.assert_called_with(self.openened_cache_file.name)
+
+        self.assertTrue(result)
+
+    @patch('pickle.load', return_value=100.123)
+    @patch('time.time', return_value=10.1)
+    def test__is_expired_not_expired_returns_false(self, mock_time, mock_pickle_load):
+        """
+        Test: _is_expired returns false
+        When: cache entry has not expired
+        """
+        result = self.cache._is_expired(self.openened_cache_file)
+
+        mock_pickle_load.assert_called_with(self.openened_cache_file)
+        mock_time.assert_called()
+
+        self.assertFalse(result)

--- a/plotting/tests/test_plot_handler.py
+++ b/plotting/tests/test_plot_handler.py
@@ -106,14 +106,6 @@ class TestPlotHandler(unittest.TestCase):
         actual_pattern = self.test_plot_handler._generate_file_extension_regex()
         self.assertEqual(expected_pattern, actual_pattern)
 
-    def test_generate_file_name_regex_invalid(self):
-        """
-        Test: Assert None is returned
-        When: calling _generate_file_name_regex with invalid instrument
-        """
-        self.test_plot_handler.instrument_name = "Not instrument"
-        self.assertIsNone(self.test_plot_handler._generate_file_name_regex())
-
     @patch('plotting.plot_handler.PlotHandler._get_plot_files_locally', return_value=[])
     @patch('plotting.plot_handler.PlotHandler._check_for_plot_files', return_value=["file1", "file2"])
     @patch('plotting.plot_handler.PlotHandler._get_plot_files_remotely', return_value=["file1", "file2"])

--- a/plotting/tests/test_plot_handler.py
+++ b/plotting/tests/test_plot_handler.py
@@ -13,7 +13,7 @@ calling the SFTPClient with correct parameters
 """
 import os
 import unittest
-from unittest.mock import patch, MagicMock, call
+from unittest.mock import patch, call
 
 from plotting.plot_handler import PlotHandler
 from utils.project.structure import get_project_root

--- a/plotting/tests/test_plot_handler.py
+++ b/plotting/tests/test_plot_handler.py
@@ -34,11 +34,10 @@ class TestPlotHandler(unittest.TestCase):
         self.expected_file_extension_regex = '(png|jpg|bmp|gif|tiff)'
         self.expected_wish_data_filename = "WISH1234"
         self.expected_wish_file_regex = f"{self.expected_wish_data_filename}.*.{self.expected_file_extension_regex}"
-        self.expected_mari_instrument_name = "MARI"
         self.expected_mari_data_filename = "MARI1234"
         self.expected_mari_file_regex = f'{self.expected_mari_data_filename}.*.{self.expected_file_extension_regex}'
         self.input_data_filepath = "\\\\isis\\inst$\\NDXMARI\\Instrument\\data\\cycle_test\\MARI1234.nxs"
-        self.expected_mari_rb_number = 12345678
+        self.expected_mari_rb_number = "12345678"
         self.expected_mari_rb_folder = "/instrument/MARI/RBNumber/RB12345678/1234/autoreduced"
 
         self.test_plot_handler = PlotHandler(data_filepath=self.input_data_filepath,
@@ -47,28 +46,17 @@ class TestPlotHandler(unittest.TestCase):
 
         self.expected_static_graph_dir = os.path.join(get_project_root(), 'WebApp', 'autoreduce_webapp', 'static',
                                                       'graphs')
-        self.mock_cache = MagicMock()
 
-    # pylint:disable=unused-argument
-    @patch('plotting.plot_handler.PlotHandler._generate_file_name_regex', return_value="pattern")
-    def test_init(self, mock_gen_reg):
+    def test_init(self):
         """
         Test: Class variables are initiated correctly
         When: PlotHandler is initialised
         """
-        # Cannot use handler from setup else we cant patch the mock method
-        plot_handler = PlotHandler(self.expected_mari_instrument_name,
-                                   self.expected_mari_run_number,
-                                   self.expected_mari_rb_folder,
-                                   rb_number=self.expected_mari_rb_number)
-
-        self.assertEqual(self.expected_mari_instrument_name, plot_handler.instrument_name)
-        self.assertEqual(self.expected_mari_run_number, plot_handler.run_number)
-        self.assertEqual(self.expected_mari_rb_folder, plot_handler.server_dir)
-        self.assertEqual(self.expected_file_extensions, plot_handler.file_extensions)
-        self.assertEqual(self.expected_mari_rb_number, plot_handler.rb_number)
-        self.assertEqual(self.expected_static_graph_dir, plot_handler.static_graph_dir)
-        self.assertEqual("pattern", plot_handler.file_regex)
+        self.assertEqual(self.test_plot_handler.data_filename, self.expected_mari_data_filename)
+        self.assertEqual(self.test_plot_handler.server_dir, self.expected_mari_rb_folder)
+        self.assertEqual(self.test_plot_handler.file_extensions, ["png", "jpg", "bmp", "gif", "tiff"])
+        self.assertEqual(self.test_plot_handler.rb_number, self.expected_mari_rb_number)
+        self.assertEqual(self.test_plot_handler.static_graph_dir, self.expected_static_graph_dir)
 
     def test_get_only_data_file_name(self):
         """

--- a/plotting/tests/test_plot_handler.py
+++ b/plotting/tests/test_plot_handler.py
@@ -34,7 +34,7 @@ class TestPlotHandler(unittest.TestCase):
         self.expected_file_extension_regex = '(png|jpg|bmp|gif|tiff)'
         self.expected_wish_data_filename = "WISH1234"
         self.expected_wish_file_regex = f"{self.expected_wish_data_filename}.*.{self.expected_file_extension_regex}"
-
+        self.expected_mari_instrument_name = "MARI"
         self.expected_mari_data_filename = "MARI1234"
         self.expected_mari_file_regex = f'{self.expected_mari_data_filename}.*.{self.expected_file_extension_regex}'
         self.input_data_filepath = "\\\\isis\\inst$\\NDXMARI\\Instrument\\data\\cycle_test\\MARI1234.nxs"


### PR DESCRIPTION
### Summary of work
<!---The changes you have made--->
Creates a custom django cache backend that is used for storing plots.
The cache extends the filebased cache and stores value with key, value pairs being plot regex string: local plot path
When `is_expired` is called the cache will also delete the plot file locally, the same way the normal cache would delete the key.

I have changed `PlotHandler` to generate the regex pattern inside the `__init__` since it is used in most places and a new `PlotHandler` is created on every access to the `run_summary` view anyway.

Currently the cache expires once per day (Elliots suggestion) but this can be increased or decreased dependant on what we need.

### How to test your work
<!---This can be a link to the---> 
Run a reduction that gets a graph. Reload the page and verify that the plot_cache has been accessed and not ceph.
Make sure plot is deleted on expiry


### Additional comments
<!---Anything else: e.g. was the estimate reasonable for this issue?---> 

Fixes #616


**Before merging ensure the release notes have been updated**