### PR TITLE
Fix the failing test

### DIFF
--- a/utils/data_archive/tests/test_file_filter.py
+++ b/utils/data_archive/tests/test_file_filter.py
@@ -120,6 +120,7 @@ class TestTimeFilterFiles(unittest.TestCase):
             with open(file_path, 'w+') as new_file:
                 new_file.write("test_file")
         actual = filter_files_by_time(self.test_output_directory, cut_off)
+        # We use a counter as we cannot guarantee the order of the return from os.listdir
         self.assertEqual(Counter(actual), Counter(new_file_paths))
 
     def test_filter_files_by_time_with_timestamp(self):

--- a/utils/data_archive/tests/test_file_filter.py
+++ b/utils/data_archive/tests/test_file_filter.py
@@ -13,6 +13,7 @@ import shutil
 import time
 import tempfile
 import unittest
+from collections import Counter
 
 from utils.data_archive.file_filter import (check_file_extension,
                                             filter_files_by_extension,
@@ -119,7 +120,7 @@ class TestTimeFilterFiles(unittest.TestCase):
             with open(file_path, 'w+') as new_file:
                 new_file.write("test_file")
         actual = filter_files_by_time(self.test_output_directory, cut_off)
-        self.assertEqual(actual, new_file_paths)
+        self.assertEqual(Counter(actual), Counter(new_file_paths))
 
     def test_filter_files_by_time_with_timestamp(self):
         """


### PR DESCRIPTION
### Summary of work
From what I understand from reading the docs `os.listdir` will return in an arbitrary order. The test assumes the order will remain the same, the order is sometimes differing in the workflow vm. So instead we compare the lists ignoring order using a `Counter`. Since the order is irrelevant for the purpose of the function anyway (based on its docstring). 


### Additional comments
<!---Anything else: e.g. was the estimate reasonable for this issue?---> 

Fixes #931


**Before merging ensure the release notes have been updated**