### PR TITLE
Implements fix for correctly updating the Python dicts

### DIFF
--- a/queue_processors/autoreduction_processor/post_process_admin.py
+++ b/queue_processors/autoreduction_processor/post_process_admin.py
@@ -117,7 +117,8 @@ class PostProcessAdmin:
 
         if not hasattr(reduce_script, "web_var"):
             reduce_script.web_var = types.ModuleType("reduce_vars")
-        map(merge_dicts, ["standard_vars", "advanced_vars"])
+        merge_dicts("standard_vars")
+        merge_dicts("advanced_vars")
         return reduce_script
 
     @staticmethod


### PR DESCRIPTION
### Summary of work
Replaces the map with the 2 manual calls.

### How to test your work
Run webapp locally with the fix and resubmit a job with changed parameters. The parameters from the WebApp should now override the standard parameters

Have a look at this comment https://github.com/ISISScientificComputing/autoreduce/issues/870#issuecomment-717188785

Fixes #870 


Release notes added to the release notes PR in commit https://github.com/ISISScientificComputing/autoreduce/commit/9f9f19f5d569a34780c8b79ab7e32faad71d41d0