### PR TITLE
Fix manual submission failing when instrument is not in VALID_INSTRUMENTS

### DIFF
--- a/scripts/manual_operations/manual_submission.py
+++ b/scripts/manual_operations/manual_submission.py
@@ -87,7 +87,7 @@ def get_location_and_rb_from_icat(icat_client, instrument, run_number, file_ext)
         print("ICAT not connected")  # pragma: no cover
         sys.exit(1)  # pragma: no cover
 
-    icat_instrument_prefix = get_icat_instrument_prefix()[instrument]
+    icat_instrument_prefix = get_icat_instrument_prefix(instrument)
     file_name = f"{icat_instrument_prefix}{str(run_number).zfill(5)}.{file_ext}"
     datafile = icat_client.execute_query("SELECT df FROM Datafile df WHERE df.name = '"
                                          + file_name +

--- a/scripts/manual_operations/tests/test_manual_submission.py
+++ b/scripts/manual_operations/tests/test_manual_submission.py
@@ -114,7 +114,7 @@ class TestManualSubmission(unittest.TestCase):
         self.assertEqual(location_and_rb, self.valid_return)
 
     @patch('scripts.manual_operations.manual_submission.get_icat_instrument_prefix',
-           return_value={'MARI': 'MAR'})
+           return_value='MAR')
     def test_icat_uses_prefix_mapper(self, _):
         """
         Test: The instrument shorthand name is used

--- a/utils/clients/tools/isisicat_prefix_mapping.py
+++ b/utils/clients/tools/isisicat_prefix_mapping.py
@@ -8,42 +8,31 @@
 get_icat_instrument_prefix() can be used to map Autoreduction to ICAT instrument prefixes
 """
 from utils.clients.icat_client import ICATClient
-from utils.settings import VALID_INSTRUMENTS as AUTOREDUCTION_INSTRUMENT_NAMES
 from utils.clients.tools.isisicat_prefix_mapping_logging_setup import logger
 
 
-def get_icat_instrument_prefix(autoreduction_instruments=None):
+def get_icat_instrument_prefix(instrument_fullname: str) -> str:
     """
     Queries ICAT for shorter names for all Autoreduction instruments or only selection if passed in
     :param autoreduction_instruments: Optionally input custom list of autoreduction instrument names
     :return: A map of Autoreduction to ICAT instrument prefixes
     """
-    if not autoreduction_instruments:
-        autoreduction_instruments = AUTOREDUCTION_INSTRUMENT_NAMES
-
     client = ICATClient()
 
     try:
         icat_instruments = client.execute_query("SELECT i FROM Instrument i")
-    except Exception:  # pylint:disable=broad-except
+    except Exception as exc:
         warning_message = "ICAT instrument query failed"
         print(warning_message)
         logger.warning(warning_message)
-        return None
+        raise RuntimeError(warning_message) from exc
 
-    instrument_fullname_to_short_name_map = {}
+    icat_instrument = next((x for x in icat_instruments if x.fullName == instrument_fullname), None)
 
-    for instrument_fullname in autoreduction_instruments:
-        icat_instrument = next((x for x in icat_instruments if x.fullName == instrument_fullname),
-                               None)
+    if not icat_instrument:
+        warning_message = f"No instrument in ICAT with fullName {instrument_fullname}"
+        print(warning_message)
+        logger.warning(warning_message)
+        raise RuntimeError(f"Instrument with fullname {instrument_fullname} not found in ICAT.")
 
-        if not icat_instrument:
-            warning_message = f"No instrument in ICAT with fullName {instrument_fullname}"
-            print(warning_message)
-            logger.warning(warning_message)
-            # Missing an instrument should also be picked up in the tests
-            continue
-
-        instrument_fullname_to_short_name_map[instrument_fullname] = icat_instrument.name
-
-    return instrument_fullname_to_short_name_map
+    return icat_instrument.name

--- a/utils/clients/tools/tests/test_isisicat_prefix_mapping.py
+++ b/utils/clients/tools/tests/test_isisicat_prefix_mapping.py
@@ -18,7 +18,6 @@ class MockInstrumentQueryResult:
     """
     Mocks result of isisicat_prefix_mapping.client.execute_query for an instrument
     """
-
     def __init__(self, name, full_name):
         self.name = name
         # camelCase used due to mocking of external class
@@ -32,68 +31,35 @@ class TestICATPrefixMapping(unittest.TestCase):
     DIR = "utils.clients.tools.isisicat_prefix_mapping"
 
     @patch('icat.Client.__init__', return_value=None)
-    @patch(f"{DIR}.AUTOREDUCTION_INSTRUMENT_NAMES", ['ENGINGX'])
-    @patch('utils.clients.icat_client.ICATClient.execute_query')
+    @patch('utils.clients.icat_client.ICATClient.execute_query',
+           return_value=[MockInstrumentQueryResult("ENG", "ENGINX")])
     def test_get_icat_instrument_prefix_executes_icat_query(self, mock_execute_query, _):
         """
         Test: If instruments are fetched through a query
         When: Testing if get_icat_instrument_prefix executes an ICAT query
         """
-        get_icat_instrument_prefix()
+        self.assertEqual("ENG", get_icat_instrument_prefix("ENGINX"))
         mock_execute_query.assert_called_once()
 
     @patch('icat.Client.__init__', return_value=None)
-    @patch(f"{DIR}.AUTOREDUCTION_INSTRUMENT_NAMES", ['INVALIDINSTUMENT'])
+    @patch('utils.clients.icat_client.ICATClient.execute_query', side_effect=Exception)
+    def test_get_icat_instrument_prefix_icat_query_raises(self, mock_execute_query, _):
+        """
+        Test: If the query raises due to a connection issue or wrong credentials
+        When: Testing if get_icat_instrument_prefix executes an ICAT query
+        """
+        self.assertRaises(RuntimeError, get_icat_instrument_prefix, "ENGINX")
+        mock_execute_query.assert_called_once()
+
+    @patch('icat.Client.__init__', return_value=None)
     @patch('logging.Logger.warning')
-    @patch('utils.clients.icat_client.ICATClient.execute_query')
+    @patch('utils.clients.icat_client.ICATClient.execute_query',
+           return_value=[MockInstrumentQueryResult("ENG", "ENGINX")])
     def test_get_icat_instrument_prefix_log_invalid_instrument(self, _mock_execute_query,
                                                                mock_logger_warning, _):
         """
         Test: If invalid instrument name in utils.settings.VALID_INSTRUMENTS is logged as not found
         When: Testing if get_icat_instrument_prefix picks up invalid instruments
         """
-        get_icat_instrument_prefix()
+        self.assertRaises(RuntimeError, get_icat_instrument_prefix, "INVALIDINSTRUMENT")
         mock_logger_warning.assert_called_once()
-
-    @patch('icat.Client.__init__', return_value=None)
-    @patch(f"{DIR}.AUTOREDUCTION_INSTRUMENT_NAMES", ["ENGINX", "GEM"])
-    @patch('utils.clients.icat_client.ICATClient.execute_query',
-           return_value=[MockInstrumentQueryResult("ENG", "ENGINX"),
-                         MockInstrumentQueryResult("GEM", "GEM")])
-    def test_icat_prefix_mapping_length(self, _mock_instruments, _mock_execute_query):
-        """
-        Test: get_icat_instrument_prefix produces the same number of results as stored in
-              utils.settings.VALID_INSTRUMENTS
-        When: Called when testing to see if the correct number of instruments in prefix mapping
-        """
-        actual = get_icat_instrument_prefix()
-        self.assertEqual(2, len(actual.keys()))
-
-    @patch('icat.Client.__init__', return_value=None)
-    @patch('utils.clients.icat_client.ICATClient.execute_query')
-    @patch(f"{DIR}.AUTOREDUCTION_INSTRUMENT_NAMES", ["ENGINX"])
-    def test_get_icat_instrument_prefix_without_argument(self, mock_execute_query, _):
-        """
-        Test: If get_icat_instrument_prefix properly maps instrument names map to ICAT
-              instrument prefixes using utils.settings.VALID_INSTRUMENTS
-        When: Called when testing correct mapping
-        """
-        expected = ("ENG", "ENGINX")
-        mock_execute_query.return_value = [MockInstrumentQueryResult(*expected)]
-
-        actual = get_icat_instrument_prefix()
-        self.assertEqual(expected[0], actual[expected[1]])
-
-    @patch('icat.Client.__init__', return_value=None)
-    @patch('utils.clients.icat_client.ICATClient.execute_query')
-    def test_get_icat_instrument_prefix_with_argument(self, mock_execute_query, _):
-        """
-        Test: If get_icat_instrument_prefix properly maps instrument names map to ICAT
-              instrument prefixes using a passed in list of instruments to check
-        When: Called when testing correct mapping using passed in list
-        """
-        expected = ("ENG", "ENGINX")
-        mock_execute_query.return_value = [MockInstrumentQueryResult(*expected)]
-
-        actual = get_icat_instrument_prefix([expected[1]])
-        self.assertEqual(expected[0], actual[expected[1]])


### PR DESCRIPTION
### Summary of work

This was causing an issue that an instrument missing in VALID_INSTRUMENTS, but valid overall, would fail during submission.

The logic for retrieving the instrument's name from ICAT was changed - `get_icat_instrument_prefix` now takes a full name and returns the ICAT name.

The behaviour where the function would take a list of instruments and return a dictionary of `{fullname: ICAT name}` was never used outside of tests, and has been removed.

The tests were adjusted to test the new behaviour, and the tests testing the multiple return behaviour have been removed.

Fixes #842

### How to test your work
- Delete any instrument from your valid instruments, e.g. remove LARMOR
- Try manually submitting a run for it - with the changes it should be successfully submitted

### Additional comments
Note: this is based on the release branch and will be merged into master afterwards!