### PR TITLE
Optimise queries in webapp

### DIFF
--- a/WebApp/autoreduce_webapp/reduction_viewer/views.py
+++ b/WebApp/autoreduce_webapp/reduction_viewer/views.py
@@ -335,13 +335,13 @@ def instrument_summary(request, instrument=None):
         sort_by = request.GET.get('sort', 'run')
         if sort_by == 'run':
             runs = (ReductionRun.objects
-                    .only('status', 'last_updated', 'run_number', 'run_version')
+                    .only('status', 'last_updated', 'run_number', 'run_version', 'run_name')
                     .select_related('status')
                     .filter(instrument=instrument_obj)
                     .order_by('-run_number', 'run_version'))
         else:
             runs = (ReductionRun.objects
-                    .only('status', 'last_updated', 'run_number', 'run_version')
+                    .only('status', 'last_updated', 'run_number', 'run_version', 'run_name')
                     .select_related('status')
                     .filter(instrument=instrument_obj)
                     .order_by('-last_updated'))

--- a/WebApp/autoreduce_webapp/templates/run_summary.html
+++ b/WebApp/autoreduce_webapp/templates/run_summary.html
@@ -12,7 +12,7 @@
         <div class="row">
             <div class="col-md-12 text-center">
                 <h2>Reduction Job #{{ run.title }}</h2>
-                {% if history.count > 1 %}
+                {% if is_rerun %}
                     <p>
                         (This run has been re-reduced,
                         <a href="#" class="js-reduction-run-history" id="run_history">see history</a>)
@@ -191,7 +191,7 @@
             {% endif %}
             {% if reduction_variables_on and has_variables%}
                 {% autoescape on %}
-                    {% view "reduction_variables.views.run_summary" run.instrument.name run.run_number run.run_version %}
+                    {% view "reduction_variables.views.run_summary" instrument run_number run_version %}
                 {% endautoescape %}
             {% endif %}
           </div>


### PR DESCRIPTION
### Summary of work
Combines some queries into single queries, casts a queryset to a list to prevent requerying for instrument summary and run summary pages

### How to test your work
Deploy the webapp on master branch.
View the instrument summary and run summary pages (HRPD has a lot of runs so is a good benchmark 78938 especially for run summary page)
Make note of how many queries and time in admin side panel
Redeploy this branch and visit the same pages and view the query differences.


### Additional comments
<!---Anything else: e.g. was the estimate reasonable for this issue?---> 

Fixes #940


**Before merging ensure the release notes have been updated**