### PR TITLE
Cleanup run summary for skipped runs

### DIFF
--- a/WebApp/autoreduce_webapp/reduction_viewer/views.py
+++ b/WebApp/autoreduce_webapp/reduction_viewer/views.py
@@ -260,6 +260,7 @@ def run_summary(_, instrument_name=None, run_number=None, run_version=0):
         run = ReductionRun.objects.get(instrument=instrument,
                                        run_number=run_number,
                                        run_version=run_version)
+        # run status value of "s" means the run is skipped
         is_skipped = run.status.value == "s"
         history = ReductionRun.objects.filter(run_number=run_number).order_by('-run_version')
         started_by = started_by_id_to_name(run.started_by)

--- a/WebApp/autoreduce_webapp/reduction_viewer/views.py
+++ b/WebApp/autoreduce_webapp/reduction_viewer/views.py
@@ -260,6 +260,7 @@ def run_summary(_, instrument_name=None, run_number=None, run_version=0):
         run = ReductionRun.objects.get(instrument=instrument,
                                        run_number=run_number,
                                        run_version=run_version)
+        is_skipped = run.status.value == "s"
         history = ReductionRun.objects.filter(run_number=run_number).order_by('-run_version')
         started_by = started_by_id_to_name(run.started_by)
 
@@ -273,6 +274,7 @@ def run_summary(_, instrument_name=None, run_number=None, run_version=0):
         rb_number = Experiment.objects.get(id=run.experiment_id).reference_number
 
         context_dictionary = {'run': run,
+                              'is_skipped': is_skipped,
                               'history': history,
                               'reduction_location': reduction_location,
                               'started_by': started_by}

--- a/WebApp/autoreduce_webapp/templates/run_summary.html
+++ b/WebApp/autoreduce_webapp/templates/run_summary.html
@@ -82,6 +82,8 @@
                                     <strong>Start:</strong>
                                     {% if run.started %}
                                         {{ run.started }}
+                                    {% elif is_skipped %}
+                                        <em>Not run</em>
                                     {% else %}
                                         <em>Not yet started</em>
                                     {% endif %}
@@ -90,6 +92,8 @@
                                     <strong>Finish:</strong>
                                     {% if run.finished %}
                                         {{ run.finished }}
+                                    {% elif is_skipped %}
+                                        <em>Not run</em>
                                     {% else %}
                                         <em>Not yet finished</em>
                                     {% endif %}
@@ -98,6 +102,8 @@
                                     <strong>Duration:</strong>
                                     {% if run.started and run.finished %}
                                         {% natural_time_difference run.started run.finished %}
+                                    {% elif is_skipped %}
+                                        <em>Not run</em>
                                     {% else %}
                                         <em>Not yet finished</em>
                                     {% endif %}
@@ -157,35 +163,39 @@
                                         <em>No reduced data found</em>
                                     {% endif %}
                                 </div>
-                                <strong>Logs:</strong>
-                                <a href="#" class="js-log-display" id="show_reduction_logs">Show reduction logs</a>
+                                {% if not is_skipped %}
+                                    <strong>Logs:</strong>
+                                    <a href="#" class="js-log-display" id="show_reduction_logs">Show reduction logs</a>
+                                {% endif %}
                             </div>
                         </div>
                     </div>
                 </div>
             </div>
         </div>
-        <div id="re-run_and_graphs">
-            {% if run.graph %}
-                <div class="panel panel-default" id="re-run_job">
-                    <div class="panel-heading">
-                        <div class="panel-title"><a data-toggle="collapse" href="#collapseGraphs" data-target="#graphs"><i
-                                class="fa fa-chevron-down"></i> Images</a></div>
+        {% if not is_skipped %}
+            <div id="re-run_and_graphs">
+                {% if run.graph %}
+                    <div class="panel panel-default" id="re-run_job">
+                        <div class="panel-heading">
+                            <div class="panel-title"><a data-toggle="collapse" href="#collapseGraphs" data-target="#graphs"><i
+                                    class="fa fa-chevron-down"></i> Images</a></div>
+                        </div>
+                        <div class="panel-body collapse in" id="graphs">
+                            {% for graph in run.graph %}
+                                <div class="text-center"><a href="{{ graph }}" target="_blank"><img src="{{ graph }}"/></a>
+                                </div>
+                            {% endfor %}
+                        </div>
                     </div>
-                    <div class="panel-body collapse in" id="graphs">
-                        {% for graph in run.graph %}
-                            <div class="text-center"><a href="{{ graph }}" target="_blank"><img src="{{ graph }}"/></a>
-                            </div>
-                        {% endfor %}
-                    </div>
-                </div>
-            {% endif %}
-            {% if reduction_variables_on %}
-                {% autoescape on %}
-                    {% view "reduction_variables.views.run_summary" run.instrument.name run.run_number run.run_version %}
-                {% endautoescape %}
-            {% endif %}
-        </div>
+                {% endif %}
+                {% if reduction_variables_on %}
+                    {% autoescape on %}
+                        {% view "reduction_variables.views.run_summary" run.instrument.name run.run_number run.run_version %}
+                    {% endautoescape %}
+                {% endif %}
+            </div>
+        {% endif %}
         <div class="run-history modal fade" tabindex="-1" role="dialog" aria-hidden="true">
             <div class="modal-dialog">
                 <div class="modal-content">

--- a/WebApp/autoreduce_webapp/templates/run_summary.html
+++ b/WebApp/autoreduce_webapp/templates/run_summary.html
@@ -90,10 +90,10 @@
                                 </div>
                                 <div>
                                     <strong>Finish:</strong>
-                                    {% if run.finished %}
-                                        {{ run.finished }}
-                                    {% elif is_skipped %}
+                                    {% if is_skipped %}
                                         <em>Not run</em>
+                                    {% elif run.finished %}
+                                        {{ run.finished }}
                                     {% else %}
                                         <em>Not yet finished</em>
                                     {% endif %}


### PR DESCRIPTION
### Summary of work
Alters the template for a skipped run
Changes start and end times, duration and hides logs and rerun option

This PR:
![image](https://user-images.githubusercontent.com/44777678/96744154-a5b7d600-13bc-11eb-986b-27e445f46375.png)


Current:
![image](https://user-images.githubusercontent.com/44777678/96743512-fe3aa380-13bb-11eb-8b26-5ce2ce781bf9.png)


### How to test your work
Skipped runs should match updated format

### Additional comments
<!---Anything else: e.g. was the estimate reasonable for this issue?---> 

Closes #853 


**Before merging ensure the release notes have been updated**