### PR TITLE
Catch the base exception

### DIFF
--- a/WebApp/autoreduce_webapp/reduction_viewer/utils.py
+++ b/WebApp/autoreduce_webapp/reduction_viewer/utils.py
@@ -185,8 +185,7 @@ class ReductionRunUtils(object):
         # Check record is safe to save
         try:
             new_job.full_clean()
-        # pylint:disable=catching-non-exception
-        except django.core.exceptions as exception:
+        except Exception as exception:
             LOGGER.error(traceback.format_exc())
             LOGGER.error(exception)
             raise


### PR DESCRIPTION
### Summary of work
We catch the base exception allowing it to be properly logged and reported instead of being swallowed and a new exception rethrown.

This should be made more specific in the future, but right now it is more important that we can identify the issue that is being hidden

### How to test your work
Resubmit a HRPD run. And the true exception is revealed.

### Additional comments
<!---Anything else: e.g. was the estimate reasonable for this issue?---> 

closes #845 


**Before merging ensure the release notes have been updated**