### PR TITLE
Remove deprecated sudo from travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
-sudo: required
 language: python
 python:
   - "3.7"


### PR DESCRIPTION
### Summary of work
Removes the deprecated sudo property from the travis config. Jobs will no longer have a warning

### How to test your work
Observe this job passes with no warning


closes #815 


**Before merging ensure the release notes have been updated**