### PR TITLE
Remove broken reference to #previewScript in run_variables.js

### DIFF
--- a/WebApp/autoreduce_webapp/static/javascript/run_variables.js
+++ b/WebApp/autoreduce_webapp/static/javascript/run_variables.js
@@ -375,7 +375,6 @@
     };
 
     var init = function init() {
-        $('#run_variables,#instrument_variables,#submit_jobs').on('click', '#previewScript', previewScript);
         $('#script-preview-modal').on('click', '#downloadScript', downloadScript);
 
         $('#run_variables,#instrument_variables').on('click', '#resetValues', resetDefaultVariables);


### PR DESCRIPTION
### Summary of work
* Removed a line of code in `run_variables.js` that references a non-existent element `#previewScript`.

### How to test your work
* On the run summary page:
  * There should be no error in the console about `#previewScript`
  * Checking checkboxes and submitting forms should work.

Fixes #953