### PR TITLE
code-scan improve pr comment

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -98,5 +98,5 @@ jobs:
             $URL \
             -H "Content-Type: application/json" \
             -H "Authorization: token $GITHUB_TOKEN" \
-            --data '{ "body": "[**Code scanning has finished for '${{ matrix.language }}'**](https://github.com/'$GITHUB_REPOSITORY'/security/code-scanning?query=ref%3Arefs%2Fheads%2F'$GITHUB_REF'+is%3Aopen+)" }'
+            --data '{ "body": "[**Code scanning has finished for '${{ matrix.language }}'**](https://github.com/'$GITHUB_REPOSITORY'/security/code-scanning)" }'
 

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -51,7 +51,7 @@ jobs:
             $URL \
             -H "Content-Type: application/json" \
             -H "Authorization: token $GITHUB_TOKEN" \
-            --data '{ "body": "[**Code scanning is in progress...**](https://github.com/'$GITHUB_REPOSITORY'/actions/runs/'$GITHUB_RUN_ID')" }'
+            --data '{ "body": "[**Code scanning is in progress for '${{ matrix.language }}'...**](https://github.com/'$GITHUB_REPOSITORY'/actions/runs/'$GITHUB_RUN_ID')" }'
       
       - uses: actions/checkout@v2
       
@@ -88,7 +88,7 @@ jobs:
         uses: github/codeql-action/analyze@v1
       
       - name: Add comment to PR - Code scanning has finished
-        if: ${{ github.event.issue.pull_request }}
+        if: ${{ always() && github.event.issue.pull_request }}
         env:
           URL: ${{ github.event.issue.comments_url }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -98,5 +98,5 @@ jobs:
             $URL \
             -H "Content-Type: application/json" \
             -H "Authorization: token $GITHUB_TOKEN" \
-            --data '{ "body": "[**Code scanning has finished**](https://github.com/'$GITHUB_REPOSITORY'/security/code-scanning?query=ref%3Arefs%2Fheads%2F'$GITHUB_REF'+is%3Aopen+)" }'
+            --data '{ "body": "[**Code scanning has finished for '${{ matrix.language }}'**](https://github.com/'$GITHUB_REPOSITORY'/security/code-scanning?query=ref%3Arefs%2Fheads%2F'$GITHUB_REF'+is%3Aopen+)" }'
 


### PR DESCRIPTION
### Summary of work
* As seen [here](https://github.com/ISISScientificComputing/autoreduce/pull/977) identical comments are repeated for each language when running `/scan-code`. This PR adds "for language" to each PR comment.
* Also fixed the finished link and ensured the finished comment is added even if the previous steps fail.