### PR TITLE
Fix manual_remove multiple version bug

### DIFF
--- a/scripts/manual_operations/manual_remove.py
+++ b/scripts/manual_operations/manual_remove.py
@@ -91,7 +91,8 @@ class ManualRemove:
         # Remove runs that the user does NOT want to delete from the delete list
         for reduction_job in self.to_delete[run_number]:
             if not int(reduction_job.run_version) in user_input:
-                self.to_delete[run_number].remove(reduction_job)
+                self.to_delete[run_number] = self.to_delete[run_number].exclude(
+                    run_version=reduction_job.run_version)
 
     def delete_records(self):
         """
@@ -102,7 +103,7 @@ class ManualRemove:
         for run_number, job_list in to_delete_copy.items():
             for version in job_list:
                 # Delete the specified version
-                print('{}{}:'.format(self.instrument, run_number))
+                print(f'{self.instrument}{run_number} - v{version.run_version}')
                 self.delete_reduction_location(version.id)
                 self.delete_data_location(version.id)
                 self.delete_variables(version.id)


### PR DESCRIPTION
### Summary of work
* Fixed functionality to manually remove a run for a given instrument when multiple versions exists

### How to test your work
* Code review
* All tests pass
* Try removing a run using the `manual_remove.py` script for 1 or multiple versions

Fixes #669 