### PR TITLE
846 disable rerun for instruments with novariables

### DIFF
--- a/WebApp/autoreduce_webapp/reduction_viewer/views.py
+++ b/WebApp/autoreduce_webapp/reduction_viewer/views.py
@@ -274,7 +274,8 @@ def run_summary(_, instrument_name=None, run_number=None, run_version=0):
         rb_number = Experiment.objects.get(id=run.experiment_id).reference_number
         has_variables = bool(
             InstrumentVariablesUtils().get_default_variables(run.instrument.name)
-            or run.run_variables.all())
+            or run.run_variables.all()) # We check default vars and run vars in case none exist
+                                        # for run but could exist for default
 
         context_dictionary = {'run': run,
                               'is_skipped': is_skipped,
@@ -342,7 +343,7 @@ def instrument_summary(request, instrument=None):
         if len(runs) == 0:
             return {'message': "No runs found for instrument."}
 
-        has_variables = InstrumentVariablesUtils().get_default_variables(instrument_obj.name)
+        has_variables = bool(InstrumentVariablesUtils().get_default_variables(instrument_obj.name))
 
         context_dictionary = {
             'instrument': instrument_obj,

--- a/WebApp/autoreduce_webapp/reduction_viewer/views.py
+++ b/WebApp/autoreduce_webapp/reduction_viewer/views.py
@@ -339,6 +339,8 @@ def instrument_summary(request, instrument=None):
         if len(runs) == 0:
             return {'message': "No runs found for instrument."}
 
+        has_variables = InstrumentVariablesUtils().get_default_variables(instrument_obj.name)
+
         context_dictionary = {
             'instrument': instrument_obj,
             'instrument_name': instrument_obj.name,
@@ -347,7 +349,8 @@ def instrument_summary(request, instrument=None):
             'processing': runs.filter(status=StatusUtils().get_processing()),
             'queued': runs.filter(status=StatusUtils().get_queued()),
             'filtering': filter_by,
-            'sort': sort_by
+            'sort': sort_by,
+            'has_variables': has_variables
         }
 
         if filter_by == 'experiment':

--- a/WebApp/autoreduce_webapp/reduction_viewer/views.py
+++ b/WebApp/autoreduce_webapp/reduction_viewer/views.py
@@ -270,11 +270,15 @@ def run_summary(_, instrument_name=None, run_number=None, run_version=0):
             reduction_location = reduction_location.replace('\\', '/')
 
         rb_number = Experiment.objects.get(id=run.experiment_id).reference_number
+        has_variables = bool(
+            InstrumentVariablesUtils().get_default_variables(run.instrument.name)
+            or run.run_variables.all())
 
         context_dictionary = {'run': run,
                               'history': history,
                               'reduction_location': reduction_location,
-                              'started_by': started_by}
+                              'started_by': started_by,
+                              'has_variables': has_variables}
 
     except PermissionDenied:
         raise

--- a/WebApp/autoreduce_webapp/reduction_viewer/views.py
+++ b/WebApp/autoreduce_webapp/reduction_viewer/views.py
@@ -16,25 +16,24 @@ import json
 import logging
 import operator
 
+from autoreduce_webapp.icat_cache import ICATCache
+from autoreduce_webapp.settings import UOWS_LOGIN_URL, USER_ACCESS_CHECKS, DEVELOPMENT_MODE
+from autoreduce_webapp.uows_client import UOWSClient
+from autoreduce_webapp.view_utils import (login_and_uows_valid, render_with,
+                                          require_admin, check_permissions)
 from django.contrib.auth import logout as django_logout, authenticate, login
 from django.contrib.auth.models import User
 from django.core.exceptions import PermissionDenied, ObjectDoesNotExist
 from django.db.models import Q
 from django.http import JsonResponse, HttpResponseNotFound
 from django.shortcuts import redirect
-
-from autoreduce_webapp.icat_cache import ICATCache
-from autoreduce_webapp.settings import UOWS_LOGIN_URL, USER_ACCESS_CHECKS, DEVELOPMENT_MODE
-from autoreduce_webapp.uows_client import UOWSClient
-from autoreduce_webapp.view_utils import (login_and_uows_valid, render_with,
-                                          require_admin, check_permissions)
-from plotting.plot_handler import PlotHandler
-from reduction_variables.utils import MessagingUtils
+from reduction_variables.utils import InstrumentVariablesUtils, MessagingUtils
 from reduction_viewer.models import Experiment, ReductionRun, Instrument, Status
 from reduction_viewer.utils import StatusUtils, ReductionRunUtils
 from reduction_viewer.view_utils import deactivate_invalid_instruments
 from utilities.pagination import CustomPaginator
 
+from plotting.plot_handler import PlotHandler
 from utils.settings import VALID_INSTRUMENTS
 
 LOGGER = logging.getLogger('app')

--- a/WebApp/autoreduce_webapp/templates/instrument_summary.html
+++ b/WebApp/autoreduce_webapp/templates/instrument_summary.html
@@ -43,11 +43,13 @@
             </div>
 
             <!-- Re-run past runs button -->
-            <div class="col-md-6 text-center" id="btn-re-run_past_job">
-                <p><a href="{% url 'instrument_submit_runs' instrument=instrument_name %}"
-                      class="btn btn-success btn-block"><i class="fa fa-arrow-left"></i>&nbsp;&nbsp;Re-run
-                    past jobs</a></p>
-            </div>
+            {% if has_variables %}
+                <div class="col-md-6 text-center" id="btn-re-run_past_job">
+                    <p><a href="{% url 'instrument_submit_runs' instrument=instrument_name %}"
+                          class="btn btn-success btn-block"><i class="fa fa-arrow-left"></i>&nbsp;&nbsp;Re-run
+                        past jobs</a></p>
+                </div>
+            {% endif %}
 
             <!-- Configure new runs button -->
             <div class="col-md-6 text-center" id="btn-configure_new_jobs">
@@ -55,7 +57,8 @@
                       class="btn btn-success btn-block"><i class="fa fa-plus"></i>&nbsp;&nbsp;Configure
                     New Jobs</a></p>
             </div>
-            {% if reduction_variables_on %}
+
+            {% if reduction_variables_on and has_variables %}
                 <div class="col-md-6 text-center" id="btn-see_instrument_variables">
                     <p><a href="{% url 'instrument_variables_summary' instrument=instrument_name %}"
                           class="btn btn-success btn-block"><i class="fa fa-eye"></i>&nbsp;&nbsp;See

--- a/WebApp/autoreduce_webapp/templates/run_summary.html
+++ b/WebApp/autoreduce_webapp/templates/run_summary.html
@@ -180,7 +180,7 @@
                     </div>
                 </div>
             {% endif %}
-            {% if reduction_variables_on %}
+            {% if reduction_variables_on and has_variables%}
                 {% autoescape on %}
                     {% view "reduction_variables.views.run_summary" run.instrument.name run.run_number run.run_version %}
                 {% endautoescape %}


### PR DESCRIPTION
### Summary of work
Removes the option to rerun jobs through the WebApp if an instrument does not have variables. (As is currently the case only for WISH)

### How to test your work
<!---This can be a link to the---> 
Check that the rerun option in the run-summary and instrument-summary do not appear for WISH only.


### Additional comments
<!---Anything else: e.g. was the estimate reasonable for this issue?---> 

closes #846


**Before merging ensure the release notes have been updated**