### PR TITLE
Check if settings are configured before configuring

### DIFF
--- a/model/database/orm.py
+++ b/model/database/orm.py
@@ -53,11 +53,12 @@ class DjangoORM:
             # import here to avoid failure without calling add_webapp_path first
             # pylint:disable=import-outside-toplevel
             from WebApp.autoreduce_webapp.autoreduce_webapp.settings import DATABASES, ORM_INSTALL
-            settings.configure(
-                DATABASES=DATABASES,
-                INSTALLED_APPS=ORM_INSTALL,
-            )
-            django.setup()
+            if not settings.configured:
+                settings.configure(
+                    DATABASES=DATABASES,
+                    INSTALLED_APPS=ORM_INSTALL,
+                )
+                django.setup()
         except RuntimeError as excep:
             logging.warning("Exception raised when attempting to setup: %s", excep)
 


### PR DESCRIPTION
### Summary of work
Adds a check to `settings.configured` before configuring again. This prevents the exception and thus the logging spam.

### How to test your work
Stick a breakpoint in the `except RuntimeError` of  `orm.py::setup_django`, and run `test_manual_remove.py` - the breakpoint won't get triggered.

Optionally run without breakpoints and check that nothing new was logged.


Fixes #787


**Before merging ensure the release notes have been updated**