### PR TITLE
Adds config for the `root` logger

### DIFF
--- a/queue_processors/queue_processor/test_settings.py
+++ b/queue_processors/queue_processor/test_settings.py
@@ -46,6 +46,11 @@ LOGGING = {
             'formatter': 'verbose'
         },
     },
+    'root': {
+        'level':LOG_LEVEL,
+        'handlers': ['file'],
+        'propagate': True
+    },
     'loggers': {
         'queue_processor': {
             'handlers': ['file'],


### PR DESCRIPTION
### Summary of work
Adds root logger that should be inherited by all `getLogger` calls.

### How to test your work
This needs to be deployed on the dev env so that we can see if queue_listener starts logging now.

Fixes #795