### PR TITLE
Remove duplicated overwrite action

### DIFF
--- a/WebApp/autoreduce_webapp/templates/submit_runs.html
+++ b/WebApp/autoreduce_webapp/templates/submit_runs.html
@@ -76,11 +76,12 @@
                                     </li>
                                     <li>
                                         <input type="checkbox" name="overwrite_checkbox" id="overwrite_checkbox" checked>
-                                        <a href="#overwrite" id="overwrite"> Overwrite Previous Data</a>
-                                        <div class="js-explaination visible-xs-block">
-											By default, when an autoreduction job is re-run, the original data from the initial run will be overwritten. If you uncheck this box,
-											original data will not be overwritten and you will have distinct folders to separate out the data output from your different re-runs.
-										</div>
+                                        <label for="overwrite_checkbox">
+                                            Overwrite Previous Data
+                                            <a href="#" data-toggle="popover" data-content="By default, when an autoreduction job is re-run, the original data from the initial run will be overwritten. If you uncheck this box,
+											   original data will not be overwritten and you will have distinct folders to separate out the data output from your different re-runs."
+                                               data-trigger="hover click focus" data-placement="top" data-container="body"><i class="fa fa-info-circle"></i></a>
+                                        </label>
                                     </li>
                                 </ul>
                             </div>

--- a/WebApp/autoreduce_webapp/templates/submit_runs.html
+++ b/WebApp/autoreduce_webapp/templates/submit_runs.html
@@ -74,11 +74,6 @@
                                         <a href="#currentScript" id="currentScript">Reset to values in current script</a>
                                         <div class="js-explaination visible-xs-block">Reset all variables to those set in the script. This will pick up any changes made to the reduce_vars.py script.</div>
                                     </li>
-									<li>
-                                        <input type="checkbox" name="overwrite_checkbox" id="overwrite_checkbox" checked>
-                                        <a href="#overwrite" id="overwrite"> Overwrite Previous Data</a>
-                                        <div class="js-explaination visible-xs-block">Uncheck this box if you don't want previous run data to be overwritten</div>
-                                    </li>
                                     <li>
                                         <input type="checkbox" name="overwrite_checkbox" id="overwrite_checkbox" checked>
                                         <a href="#overwrite" id="overwrite"> Overwrite Previous Data</a>

--- a/WebApp/autoreduce_webapp/templates/submit_runs.html
+++ b/WebApp/autoreduce_webapp/templates/submit_runs.html
@@ -77,9 +77,9 @@
                                     <li>
                                         <input type="checkbox" name="overwrite_checkbox" id="overwrite_checkbox" checked>
                                         <label for="overwrite_checkbox">
-                                            Overwrite Previous Data
+                                            Overwrite previous data
                                             <a href="#" data-toggle="popover" data-content="By default, when an autoreduction job is re-run, the original data from the initial run will be overwritten. If you uncheck this box,
-											   original data will not be overwritten and you will have distinct folders to separate out the data output from your different re-runs."
+                                                                                            original data will not be overwritten and you will have distinct folders to separate out the data output from your different re-runs."
                                                data-trigger="hover click focus" data-placement="top" data-container="body"><i class="fa fa-info-circle"></i></a>
                                         </label>
                                     </li>


### PR DESCRIPTION
### Summary of work
<!---The changes you have made--->
This PR does:
- Removes duplicated action
- Removes dead link
- Gives a way to show the currently invisible help text
- Adds missing label for accessibility

This PR does not:
- Verify if the additional actions are or were ever working correctly.

Previously:
![image](https://user-images.githubusercontent.com/44777678/93332635-08481000-f81a-11ea-9039-35755777b190.png)

Now:
![info](https://user-images.githubusercontent.com/44777678/93331905-e69a5900-f818-11ea-9c34-9512b7e1617f.gif)

I went with the second of the 2 help texts as that was added later in a commit to improve the message.
I have also opened #774 

### How to test your work
<!---This can be a link to the---> 


Fixes #770 


**Before merging ensure the release notes have been updated**