### PR TITLE
Accommodate SOAP/WSDL URL migration

### DIFF
--- a/WebApp/autoreduce_webapp/autoreduce_webapp/test_settings.py
+++ b/WebApp/autoreduce_webapp/autoreduce_webapp/test_settings.py
@@ -239,7 +239,6 @@ EMAIL_PORT = 25
 EMAIL_ERROR_RECIPIENTS = ['isisreduce@stfc.ac.uk']
 EMAIL_ERROR_SENDER = 'autoreducedev@reduce.isis.cclrc.ac.uk'
 BASE_URL = 'http://reduce.isis.cclrc.ac.uk/'
-CERTIFICATE_LOCATION = 'C:\\certificates\\FITBAWEB1isiscclrcacuk.crt'
 
 # Constant vars
 SESSION_COOKIE_AGE = 3600  # The MAX length before user is logged out, 1 hour in seconds

--- a/WebApp/autoreduce_webapp/autoreduce_webapp/test_settings.py
+++ b/WebApp/autoreduce_webapp/autoreduce_webapp/test_settings.py
@@ -228,7 +228,7 @@ OUTDATED_BROWSERS = {
 
 # UserOffice WebService
 
-UOWS_URL = 'https://fitbaweb1.isis.cclrc.ac.uk:8443/UserOfficeWebService/UserOfficeWebService?wsdl'
+UOWS_URL = 'https://api.facilities.rl.ac.uk/ws/UserOfficeWebService?wsdl'
 UOWS_LOGIN_URL = 'https://users.facilities.rl.ac.uk/auth/?service=http://reduce.isis.cclrc.ac.uk&redirecturl='
 
 # Email for notifications

--- a/WebApp/autoreduce_webapp/autoreduce_webapp/uows_client.py
+++ b/WebApp/autoreduce_webapp/autoreduce_webapp/uows_client.py
@@ -15,29 +15,8 @@ import suds
 from suds.transport.https import HttpAuthenticated
 from suds.client import Client
 
-# The below is a template on the repository
-# pylint: disable=relative-import
-from .settings import CERTIFICATE_LOCATION, UOWS_URL
-
 
 LOGGER = logging.getLogger(__name__)
-
-
-class CustomTransport(HttpAuthenticated):
-    """
-    Custom HTTPAuthentication class to check user certificate
-    """
-    def u2handlers(self):
-        # use handlers from superclass
-        handlers = HttpAuthenticated.u2handlers(self)
-        # create custom ssl context, e.g.
-        ctx = ssl.create_default_context(cafile=CERTIFICATE_LOCATION)
-        # configure context as needed...
-        ctx.check_hostname = False
-
-        # add a https handler using the custom context
-        handlers.append(HTTPSHandler(context=ctx))
-        return handlers
 
 
 class UOWSClient(object):
@@ -48,7 +27,7 @@ class UOWSClient(object):
         url = UOWS_URL
         if 'URL' in kwargs:
             url = kwargs['URL']
-        self.client = Client(url, transport=CustomTransport())
+        self.client = Client(url)
 
     # Add the ability to use 'with'
     def __enter__(self):

--- a/WebApp/autoreduce_webapp/autoreduce_webapp/uows_client.py
+++ b/WebApp/autoreduce_webapp/autoreduce_webapp/uows_client.py
@@ -15,6 +15,10 @@ import suds
 from suds.transport.https import HttpAuthenticated
 from suds.client import Client
 
+# The below is a template on the repository
+# pylint: disable=relative-import
+from .settings import UOWS_URL
+
 
 LOGGER = logging.getLogger(__name__)
 

--- a/WebApp/autoreduce_webapp/autoreduce_webapp/uows_client.py
+++ b/WebApp/autoreduce_webapp/autoreduce_webapp/uows_client.py
@@ -7,12 +7,9 @@
 """
 Client for accessing the user office logon
 """
-import ssl
-from urllib.request import HTTPSHandler
 import logging
 
 import suds
-from suds.transport.https import HttpAuthenticated
 from suds.client import Client
 
 # The below is a template on the repository


### PR DESCRIPTION
### Summary of work
See description in #773

Removed certificate also. Panda writes "The certificate for this service is signed by a trusted authority now so you shouldn’t need to import the FITBAWEB1 certificate any more"

### How to test your work
* check code changes
*  check that works. On dev environment by changing temporarily change setting `DEVELOPMENT_MODE = True` to `DEVELOPMENT_MODE = False` and check if can login

Fixes #773
