### PR TITLE
Makes getLogger consistently use __file__

### DIFF
--- a/queue_processors/queue_processor/README.md
+++ b/queue_processors/queue_processor/README.md
@@ -1,9 +1,14 @@
 ## queue_processor module
 
-This modules handles the majority of message management in the autoreduction system. It is responsible for the initial creation of the database records for reduction jobs. 
-This module also handles updating of status's to reduction records as the AMQ message traverses through the system. 
+This modules handles the majority of message management in the autoreduction system. It is responsible for the initial creation of the database records for reduction jobs.
+This module also handles updating of status's to reduction records as the AMQ message traverses through the system.
 
-The `queue_listener.py` is responsible for ingesting and distributing messages to their correct functions for processing. The `queue_listner` consumes messages from the `/DataReady`, `/ReductionStarted`,`/ReductionComplete`, `/ReductionError` and `/ReductionSkipped` queues. The service is run as a daemon process - as such only runs on Linux.  The daemon process is controlled by `queue_processor_daemon.py`, which produces a command line interface to start/stop/restart the daemon process. 
-However, the daemon is normally controlled in tandem with the `autoreduction_processor` via the `../restart.sh` script that restarts both these processes. 
+The `queue_listener.py` is responsible for ingesting and distributing messages to their correct functions for processing. The `queue_listner` consumes messages from the `/DataReady`, `/ReductionStarted`,`/ReductionComplete`, `/ReductionError` and `/ReductionSkipped` queues. The service is run as a daemon process - as such only runs on Linux.  The daemon process is controlled by `queue_processor_daemon.py`, which produces a command line interface to start/stop/restart the daemon process.
+However, the daemon is normally controlled in tandem with the `autoreduction_processor` via the `../restart.sh` script that restarts both these processes.
 
-The process that performs the message management and logic is stored in `handle_message.py`. This contains individual functions that are responsible for each stage of the autoreduction workflow (except for the reduction stage that is handled by the `autoreduction_processor`). The code for this is fairly self documenting, so read the functions and the docstrings in the `handle_message.py` file to learn what each stage is responsible for. 
+The process that performs the message management and logic is stored in `handle_message.py`. This contains individual functions that are responsible for each stage of the autoreduction workflow (except for the reduction stage that is handled by the `autoreduction_processor`). The code for this is fairly self documenting, so read the functions and the docstrings in the `handle_message.py` file to learn what each stage is responsible for.
+
+## Daily restart to update permissions
+The `queue_listener_daemon.py` is rigged to gracefully stop after running for 23h 45min. This is because the process needs to be restarted in order to reload permissions on data files.
+
+It is expected that a cronjob is set up to restart the `queue_processor` at midnight: `0 0 * * * .../path/to/queue_processor/restart.sh`. If the cronjob is missing then the `queue_processor` will be shutting down when the timer triggers, and the queue processing will stop.

--- a/queue_processors/queue_processor/queue_listener.py
+++ b/queue_processors/queue_processor/queue_listener.py
@@ -32,7 +32,7 @@ class QueueListener:
         # Set up logging and attach the logging to the right part of the
         # config.
         logging.config.dictConfig(LOGGING)
-        self._logger = logging.getLogger("queue_listener")
+        self._logger = logging.getLogger(__file__)
 
     def on_message(self, headers, message):
         """ This method is where consumed messages are dealt with. It will

--- a/queue_processors/queue_processor/queue_listener_daemon.py
+++ b/queue_processors/queue_processor/queue_listener_daemon.py
@@ -50,7 +50,8 @@ class QueueListenerDaemon(Daemon):
         """ Run queue processor. """
         self._logger.info("Starting Queue Processor")
         self._client_handle = queue_listener.main()
-        self._logger.info("Setting shutdown timer for %s", str(datetime.datetime.now()+datetime.timedelta(hours=23, minutes=45)))
+        self._logger.info("Setting shutdown timer for %s",
+                          str(datetime.datetime.now() + datetime.timedelta(hours=23, minutes=45)))
         self._stop_timer = threading.Timer(self.stop_interval, self.stop)
         self._stop_timer.start()
 

--- a/queue_processors/queue_processor/queue_listener_daemon.py
+++ b/queue_processors/queue_processor/queue_listener_daemon.py
@@ -76,12 +76,12 @@ def _wait_for_client(daemon):
     was_safe_shutdown = daemon.safe_shutdown.wait(timeout=60)
 
     if not was_safe_shutdown:
-        log = logging.getLogger(__file__)
-        # You will also see this message in the log if manually stop the process
+        logger = logging.getLogger(__file__)
+        # You will also see this message in the logger if manually stop the process
         # that is expected and is OK. If seen and not manually shut-down
         # this means the client_handle did not disconnect in time and was
         # in the middle of processing something!
-        log.error("%s: Queue Client did not shutdown gracefully before timeout, "
+        logger.error("%s: Queue Client did not shutdown gracefully before timeout, "
                   "so it was killed. This should be investigated as it could "
                   "cause messages to get lost.", datetime.datetime.now().isoformat())
 

--- a/utils/clients/queue_client.py
+++ b/utils/clients/queue_client.py
@@ -18,11 +18,6 @@ from model.message.message import Message
 from utils.clients.abstract_client import AbstractClient
 from utils.clients.connection_exception import ConnectionException
 from utils.settings import ACTIVEMQ_SETTINGS
-from utils.project.structure import get_log_file
-from utils.project.static_content import LOG_FORMAT
-
-logging.basicConfig(filename=get_log_file('queue_client.log'), level=logging.INFO,
-                    format=LOG_FORMAT)
 
 
 class QueueClient(AbstractClient):
@@ -36,6 +31,7 @@ class QueueClient(AbstractClient):
         self._connection = None
         self._consumer_name = consumer_name
         self._autoreduce_queues = self.credentials.all_subscriptions
+        self._logger = logging.getLogger(__file__)
 
     # pylint:disable=arguments-differ
     def connect(self, listener=None):
@@ -56,7 +52,7 @@ class QueueClient(AbstractClient):
         """
         Disconnect from queue service
         """
-        logging.info("Disconnecting from activemq")
+        self._logger.info("Disconnecting from activemq")
         if self._connection is not None and self._connection.is_connected():
             # By passing a receipt Stomp will call stop on the transport layer
             # which causes it to wait on the listener thread (if it's still
@@ -78,7 +74,7 @@ class QueueClient(AbstractClient):
                                               use_ssl=False)
                 if listener:
                     connection.set_listener('Autoreduction', listener)
-                logging.info("Starting connection to %s", host_port)
+                self._logger.info("Starting connection to %s", host_port)
                 connection.connect(username=self.credentials.username,
                                    passcode=self.credentials.password,
                                    wait=False,
@@ -105,8 +101,8 @@ class QueueClient(AbstractClient):
                                        id='1',
                                        ack=ack,
                                        header={'activemq.prefetchSize': '1'})
-            logging.info("[%s] Subscribing to %s", consumer_name, queue)
-        logging.info("Successfully subscribed to all of the queues")
+            self._logger.info("[%s] Subscribing to %s", consumer_name, queue)
+        self._logger.info("Successfully subscribed to all of the queues")
 
     def subscribe_autoreduce(self, consumer_name, listener, ack='auto'):
         """


### PR DESCRIPTION
### Summary of work

- Small cleanup and improving comments in queue_listener.py
- Adds a paragraph about how a cronjob is expected to restart the queue_processor daily

### How to test your work
Need to deploy on dev env and restart the `queue_processor` - then check that `logs/queue_processor.log` contains entries from `queue_listener_daemon.py`, and possibly `daemon.py` or `queue_listener.py`

### Additional comments
Should be merged after #796 

No associated issue