### PR TITLE
Fix manual_remove multiple version bug

### DIFF
--- a/scripts/manual_operations/manual_remove.py
+++ b/scripts/manual_operations/manual_remove.py
@@ -91,7 +91,7 @@ class ManualRemove:
         # Remove runs that the user does NOT want to delete from the delete list
         for reduction_job in self.to_delete[run_number]:
             if not int(reduction_job.run_version) in user_input:
-                # this excludes the versions that the user DID NOT type
+                # this removes the versions that the user DID NOT enter
                 # from the list of run versions that will be DELETED
                 self.to_delete[run_number].remove(reduction_job)
 

--- a/scripts/manual_operations/manual_remove.py
+++ b/scripts/manual_operations/manual_remove.py
@@ -43,7 +43,7 @@ class ManualRemove:
             .filter(instrument=instrument_record.id) \
             .filter(run_number=run_number) \
             .order_by('-created')
-        self.to_delete[run_number] = result
+        self.to_delete[run_number] = list(result)
         return result
 
     def process_results(self):
@@ -93,8 +93,7 @@ class ManualRemove:
             if not int(reduction_job.run_version) in user_input:
                 # this excludes the versions that the user DID NOT type
                 # from the list of run versions that will be DELETED
-                self.to_delete[run_number] = self.to_delete[run_number].exclude(
-                    run_version=reduction_job.run_version)
+                self.to_delete[run_number].remove(reduction_job)
 
     def delete_records(self):
         """

--- a/scripts/manual_operations/manual_remove.py
+++ b/scripts/manual_operations/manual_remove.py
@@ -91,6 +91,8 @@ class ManualRemove:
         # Remove runs that the user does NOT want to delete from the delete list
         for reduction_job in self.to_delete[run_number]:
             if not int(reduction_job.run_version) in user_input:
+                # this excludes the versions that the user DID NOT type
+                # from the list of run versions that will be DELETED
                 self.to_delete[run_number] = self.to_delete[run_number].exclude(
                     run_version=reduction_job.run_version)
 

--- a/scripts/manual_operations/manual_remove.py
+++ b/scripts/manual_operations/manual_remove.py
@@ -91,7 +91,8 @@ class ManualRemove:
         # Remove runs that the user does NOT want to delete from the delete list
         for reduction_job in self.to_delete[run_number]:
             if not int(reduction_job.run_version) in user_input:
-                self.to_delete[run_number].remove(reduction_job)
+                self.to_delete[run_number] = self.to_delete[run_number].exclude(
+                    run_version=reduction_job.run_version)
 
     def delete_records(self):
         """
@@ -102,7 +103,7 @@ class ManualRemove:
         for run_number, job_list in to_delete_copy.items():
             for version in job_list:
                 # Delete the specified version
-                print('{}{}:'.format(self.instrument, run_number))
+                print(f'{self.instrument}{run_number} - v{version.run_version}')
                 self.delete_reduction_location(version.id)
                 self.delete_data_location(version.id)
                 self.delete_variables(version.id)

--- a/scripts/manual_operations/manual_remove.py
+++ b/scripts/manual_operations/manual_remove.py
@@ -89,11 +89,10 @@ class ManualRemove:
             input_valid, user_input = self.validate_csv_input(user_input)
 
         # Remove runs that the user does NOT want to delete from the delete list
-        for reduction_job in self.to_delete[run_number]:
-            if not int(reduction_job.run_version) in user_input:
-                # this removes the versions that the user DID NOT enter
-                # from the list of run versions that will be DELETED
-                self.to_delete[run_number].remove(reduction_job)
+        self.to_delete[run_number] = [
+            reduction_job for reduction_job in self.to_delete[run_number]
+            if reduction_job.run_version in user_input
+        ]
 
     def delete_records(self):
         """

--- a/scripts/manual_operations/tests/test_manual_remove.py
+++ b/scripts/manual_operations/tests/test_manual_remove.py
@@ -150,7 +150,7 @@ class TestManualRemove(unittest.TestCase):
                                                self.gem_object_2]
         self.assertEqual(2, len(self.manual_remove.to_delete['123']))
         mock_input.return_value = '1,2'
-        mock_validate_csv.return_value = (True, [1, 2])
+        mock_validate_csv.return_value = (True, ['1', '2'])
         self.manual_remove.multiple_versions_found('123')
         # We said to delete version 2 so it should be the only entry for that run number
         self.assertEqual(2, len(self.manual_remove.to_delete['123']))

--- a/scripts/manual_operations/tests/test_manual_remove.py
+++ b/scripts/manual_operations/tests/test_manual_remove.py
@@ -117,7 +117,7 @@ class TestManualRemove(unittest.TestCase):
                                                self.gem_object_2]
         self.assertEqual(2, len(self.manual_remove.to_delete['123']))
         mock_input.return_value = '2'
-        mock_validate_csv.return_value = (True, [2])
+        mock_validate_csv.return_value = (True, ['2'])
         self.manual_remove.multiple_versions_found('123')
         # We said to delete version 2 so it should be the only entry for that run number
         self.assertEqual(1, len(self.manual_remove.to_delete['123']))
@@ -134,7 +134,7 @@ class TestManualRemove(unittest.TestCase):
                                                self.gem_object_2]
         self.assertEqual(2, len(self.manual_remove.to_delete['123']))
         mock_input.side_effect = ['invalid', '2']
-        mock_validate_csv.side_effect = [(False, []), (True, [2])]
+        mock_validate_csv.side_effect = [(False, []), (True, ['2'])]
         self.manual_remove.multiple_versions_found('123')
         self.assertEqual(2, mock_validate_csv.call_count)
         mock_validate_csv.assert_has_calls([call('invalid'), call('2')])


### PR DESCRIPTION
### Summary of work
* Fixed functionality to manually remove a run for a given instrument when multiple versions exists

### How to test your work
* Code review
* All tests pass
* Try removing a run using the `manual_remove.py` script for 1 or multiple versions

Fixes #669 