### PR TITLE
Use ReduceRun.delete() to delete a run, adds `--delete-all-versions` flag

### DIFF
--- a/scripts/manual_operations/manual_remove.py
+++ b/scripts/manual_operations/manual_remove.py
@@ -46,7 +46,7 @@ class ManualRemove:
         self.to_delete[run_number] = list(result)
         return result
 
-    def process_results(self):
+    def process_results(self, delete_all_versions: bool):
         """
         Process all the results what to do with the run based on the result of database query
         """
@@ -56,7 +56,7 @@ class ManualRemove:
                 self.run_not_found(run_number=key)
             if len(value) == 1:
                 continue
-            if len(value) > 1:
+            if len(value) > 1 and not delete_all_versions:
                 self.multiple_versions_found(run_number=key)
 
     def run_not_found(self, run_number):
@@ -139,7 +139,7 @@ class ManualRemove:
         return True, processed_input
 
 
-def remove(instrument, run_number):
+def remove(instrument, run_number, delete_all_versions:bool):
     """
     Run the remove script for an instrument and run_number
     :param instrument: (str) Instrument to run on
@@ -147,7 +147,7 @@ def remove(instrument, run_number):
     """
     manual_remove = ManualRemove(instrument)
     manual_remove.find_run_versions_in_database(run_number)
-    manual_remove.process_results()
+    manual_remove.process_results(delete_all_versions)
     manual_remove.delete_records()
 
 
@@ -171,12 +171,13 @@ def user_input_check(instrument, run_numbers):
     return user_input
 
 
-def main(instrument: str, first_run: int, last_run: int = None):
+def main(instrument: str, first_run: int, last_run: int = None, delete_all_versions=False):
     """
     Parse user input and run the script to remove runs for a given instrument
     :param instrument: (str) Instrument to run on
     :param first_run: (int) First run to be removed
     :param last_run: (int) Optional last run to be removed
+    :param delete_all_versions: (bool) Deletes all versions for a run without asking
     """
     run_numbers = get_run_range(first_run, last_run=last_run)
 
@@ -188,7 +189,7 @@ def main(instrument: str, first_run: int, last_run: int = None):
             sys.exit()
 
     for run in run_numbers:
-        remove(instrument, run)
+        remove(instrument, run, delete_all_versions)
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/scripts/manual_operations/manual_remove.py
+++ b/scripts/manual_operations/manual_remove.py
@@ -102,62 +102,8 @@ class ManualRemove:
         to_delete_copy = self.to_delete.copy()
         for run_number, job_list in to_delete_copy.items():
             for version in job_list:
-                # Delete the specified version
                 print(f'Deleting {self.instrument}{run_number} - v{version.run_version}')
-                self.delete_reduction_location(version.id)
-                self.delete_data_location(version.id)
-                self.delete_variables(version.id)
-                self.delete_reduction_run(version.id)
-
-            # Remove deleted run from dictionary
-            del self.to_delete[run_number]
-
-    def delete_reduction_location(self, reduction_run_id):
-        """
-        Delete a ReductionLocation record from the database
-        :param reduction_run_id: (int) The id of the associated reduction job
-        """
-        self.database.data_model.ReductionLocation.objects \
-            .filter(reduction_run_id=reduction_run_id) \
-            .delete()
-
-    def delete_data_location(self, reduction_run_id):
-        """
-        Delete a DataLocation record from the database
-        :param reduction_run_id: (int) The id of the associated reduction job
-        """
-        self.database.data_model.DataLocation.objects \
-            .filter(reduction_run_id=reduction_run_id) \
-            .delete()
-
-    def delete_variables(self, reduction_run_id):
-        """
-        Removes all the RunVariable records associated with a given ReductionRun from the database
-        :param reduction_run_id: (int) The id of the associated reduction job
-        """
-        run_variables = self.find_variables_of_reduction(reduction_run_id)
-        for record in run_variables:
-            self.database.variable_model.RunVariable.objects \
-                .filter(variable_ptr_id=record.variable_ptr_id) \
-                .delete()
-
-    def find_variables_of_reduction(self, reduction_run_id):
-        """
-        Find all the RunVariable records in the database associated with a reduction job
-        :param reduction_run_id: (int) The id of the reduction job to filter by
-        :return: (QuerySet) of the associated RunVariables
-        """
-        return self.database.variable_model.RunVariable.objects \
-            .filter(reduction_run_id=reduction_run_id)
-
-    def delete_reduction_run(self, reduction_run_id):
-        """
-        Delete a ReductionRun record from the database
-        :param reduction_run_id: (int) The id of the associated reduction job
-        """
-        self.database.data_model.ReductionRun.objects \
-            .filter(id=reduction_run_id) \
-            .delete()
+                version.delete()
 
     @staticmethod
     def validate_csv_input(user_input):

--- a/scripts/manual_operations/manual_remove.py
+++ b/scripts/manual_operations/manual_remove.py
@@ -12,17 +12,16 @@ from __future__ import print_function
 import sys
 
 import fire
-
+from django.db import IntegrityError
+from model.database import access as db
 from scripts.manual_operations.util import get_run_range
 from utils.clients.django_database_client import DatabaseClient
-from model.database import access as db
 
 
 class ManualRemove:
     """
     Handles removing a run from the database
     """
-
     def __init__(self, instrument):
         """
         :param instrument: (str) The name of the instrument associated with runs
@@ -199,7 +198,7 @@ class ManualRemove:
         return True, processed_input
 
 
-def remove(instrument, run_number, delete_all_versions:bool):
+def remove(instrument, run_number, delete_all_versions: bool):
     """
     Run the remove script for an instrument and run_number
     :param instrument: (str) Instrument to run on

--- a/scripts/manual_operations/tests/test_manual_remove.py
+++ b/scripts/manual_operations/tests/test_manual_remove.py
@@ -134,8 +134,7 @@ class TestManualRemove(unittest.TestCase):
         Test: That the user is not asked more than once for input
         When: The input is valid
         """
-        self.manual_remove.to_delete['123'] = [self.gem_object_1,
-                                               self.gem_object_2]
+        self.manual_remove.to_delete['123'] = [self.gem_object_1, self.gem_object_2]
         mock_input.return_value = '2'
         mock_validate_csv.return_value = (True, ['2'])
         self.manual_remove.multiple_versions_found('123')
@@ -150,8 +149,7 @@ class TestManualRemove(unittest.TestCase):
         Test: Input is re-validated
         When: The user initially gives incorrect input
         """
-        self.manual_remove.to_delete['123'] = [self.gem_object_1,
-                                               self.gem_object_2]
+        self.manual_remove.to_delete['123'] = [self.gem_object_1, self.gem_object_2]
         mock_input.side_effect = ['invalid', '2']
         mock_validate_csv.side_effect = [(False, []), (True, ['2'])]
         self.manual_remove.multiple_versions_found('123')
@@ -166,8 +164,7 @@ class TestManualRemove(unittest.TestCase):
         Test: That manual_remove will remove one run version
         When: Multiple versions are found for a run and one version is inputted
         """
-        self.manual_remove.to_delete['123'] = [self.gem_object_1,
-                                               self.gem_object_2]
+        self.manual_remove.to_delete['123'] = [self.gem_object_1, self.gem_object_2]
         mock_input.return_value = '2'
         mock_validate_csv.return_value = (True, ['2'])
         self.manual_remove.multiple_versions_found('123')
@@ -183,8 +180,7 @@ class TestManualRemove(unittest.TestCase):
         Test: The correct versions are deleted
         When: The user asks to delete two run versions as an inputted list
         """
-        self.manual_remove.to_delete['123'] = [self.gem_object_1,
-                                               self.gem_object_3]
+        self.manual_remove.to_delete['123'] = [self.gem_object_1, self.gem_object_3]
         mock_input.return_value = '1,3'
         mock_validate_csv.return_value = (True, ['1', '3'])
         self.manual_remove.multiple_versions_found('123')
@@ -201,9 +197,9 @@ class TestManualRemove(unittest.TestCase):
         Test: That the correct versions are deleted
         When: The user asks to delete a range of versions
         """
-        self.manual_remove.to_delete['123'] = [self.gem_object_1,
-                                               self.gem_object_2,
-                                               self.gem_object_3]
+        self.manual_remove.to_delete['123'] = [
+            self.gem_object_1, self.gem_object_2, self.gem_object_3
+        ]
         mock_input.return_value = '1-3'
         mock_validate_csv.return_value = (True, ['1', '2', '3'])
         self.manual_remove.multiple_versions_found('123')
@@ -221,9 +217,9 @@ class TestManualRemove(unittest.TestCase):
         Test: That the correct versions are deleted
         When: The user asks to delete a range of versions in reverse
         """
-        self.manual_remove.to_delete['123'] = [self.gem_object_1,
-                                               self.gem_object_2,
-                                               self.gem_object_3]
+        self.manual_remove.to_delete['123'] = [
+            self.gem_object_1, self.gem_object_2, self.gem_object_3
+        ]
         mock_input.return_value = '3-1'
         mock_validate_csv.return_value = (True, ['1', '2', '3'])
         self.manual_remove.multiple_versions_found('123')
@@ -416,8 +412,10 @@ class TestManualRemove(unittest.TestCase):
         Test: ALL variable records are successfully deleted from the database
         When: Delete_variables function is called.
         """
-        mock_run_variables = [self._run_variable(variable_ptr_id=3),
-                              self._run_variable(variable_ptr_id=5)]
+        mock_run_variables = [
+            self._run_variable(variable_ptr_id=3),
+            self._run_variable(variable_ptr_id=5)
+        ]
         mock_find_vars.return_value = mock_run_variables
         mock_variable_model = Mock()
         self.manual_remove.database.variable_model = mock_variable_model

--- a/systemtests/test_end_to_end.py
+++ b/systemtests/test_end_to_end.py
@@ -205,7 +205,7 @@ if os.name != 'nt':
             Uses the scripts.manual_operations.manual_remove script
             to remove records added to the database
             """
-            remove.remove(instrument, run_number)
+            remove.remove(instrument, run_number, delete_all_versions=False)
 
         @staticmethod
         def _delete_reduction_directory():


### PR DESCRIPTION
### Summary of work
- Tries to call the `.delete()` on the `ReducedRun` model. Everything else should get deleted via the on delete cascade.
	- It seems like this isn't always the case! Sometimes the DB raises an integrity error - as a workaround the code will revert to it's old behaviour then. This needs further investigation.

- Adds `--delete-all-versions` flag - specifying this means the script will no longer ask you to enter version range. It will just delete all versions for that run. 

### How to test your work
- Check that the related foreign key models aren't missing `on_delete=models.CASCADE` (I had a look but possible I missed something)
- This is a huge pain to test manually. The easiest (but not particularly easy) way that I recommend is to:
	- Run the script with a debugger attached. 
	- Breakpoint before or on `version.delete()` call
	- Run some of the previous queries in the debug terminal before the delete() gets executed
		- This should net you a QuerySet of some RunVariables / DataLocation (depending on which one you run)
	- Let the `delete()` execute
	- Run the previous query again - it should return you an empty QuerySet now

I checked that this happens while removing some runs from production today - it seems everything is being deleted as expected. If it wasn't deleting properly I'd also expect the DB to complain about consistency, but it might not if we don't have our relations set up correctly.

### Additional comments
<!---Anything else: e.g. was the estimate reasonable for this issue?---> 

Fixes #937 