### PR TITLE
Use dash_core_components==1.12.1 for GitHub Actions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,7 @@ from build.commands.start import Start
 setup_requires = ['attrs==20.3.0',
                   'dash==1.16.3',
                   'dash_html_components==1.1.1',
+                  # dash 1.16.3 depends on dash-core-components==1.12.1
                   'dash_core_components==1.12.1',
                   'docker==4.4.0',
                   'Django==3.1.2',

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ from build.commands.start import Start
 setup_requires = ['attrs==20.3.0',
                   'dash==1.16.3',
                   'dash_html_components==1.1.1',
-                  'dash_core_components==1.13.0',
+                  'dash_core_components==1.12.1',
                   'docker==4.4.0',
                   'Django==3.1.2',
                   'django_extensions==3.0.9',


### PR DESCRIPTION
### Summary of work
* Use dash_core_components==1.12.1 because of dependency clash seen [here](https://github.com/ISISScientificComputing/autoreduce/runs/1474250570):
```
The conflict is caused by:
    autoreduction 20.3 depends on dash_core_components==1.13.0
    dash 1.16.3 depends on dash-core-components==1.12.1
```

### How to test your work
* Tests pass
