### PR TITLE
Lowers IPython version pin to 7.16.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,9 @@ dash==1.16.3
 django-debug-toolbar==3.1.1
 django_plotly_dash==1.4.2
 gitpython==3.1.7
-ipython==7.18.1
+# this is the highest available version that pip can find on CentOS - be careful when updating
+# because Travis runs on Ubuntu so even if the build pass, the installation could fail
+ipython==7.16.1
 lxml==4.5.2
 mock==4.0.2
 pandas==1.1.0

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,9 @@ setup_requires = ['attrs==20.2.0',
                   'filelock==3.0.12',
                   'fire==0.3.1',
                   'gitpython==3.1.7',
-                  'IPython==7.18.1',
+                  # this is the highest available version that pip can find on CentOS - be careful when updating
+                  # because Travis runs on Ubuntu so even if the build pass, the installation could fail
+                  'IPython==7.16.1',
                   'mysqlclient==2.0.1',
                   'mysql-connector==2.2.9',
                   'nexusformat==0.5.3',


### PR DESCRIPTION
### Summary of work
This is due to 7.16.1 being the highest one that pip can find on CentOS.
Also added comments to warn about this as travis runs Ubuntu and thus
if `dependabot` opens a PR with an update the builds will pass successfully,
but then fail to install on our environments

### How to test your work
On dev queue env:
```
virtualenv /tmp/pr
source /tmp/pr/bin/activate

# Go into autoreduction folder and just install
pip3 install -e .
pip3 install -r requirements.txt
```