### PR TITLE
Fix status values on webapp

### DIFF
--- a/WebApp/autoreduce_webapp/reduction_viewer/utils.py
+++ b/WebApp/autoreduce_webapp/reduction_viewer/utils.py
@@ -47,23 +47,23 @@ class StatusUtils(object):
 
     def get_error(self):
         """ :return: Error Status object """
-        return self._get_status("Error")
+        return self._get_status("e")
 
     def get_completed(self):
         """ :return: Completed Status object """
-        return self._get_status("Completed")
+        return self._get_status("c")
 
     def get_processing(self):
         """ :return: Processing Status object """
-        return self._get_status("Processing")
+        return self._get_status("p")
 
     def get_queued(self):
         """ :return: Queued Status object """
-        return self._get_status("Queued")
+        return self._get_status("q")
 
     def get_skipped(self):
         """ :return: Skipped Status object """
-        return self._get_status("Skipped")
+        return self._get_status("s")
 
 
 # pylint:disable=too-few-public-methods

--- a/WebApp/autoreduce_webapp/templates/admin/graph_instrument.html
+++ b/WebApp/autoreduce_webapp/templates/admin/graph_instrument.html
@@ -22,7 +22,7 @@ var reductionRuns = [
         'runNumber': '{{ run.run_number}}',
         'runVersion': '{{ run.run_version}}',
         'executionTime': '{{ run.run_time }}',
-        'status': '{{ run.status.value }}',
+        'status': '{{ run.status.value_verbose }}',
         'created': '{{ run.created }}'
     },
     {% endfor %}

--- a/WebApp/autoreduce_webapp/templates/experiment_summary.html
+++ b/WebApp/autoreduce_webapp/templates/experiment_summary.html
@@ -85,7 +85,7 @@
                                     <td>
                                         <a href="{% url 'run_summary' instrument_name=job.instrument.name run_number=job.run_number run_version=job.run_version %}">{{ job.title }}</a>
                                     </td>
-                                    <td class="text-{% colour_table_row job.status.value %}"><strong>{{ job.status.value }}</strong></td>
+                                    <td class="text-{% colour_table_row job.status.value_verbose %}"><strong>{{ job.status.value_verbose }}</strong></td>
                                     <td title="{{ job.last_updated|date:'SHORT_DATETIME_FORMAT' }}">{{ job.last_updated|naturaltime }}</td>
                                     <td>
                                         {% if started_by %}

--- a/WebApp/autoreduce_webapp/templates/fail_queue.html
+++ b/WebApp/autoreduce_webapp/templates/fail_queue.html
@@ -45,9 +45,9 @@
                 <tbody>
                     {% for job in queue %}
                       {% if job.retry_run %}
-                        <tr name='runRow' class="{% colour_table_row job.retry_run.status.value %}">
+                        <tr name='runRow' class="{% colour_table_row job.retry_run.status.value_verbose %}">
                       {% else %}
-                        <tr name='runRow' class="{% colour_table_row job.status.value %}">
+                        <tr name='runRow' class="{% colour_table_row job.status.value_verbose %}">
                       {% endif %}
                             <td><input type='checkbox' name='runCheckbox' data-run_number='{{job.run_number}}' data-run_version='{{job.run_version}}' data-rb_number='{{job.experiment.reference_number}}'></td>
                             <td>
@@ -63,7 +63,7 @@
                                         <span> (Last attempt)</span>
                                     {% endif %}
                                     {% if job.retry_run %}
-                                        <a href="{% url 'run_summary' instrument_name=job.instrument.name run_number=job.retry_run.run_number run_version=job.retry_run.run_version %}"> ({{ job.retry_run.status.value }})</a>
+                                        <a href="{% url 'run_summary' instrument_name=job.instrument.name run_number=job.retry_run.run_number run_version=job.retry_run.run_version %}"> ({{ job.retry_run.status.value_verbose }})</a>
                                     {% endif %}
                                 {% else %}
                                     Never

--- a/WebApp/autoreduce_webapp/templates/instrument_summary.html
+++ b/WebApp/autoreduce_webapp/templates/instrument_summary.html
@@ -107,7 +107,7 @@
                                     <div class="row run-row">
                                 {% endif %}
                                     <div class="col-md-5 col-sm-5 col-md-offset-1 col-xs-4"><a href="{% url 'run_summary' instrument_name=instrument_name run_number=run.run_number run_version=run.run_version %}" id="top-run-number">{{ run.title }}</a></div>
-                                    <div class="col-md-2 col-sm-2 col-xs-4 run-status text-{% colour_table_row run.status.value %}"><strong>{{ run.status.value }}</strong></div>
+                                    <div class="col-md-2 col-sm-2 col-xs-4 run-status text-{% colour_table_row run.status.value_verbose %}"><strong>{{ run.status.value_verbose }}</strong></div>
                                     <div class="col-md-4 col-sm-5 col-xs-4"><strong>Last updated:</strong> {{ run.last_updated }}</div>
                                 </div>
                             {% endfor %}
@@ -128,7 +128,7 @@
                                 {% for run in associated_runs %}
                                 <div class="row run-row-internal">
                                     <div class="col-md-5 col-sm-5 col-md-offset-1 col-xs-4"><a href="{% url 'run_summary' instrument_name=instrument_name run_number=run.run_number run_version=run.run_version %}">{{ run.title }}</a></div>
-                                    <div class="col-md-2 col-sm-2 col-xs-4 run-status text-{% colour_table_row run.status.value %}"><strong>{{ run.status.value }}</strong></div>
+                                    <div class="col-md-2 col-sm-2 col-xs-4 run-status text-{% colour_table_row run.status.value_verbose %}"><strong>{{ run.status.value_verbose }}</strong></div>
                                     <div class="col-md-4 col-sm-5 col-xs-4"><strong>Last updated:</strong> {{ run.last_updated }}</div>
                                 </div>
                                 {% endfor %}

--- a/WebApp/autoreduce_webapp/templates/run_queue.html
+++ b/WebApp/autoreduce_webapp/templates/run_queue.html
@@ -23,12 +23,12 @@
             </thead>
             <tbody>
                 {% for job, started_by in queue %}
-                    <tr class="{% colour_table_row job.status.value %}">
+                    <tr class="{% colour_table_row job.status.value_verbose %}">
                         <td>
                             <a href="{% url 'run_summary' instrument_name=job.instrument.name run_number=job.run_number run_version=job.run_version %}">{{ job.title }}</a>
                         </td>
                         <td>{{ job.instrument.name }}</td>
-                        <td><strong>{{ job.status.value }}</strong></td>
+                        <td><strong>{{ job.status.value_verbose }}</strong></td>
                         <td title="{{ job.created|date:'SHORT_DATETIME_FORMAT' }}">{{ job.created|naturaltime }}</td>
                         <td> {{ started_by }} </td>
                     </tr>

--- a/WebApp/autoreduce_webapp/templates/run_summary.html
+++ b/WebApp/autoreduce_webapp/templates/run_summary.html
@@ -30,12 +30,12 @@
         {% endif %}
         {% if run.message %}
             {% if 'Skipped' in run.message %}
-                <div class="alert alert-{% replace run.status.value 'Skipped' 'info' %} word-wrap" role="alert">
-                    <i class="fa fa-{% replace run.status.value 'Skipped' 'question' %} fa-{% replace run.status.value 'Skipped' 'question' %}-circle fa-lg"></i> <a href="#" class="js-log-display"> {{ run.message }}</a>
+                <div class="alert alert-{% replace run.status.value_verbose 'Skipped' 'info' %} word-wrap" role="alert">
+                    <i class="fa fa-{% replace run.status.value_verbose 'Skipped' 'question' %} fa-{% replace run.status.value_verbose 'Skipped' 'question' %}-circle fa-lg"></i> <a href="#" class="js-log-display"> {{ run.message }}</a>
                 </div>
             {% else %}
-                <div class="alert alert-{% replace run.status.value 'Error' 'danger' %} word-wrap" role="alert">
-                    <i class="fa fa-{% replace run.status.value 'Error' 'exclamation' %} fa-{% replace run.status.value 'Error' 'exclamation' %}-circle fa-lg"></i> <a href="#" class="js-log-display">[{{ run.finished }}] {{ run.message }}</a>
+                <div class="alert alert-{% replace run.status.value_verbose 'Error' 'danger' %} word-wrap" role="alert">
+                    <i class="fa fa-{% replace run.status.value_verbose 'Error' 'exclamation' %} fa-{% replace run.status.value_verbose 'Error' 'exclamation' %}-circle fa-lg"></i> <a href="#" class="js-log-display">[{{ run.finished }}] {{ run.message }}</a>
                 </div>
             {% endif %}
         {% endif %}
@@ -51,7 +51,7 @@
                                     {% endif %}
                                 </div>
                                 <div>
-                                    <strong>Status:</strong> <strong class="text-{% colour_table_row run.status.value %}">{{ run.status.value }}</strong>
+                                    <strong>Status:</strong> <strong class="text-{% colour_table_row run.status.value_verbose %}">{{ run.status.value_verbose }}</strong>
                                 </div>
                                 <div>
                                     <strong>Instrument:</strong> <a href="{% url 'instrument_summary' instrument=run.instrument.name %}">{{ run.instrument.name }}</a>
@@ -97,7 +97,7 @@
                                                 <span> (Last attempt)</span>
                                             {% endif %}
                                             {% if run.retry_run %}
-                                                <a href="{% url 'run_summary' instrument_name=run.instrument.name run_number=run.retry_run.run_number run_version=run.retry_run.run_version %}"> ({{ run.retry_run.status.value }})</a>
+                                                <a href="{% url 'run_summary' instrument_name=run.instrument.name run_number=run.retry_run.run_number run_version=run.retry_run.run_version %}"> ({{ run.retry_run.status.value_verbose }})</a>
                                             {% endif %}
                                         {% else %}
                                             Never
@@ -196,7 +196,7 @@
                                                 {{ job.title }}
                                             {% endif %}
                                         </td>
-                                        <td class="text-{% colour_table_row job.status.value %}"><strong>{{ job.status.value }}</strong></td>
+                                        <td class="text-{% colour_table_row job.status.value_verbose %}"><strong>{{ job.status.value_verbose }}</strong></td>
                                         <td title="{{ job.last_updated|date:'SHORT_DATETIME_FORMAT' }}">{{ job.last_updated|naturaltime }}</td>
                                         <td>
                                             {% if started_by %}

--- a/WebApp/autoreduce_webapp/templates/snippets/instrument_status.html
+++ b/WebApp/autoreduce_webapp/templates/snippets/instrument_status.html
@@ -9,7 +9,7 @@
                 <div class="col-md-4"><strong>Last run on instrument:</strong></div>
                 <div class="col-md-8">
                     <a href="{% url 'run_summary' instrument_name=last_instrument_run.instrument.name run_number=last_instrument_run.run_number run_version=last_instrument_run.run_version %}">{{ last_instrument_run.title }}</a>
-                    <strong class="text-{% colour_table_row last_instrument_run.status.value %}"> ({{ last_instrument_run.status.value }})</strong>
+                    <strong class="text-{% colour_table_row last_instrument_run.status.value_verbose %}"> ({{ last_instrument_run.status.value_verbose }})</strong>
                 </div>
             </div>
             {% if processing %}
@@ -44,7 +44,7 @@
             <div class="text-center">
                 <strong>Last run on instrument: </strong>
                 <a href="{% url 'run_summary' instrument_name=last_instrument_run.instrument.name run_number=last_instrument_run.run_number run_version=last_instrument_run.run_version %}">{{ last_instrument_run.title }}</a>
-                <strong class="text-{% colour_table_row last_instrument_run.status.value %}"> ({{ last_instrument_run.status.value }})</strong>
+                <strong class="text-{% colour_table_row last_instrument_run.status.value_verbose %}"> ({{ last_instrument_run.status.value_verbose }})</strong>
             </div>
             <div class="text-center">
                 All reduction jobs complete.

--- a/WebApp/autoreduce_webapp/templates/snippets/run_table.html
+++ b/WebApp/autoreduce_webapp/templates/snippets/run_table.html
@@ -2,6 +2,6 @@
 
 <div class="row run-row">
     <div class="col-md-5  col-sm-5 col-md-offset-1 col-xs-4"><a href="{% url 'run_summary' instrument_name=run.instrument.name run_number=run.run_number run_version=run.run_version %}">{{ run.title }}</a></div>
-    <div class="col-md-2 col-sm-2 col-xs-4 run-status text-{% colour_table_row run.status.value %}"><strong>{{ run.status.value }}</strong></div>
+    <div class="col-md-2 col-sm-2 col-xs-4 run-status text-{% colour_table_row run.status.value_verbose %}"><strong>{{ run.status.value_verbose }}</strong></div>
     <div class="col-md-4 col-sm-5 col-xs-4"><strong>Last updated:</strong> {{ run.last_updated }}</div>
 </div>


### PR DESCRIPTION
### Summary of work
* Changed the dev database to conform to new status value. See [constrain status model PR](https://github.com/ISISScientificComputing/autoreduce/pull/691).
* Now using `status.verbose_value` (e.g. "Completed") in web app as opposed to `status.value` (e.g "c")

### How to test your work
* Code review
* All tests pass
* Open web app and look at the locations of where the run status value will be shown. Check that the full verbose value appears.

### Additional comments
* The production database will also need to be altered. Steps I took on the dev database were as follows:
    * Change all the status values in `reduction_viewer_status` to char values. There should be only 5 values there.
    * Fix all occurrences of status values of greater than 5 in reduction_viewer_reductionrun (there shouldn't be any on production).