### PR TITLE
Control which instruments appear in WebApp

### DIFF
--- a/WebApp/autoreduce_webapp/reduction_viewer/views.py
+++ b/WebApp/autoreduce_webapp/reduction_viewer/views.py
@@ -37,6 +37,8 @@ from plotting.plot_handler import PlotHandler
 
 from utilities.pagination import CustomPaginator
 
+from utils.settings import VALID_INSTRUMENTS
+
 LOGGER = logging.getLogger('app')
 
 
@@ -103,7 +105,7 @@ def overview(_):
     Render the overview landing page (redirect from /index)
     Note: _ is replacing the passed in request parameter
     """
-    instruments = Instrument.objects.order_by('name')
+    instruments = VALID_INSTRUMENTS
     context_dictionary = {}
     if instruments:
         context_dictionary = {'instrument_list': instruments}

--- a/WebApp/autoreduce_webapp/templates/overview.html
+++ b/WebApp/autoreduce_webapp/templates/overview.html
@@ -6,8 +6,8 @@
     <div class="instrument-btns-row row form-group">
     {% if instrument_list %}
         {% for instrument in instrument_list %}
-                <div class="instrument-btn col-md-4 text-center" id={{ instrument.name }}-instrument-btn>
-                    <a href="/instrument/{{ instrument.name }}" class="btn btn-primary btn-lg btn-block">{{ instrument.name }}</a>
+                <div class="instrument-btn col-md-4 text-center" id={{ instrument }}-instrument-btn>
+                    <a href="/instrument/{{ instrument }}" class="btn btn-primary btn-lg btn-block">{{ instrument }}</a>
                 </div>
         {% if forloop.counter|divisibleby:3 %}
         </div>

--- a/scripts/database_management/reset_database_post_cycle.py
+++ b/scripts/database_management/reset_database_post_cycle.py
@@ -110,6 +110,7 @@ class DatabaseReset:
         # The list of tables to be deleted
         tables_to_delete = ['reduction_viewer_datalocation',
                             'reduction_viewer_experiment',
+                            'reduction_viewer_instrument',
                             'reduction_viewer_notification',
                             'reduction_viewer_reductionrun',
                             'reduction_viewer_reductionlocation',


### PR DESCRIPTION
Note: Travis fails because of `sentry_sdk` issue mentioned on teams and referenced here #808

### Summary of work
The instrument buttons in the overview page are now populated from `VALID_INSTRUMENTS` from `utils.settings`.
The reset script will also now delete the instrument table.
I had quite a few issues running the script which were out of the scope of this issue, so I have opened #809

### How to test your work
Add an instrument to `VALID_INSTRUMENTS` and verify it appears on the overview page
Remove an instrument and verify it is removed from the overview page
Run the database reset script and verify that all instruments are also removed
Run `setup.py database` and verify all models successfully migrated.

### Additional comments
<!---Anything else: e.g. was the estimate reasonable for this issue?---> 

closes #766


**Before merging ensure the release notes have been updated**