### PR TITLE
Fix sessionid typo which is causing a 500 error on the web app

### DIFF
--- a/WebApp/autoreduce_webapp/reduction_viewer/views.py
+++ b/WebApp/autoreduce_webapp/reduction_viewer/views.py
@@ -61,7 +61,7 @@ def index(request):
     else:
         if 'sessionid' in request.session.keys():
             authenticated = request.user.is_authenticated \
-                            and UOWSClient().check_session(request.session['sessionId'])
+                            and UOWSClient().check_session(request.session['sessionid'])
 
     if authenticated:
         if request.GET.get('next'):


### PR DESCRIPTION
### Summary of work
* Changed `sessionId` to `sessionid` in `reduction_viewer.views.index()`

### How to test your work
* Load the web app at `/` and see that it does not produces a 500 error

### Additional comments
* This was a tricky one to spot!

 Fixes #882