### PR TITLE
Fixes runs not displaying due to any error in plot retrieving code

### DIFF
--- a/WebApp/autoreduce_webapp/reduction_viewer/views.py
+++ b/WebApp/autoreduce_webapp/reduction_viewer/views.py
@@ -28,13 +28,11 @@ from autoreduce_webapp.settings import UOWS_LOGIN_URL, USER_ACCESS_CHECKS, DEVEL
 from autoreduce_webapp.uows_client import UOWSClient
 from autoreduce_webapp.view_utils import (login_and_uows_valid, render_with,
                                           require_admin, check_permissions)
+from plotting.plot_handler import PlotHandler
 from reduction_variables.utils import MessagingUtils
 from reduction_viewer.models import Experiment, ReductionRun, Instrument, Status
 from reduction_viewer.utils import StatusUtils, ReductionRunUtils
 from reduction_viewer.view_utils import deactivate_invalid_instruments
-
-from plotting.plot_handler import PlotHandler
-
 from utilities.pagination import CustomPaginator
 
 LOGGER = logging.getLogger('app')

--- a/WebApp/autoreduce_webapp/reduction_viewer/views.py
+++ b/WebApp/autoreduce_webapp/reduction_viewer/views.py
@@ -295,8 +295,9 @@ def run_summary(_, instrument_name=None, run_number=None, run_version=0):
             # Lack of plot images is recoverable - we shouldn't stop the whole page rendering
             # if something is wrong with the plot images - but display an error message
             err_msg = "Encountered error while retrieving plots for this run"
-            LOGGER.error(f"{err_msg}. Run {run}\n. Error: {exception}")
-            context_dictionary["plot_error_message"] = f"{err_msg}. Error: {str(exception)}"
+            LOGGER.error("%s. Instrument: %s, run %s. RB Number %s Error: %s",
+                         err_msg, run.instrument.name, run, rb_number, exception)
+            context_dictionary["plot_error_message"] = f"{err_msg}."
 
     return context_dictionary
 

--- a/WebApp/autoreduce_webapp/templates/run_summary.html
+++ b/WebApp/autoreduce_webapp/templates/run_summary.html
@@ -13,29 +13,36 @@
             <div class="col-md-12 text-center">
                 <h2>Reduction Job #{{ run.title }}</h2>
                 {% if history.count > 1 %}
-                    (This run has been re-reduced, <a href="#" class="js-reduction-run-history" id="run_history">see history</a>)
+                    (This run has been re-reduced,
+                    <a href="#" class="js-reduction-run-history" id="run_history">see history</a>)
                 {% endif %}
             </div>
         </div>
         {% if plot_locations %}
             <div class="row plot-container">
-            {% for plot_file in plot_locations %}
-                {% if plot_locations|length == 1 %}
-                    <img class="center-block" src="{{ plot_file }}">
-                {%else%}
-                    <img class="col-md-6" src="{{ plot_file }}">
-                {% endif %}
-            {% endfor %}
+                {% for plot_file in plot_locations %}
+                    {% if plot_locations|length == 1 %}
+                        <img class="center-block" src="{{ plot_file }}">
+                    {% else %}
+                        <img class="col-md-6" src="{{ plot_file }}">
+                    {% endif %}
+                {% endfor %}
+            </div>
+        {% elif plot_error_message %}
+            <div class="row">
+                <p>{{ plot_error_message }}</p>
             </div>
         {% endif %}
         {% if run.message %}
             {% if 'Skipped' in run.message %}
                 <div class="alert alert-{% replace run.status.value_verbose 'Skipped' 'info' %} word-wrap" role="alert">
-                    <i class="fa fa-{% replace run.status.value_verbose 'Skipped' 'question' %} fa-{% replace run.status.value_verbose 'Skipped' 'question' %}-circle fa-lg"></i> <a href="#" class="js-log-display"> {{ run.message }}</a>
+                    <i class="fa fa-{% replace run.status.value_verbose 'Skipped' 'question' %} fa-{% replace run.status.value_verbose 'Skipped' 'question' %}-circle fa-lg"></i>
+                    <a href="#" class="js-log-display"> {{ run.message }}</a>
                 </div>
             {% else %}
                 <div class="alert alert-{% replace run.status.value_verbose 'Error' 'danger' %} word-wrap" role="alert">
-                    <i class="fa fa-{% replace run.status.value_verbose 'Error' 'exclamation' %} fa-{% replace run.status.value_verbose 'Error' 'exclamation' %}-circle fa-lg"></i> <a href="#" class="js-log-display">[{{ run.finished }}] {{ run.message }}</a>
+                    <i class="fa fa-{% replace run.status.value_verbose 'Error' 'exclamation' %} fa-{% replace run.status.value_verbose 'Error' 'exclamation' %}-circle fa-lg"></i>
+                    <a href="#" class="js-log-display">[{{ run.finished }}] {{ run.message }}</a>
                 </div>
             {% endif %}
         {% endif %}
@@ -47,17 +54,20 @@
                             <div class="col-md-6">
                                 <div>
                                     {% if started_by is not null %}
-                                    <strong>Started by:</strong> {{ started_by }}
+                                        <strong>Started by:</strong> {{ started_by }}
                                     {% endif %}
                                 </div>
                                 <div>
-                                    <strong>Status:</strong> <strong class="text-{% colour_table_row run.status.value_verbose %}">{{ run.status.value_verbose }}</strong>
+                                    <strong>Status:</strong> <strong
+                                        class="text-{% colour_table_row run.status.value_verbose %}">{{ run.status.value_verbose }}</strong>
                                 </div>
                                 <div>
-                                    <strong>Instrument:</strong> <a href="{% url 'instrument_summary' instrument=run.instrument.name %}">{{ run.instrument.name }}</a>
+                                    <strong>Instrument:</strong> <a
+                                        href="{% url 'instrument_summary' instrument=run.instrument.name %}">{{ run.instrument.name }}</a>
                                 </div>
                                 <div>
-                                    <strong>RB Number:</strong> <a href="{% url 'experiment_summary' reference_number=run.experiment.reference_number %}">{{ run.experiment.reference_number }}</a>
+                                    <strong>RB Number:</strong> <a
+                                        href="{% url 'experiment_summary' reference_number=run.experiment.reference_number %}">{{ run.experiment.reference_number }}</a>
                                 </div>
                                 <div>
                                     <strong>Last Updated:</strong> {{ run.last_updated }}
@@ -65,7 +75,7 @@
                             </div>
                             <div class="col-md-6">
                                 <div>
-                                    <strong>Start:</strong> 
+                                    <strong>Start:</strong>
                                     {% if run.started %}
                                         {{ run.started }}
                                     {% else %}
@@ -73,7 +83,7 @@
                                     {% endif %}
                                 </div>
                                 <div>
-                                    <strong>Finish:</strong> 
+                                    <strong>Finish:</strong>
                                     {% if run.finished %}
                                         {{ run.finished }}
                                     {% else %}
@@ -81,7 +91,7 @@
                                     {% endif %}
                                 </div>
                                 <div>
-                                    <strong>Duration:</strong> 
+                                    <strong>Duration:</strong>
                                     {% if run.started and run.finished %}
                                         {% natural_time_difference run.started run.finished %}
                                     {% else %}
@@ -89,7 +99,7 @@
                                     {% endif %}
                                 </div>
                                 <div>
-                                    <strong>Retrying:</strong> 
+                                    <strong>Retrying:</strong>
                                     {% if run.finished %}
                                         {% if run.retry_when %}
                                             {{ run.retry_when|naturaltime }}
@@ -97,7 +107,8 @@
                                                 <span> (Last attempt)</span>
                                             {% endif %}
                                             {% if run.retry_run %}
-                                                <a href="{% url 'run_summary' instrument_name=run.instrument.name run_number=run.retry_run.run_number run_version=run.retry_run.run_version %}"> ({{ run.retry_run.status.value_verbose }})</a>
+                                                <a href="{% url 'run_summary' instrument_name=run.instrument.name run_number=run.retry_run.run_number run_version=run.retry_run.run_version %}">
+                                                    ({{ run.retry_run.status.value_verbose }})</a>
                                             {% endif %}
                                         {% else %}
                                             Never
@@ -154,11 +165,13 @@
             {% if run.graph %}
                 <div class="panel panel-default" id="re-run_job">
                     <div class="panel-heading">
-                      <div class="panel-title"><a data-toggle="collapse" href="#collapseGraphs" data-target="#graphs"><i class="fa fa-chevron-down"></i> Images</a></div>
+                        <div class="panel-title"><a data-toggle="collapse" href="#collapseGraphs" data-target="#graphs"><i
+                                class="fa fa-chevron-down"></i> Images</a></div>
                     </div>
                     <div class="panel-body collapse in" id="graphs">
                         {% for graph in run.graph %}
-                            <div class="text-center"><a href="{{ graph }}" target="_blank"><img src="{{ graph }}" /></a></div>
+                            <div class="text-center"><a href="{{ graph }}" target="_blank"><img src="{{ graph }}"/></a>
+                            </div>
                         {% endfor %}
                     </div>
                 </div>
@@ -173,52 +186,55 @@
             <div class="modal-dialog">
                 <div class="modal-content">
                     <div class="modal-header">
-                        <button type="button" class="close" data-dismiss="modal"><span aria-hidden="true">&times;</span><span class="sr-only">Close</span></button>
+                        <button type="button" class="close" data-dismiss="modal"><span aria-hidden="true">&times;</span><span
+                                class="sr-only">Close</span></button>
                         <h4 class="modal-title">Job History</h4>
                     </div>
                     <div class="modal-body">
                         <table class="table table-striped table-bordered">
                             <thead>
-                                <tr>
-                                    <th>Job Number</th>
-                                    <th>Status</th>
-                                    <th>Last Updated</th>
-                                    <th>Submitted By</th>
-                                </tr>
+                            <tr>
+                                <th>Job Number</th>
+                                <th>Status</th>
+                                <th>Last Updated</th>
+                                <th>Submitted By</th>
+                            </tr>
                             </thead>
                             <tbody>
-                                {% for job in history %}
-                                    <tr>
-                                        <td>
-                                            {% if job.run_version != run.run_version %}
+                            {% for job in history %}
+                                <tr>
+                                    <td>
+                                        {% if job.run_version != run.run_version %}
                                             <a href="{% url 'run_summary' instrument_name=run.instrument.name run_number=job.run_number run_version=job.run_version %}">{{ job.title }}</a>
-                                            {% else %}
-                                                {{ job.title }}
-                                            {% endif %}
-                                        </td>
-                                        <td class="text-{% colour_table_row job.status.value_verbose %}"><strong>{{ job.status.value_verbose }}</strong></td>
-                                        <td title="{{ job.last_updated|date:'SHORT_DATETIME_FORMAT' }}">{{ job.last_updated|naturaltime }}</td>
-                                        <td>
-                                            {% if started_by %}
-                                                {{ started_by }}
-                                            {% else %}
-                                                Unknown
-                                            {% endif %}
-                                        </td>
-                                    </tr>
-                                {% endfor %}
+                                        {% else %}
+                                            {{ job.title }}
+                                        {% endif %}
+                                    </td>
+                                    <td class="text-{% colour_table_row job.status.value_verbose %}">
+                                        <strong>{{ job.status.value_verbose }}</strong></td>
+                                    <td title="{{ job.last_updated|date:'SHORT_DATETIME_FORMAT' }}">{{ job.last_updated|naturaltime }}</td>
+                                    <td>
+                                        {% if started_by %}
+                                            {{ started_by }}
+                                        {% else %}
+                                            Unknown
+                                        {% endif %}
+                                    </td>
+                                </tr>
+                            {% endfor %}
                             </tbody>
                         </table>
                     </div>
                 </div>
             </div>
         </div>
-        
+
         <div class="log-display modal fade" tabindex="-1" role="dialog" aria-hidden="true">
             <div class="modal-dialog">
                 <div class="modal-content">
                     <div class="modal-header">
-                        <button type="button" class="close" data-dismiss="modal"><span aria-hidden="true">&times;</span><span class="sr-only">Close</span></button>
+                        <button type="button" class="close" data-dismiss="modal"><span aria-hidden="true">&times;</span><span
+                                class="sr-only">Close</span></button>
                         <h4 class="modal-title">Reduction logs</h4>
                     </div>
                     <div class="modal-body">
@@ -229,7 +245,7 @@
         </div>
     {% else %}
         <div class="text-center col-md-6 col-md-offset-3 well well-small">
-            Reduction run not found.
+            Reduction run not found or error encountered: {{ message }}.
         </div>
     {% endif %}
 {% endblock %}
@@ -237,17 +253,17 @@
 
 
 {% block stylesheets %}
-    {% if reduction_variables_on %}  
+    {% if reduction_variables_on %}
         <link rel="stylesheet" href="{% static "css/vendor/prettify.css" %}">
     {% endif %}
     <link rel="stylesheet" href="{% static "css/vendor/bootstrap-tour.min.css" %}">
 {% endblock %}
 {% block scripts %}
     <script src="{% static "javascript/run_summary.js" %}"></script>
-    {% if reduction_variables_on %}  
+    {% if reduction_variables_on %}
         <script src="{% static "javascript/vendor/prettify.js" %}"></script>
         <script src="{% static "javascript/run_variables.js" %}"></script>
-         <script src="{% static "javascript/vendor/bootstrap-tour.min.js" %}"></script>
+        <script src="{% static "javascript/vendor/bootstrap-tour.min.js" %}"></script>
 
         <script src="{% static "javascript/tours/run_summary_tour.js" %}"></script>
         <script src="{% static "javascript/create_tour.js" %}"></script>

--- a/WebApp/autoreduce_webapp/templates/run_summary.html
+++ b/WebApp/autoreduce_webapp/templates/run_summary.html
@@ -30,7 +30,9 @@
             </div>
         {% elif plot_error_message %}
             <div class="row">
-                <p>{{ plot_error_message }}</p>
+                <div class="col-md-8 col-md-offset-2">
+                    <p class="panel panel-warning text-center">{{ plot_error_message }}</p>
+                </div>
             </div>
         {% endif %}
         {% if run.message %}

--- a/WebApp/autoreduce_webapp/templates/run_summary.html
+++ b/WebApp/autoreduce_webapp/templates/run_summary.html
@@ -13,8 +13,10 @@
             <div class="col-md-12 text-center">
                 <h2>Reduction Job #{{ run.title }}</h2>
                 {% if history.count > 1 %}
-                    (This run has been re-reduced,
-                    <a href="#" class="js-reduction-run-history" id="run_history">see history</a>)
+                    <p>
+                        (This run has been re-reduced,
+                        <a href="#" class="js-reduction-run-history" id="run_history">see history</a>)
+                    </p>
                 {% endif %}
             </div>
         </div>

--- a/plotting/plot_handler.py
+++ b/plotting/plot_handler.py
@@ -76,9 +76,8 @@ class PlotHandler:
         file_name_regex = self._generate_file_name_regex()
         if file_name_regex is None:
             return None
-        else:
-            return [f'/static/graphs/{file}' for file in os.listdir(self.static_graph_dir)
-                    if re.match(file_name_regex, file)]
+        return [f'/static/graphs/{file}' for file in os.listdir(self.static_graph_dir) if
+                re.match(file_name_regex, file)]
 
     def _check_for_plot_files(self):
         """

--- a/plotting/plot_handler.py
+++ b/plotting/plot_handler.py
@@ -52,11 +52,12 @@ class PlotHandler:
         """
         try:
             _inst_regex = INSTRUMENT_REGEX_MAP[self.instrument_name]
-            _file_extension_regex = self._generate_file_extension_regex()
-            return f'{_inst_regex}{self.run_number}.*.{_file_extension_regex}'
-        except KeyError:  # Instrument name does not appear in dictionary of known instruments
-            LOGGER.info("The instrument name is not recognised")
+        except KeyError:
+            LOGGER.info("Plots for this instruments are not currently handled")
             return None
+
+        _file_extension_regex = self._generate_file_extension_regex()
+        return f'{_inst_regex}{self.run_number}.*.{_file_extension_regex}'
 
     def _generate_file_extension_regex(self):
         """
@@ -64,7 +65,7 @@ class PlotHandler:
         .png, .gif and .jpg: The returned value would be (png|gif|jpg)
         :return: (str) expression pattern matching the file extensions of the plot handler
         """
-        return f"({','.join(self.file_extensions).replace(',','|')})"
+        return f"({','.join(self.file_extensions).replace(',', '|')})"
 
     def _get_plot_files_locally(self):
         """
@@ -72,8 +73,12 @@ class PlotHandler:
         a list of matching paths
         :return: (list) - The list of matching file paths.
         """
-        return [f'/static/graphs/{file}' for file in os.listdir(self.static_graph_dir)
-                if re.match(self._generate_file_name_regex(), file)]
+        file_name_regex = self._generate_file_name_regex()
+        if file_name_regex is None:
+            return None
+        else:
+            return [f'/static/graphs/{file}' for file in os.listdir(self.static_graph_dir)
+                    if re.match(file_name_regex, file)]
 
     def _check_for_plot_files(self):
         """


### PR DESCRIPTION
### Summary of work
The issue was caused by the rendering code falling over when trying to retrieve plot images for:
- Instruments that we don't support plotting at all
- Instruments that have no cached plots

Now renders the page regardless of presence of plot images. If plots are supported for the instrument (seems like only MARI and WISH are according to the code) but not found due to some issue (e.g. locally it was `Authentication failed` because I don't have the correct mount), a warning is displayed:
![image](https://user-images.githubusercontent.com/9135965/95073087-2cee2400-0704-11eb-9792-66ea8505b092.png)


### How to test your work
- Run web-app locally or pull onto dev env. 
- Go into any run on any instrument.

Need to test whether plots still render properly! I couldn't find a run with plots, nor a way to generate them.

### Additional comments
The first commit is PyCharm enforcing it's formatting on the changed files. I'm not sure we have a strict formatter (e.g. YAPF) so can't avoid this for now.

Fixes #760 


~~**Before merging ensure the release notes have been updated**~~
-- Not sure this needs release notes