### PR TITLE
Codeql analysis improvements

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,6 +1,7 @@
 name: "Code Scanning"
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - main

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -2,22 +2,17 @@ name: "Code Scanning"
 
 on:
   workflow_dispatch:
-  push:
-    branches:
-      - main
   schedule:
-    - cron: '0 6 * * 1' # Runs at 06:00 UTC on Monday
+    - cron: '0 5 * * 1' # Runs at 05:00 UTC on Monday
   issue_comment:
     types: [created]
   
-
 jobs:
   analyze:
     name: Analyze
     if: >
       (github.event.issue.pull_request && startsWith(github.event.comment.body, '/scan-code')) || 
-      github.event_name == 'schedule' || 
-      github.event_name == 'push' || 
+      (github.ref == 'refs/heads/master' && github.event_name == 'schedule') || 
       github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-18.04
     
@@ -54,12 +49,17 @@ jobs:
             -H "Authorization: token $GITHUB_TOKEN" \
             --data '{ "body": "[**Code scanning is in progress for '${{ matrix.language }}'...**](https://github.com/'$GITHUB_REPOSITORY'/actions/runs/'$GITHUB_RUN_ID')" }'
       
-      - uses: actions/checkout@v2
-      
-      # If this run was triggered by a pull request event, then checkout
-      # the head of the pull request instead of the merge commit.
-      - run: git checkout HEAD^2
-        if: ${{ github.event_name == 'pull_request' }}
+      - name: Get Branch name
+        id: branchName
+        run: |
+          echo ::set-output name=branch::$(echo $PR_COMMENT | cut -d "[" -f2 | cut -d "]" -f1)
+        env:
+          PR_COMMENT: ${{ github.event.comment.body }}
+          
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with: 
+          ref: ${{ steps.branchName.outputs.branch }}
       
       - name: Set up Python 3.7
         uses: actions/setup-python@v2
@@ -100,4 +100,3 @@ jobs:
             -H "Content-Type: application/json" \
             -H "Authorization: token $GITHUB_TOKEN" \
             --data '{ "body": "[**Code scanning has finished for '${{ matrix.language }}'**](https://github.com/'$GITHUB_REPOSITORY'/security/code-scanning)" }'
-

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -4,18 +4,11 @@ on:
   workflow_dispatch:
   schedule:
     - cron: '0 5 * * 1' # Runs at 05:00 UTC on Monday
-  issue_comment:
-    types: [created]
-  
+
 jobs:
   analyze:
     name: Analyze
-    if: >
-      (github.event.issue.pull_request && startsWith(github.event.comment.body, '/scan-code')) || 
-      github.event_name == 'schedule' || 
-      github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-18.04
-    
     services:
       mysql:
         image: mysql:5.7
@@ -29,37 +22,13 @@ jobs:
         options: >-
           --health-cmd="mysqladmin ping" --health-interval=10s 
           --health-timeout=5s --health-retries=3
-
     strategy:
       fail-fast: false
       matrix:
         language: ['python', 'javascript']
         
     steps:
-      - name: Add comment to PR - Code scanning is in progress
-        if: ${{ github.event.issue.pull_request }}
-        env:
-          URL: ${{ github.event.issue.comments_url }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          curl \
-            -X POST \
-            $URL \
-            -H "Content-Type: application/json" \
-            -H "Authorization: token $GITHUB_TOKEN" \
-            --data '{ "body": "[**Code scanning is in progress for '${{ matrix.language }}'...**](https://github.com/'$GITHUB_REPOSITORY'/actions/runs/'$GITHUB_RUN_ID')" }'
-      
-      - name: Get Branch name
-        if: ${{ always() && github.event.issue.pull_request }}
-        id: branchName
-        run: echo ::set-output name=branch::$(echo $PR_COMMENT | cut -d "[" -f2 | cut -d "]" -f1)
-        env:
-          PR_COMMENT: ${{ github.event.comment.body }}
-          
-      - name: Checkout code
-        uses: actions/checkout@v2
-        with: 
-          ref: ${{ steps.branchName.outputs.branch }}
+      - uses: actions/checkout@v2
       
       - name: Set up Python 3.7
         uses: actions/setup-python@v2
@@ -87,16 +56,3 @@ jobs:
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v1
-      
-      - name: Add comment to PR - Code scanning has finished
-        if: ${{ always() && github.event.issue.pull_request }}
-        env:
-          URL: ${{ github.event.issue.comments_url }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          curl \
-            -X POST \
-            $URL \
-            -H "Content-Type: application/json" \
-            -H "Authorization: token $GITHUB_TOKEN" \
-            --data '{ "body": "[**Code scanning has finished for '${{ matrix.language }}'**](https://github.com/'$GITHUB_REPOSITORY'/security/code-scanning?query=ref%3A'${{ steps.branchName.outputs.branch }}')" }'

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -12,7 +12,7 @@ jobs:
     name: Analyze
     if: >
       (github.event.issue.pull_request && startsWith(github.event.comment.body, '/scan-code')) || 
-      (github.ref == 'refs/heads/master' && github.event_name == 'schedule') || 
+      github.event_name == 'schedule' || 
       github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-18.04
     
@@ -50,9 +50,9 @@ jobs:
             --data '{ "body": "[**Code scanning is in progress for '${{ matrix.language }}'...**](https://github.com/'$GITHUB_REPOSITORY'/actions/runs/'$GITHUB_RUN_ID')" }'
       
       - name: Get Branch name
+        if: ${{ always() && github.event.issue.pull_request }}
         id: branchName
-        run: |
-          echo ::set-output name=branch::$(echo $PR_COMMENT | cut -d "[" -f2 | cut -d "]" -f1)
+        run: echo ::set-output name=branch::$(echo $PR_COMMENT | cut -d "[" -f2 | cut -d "]" -f1)
         env:
           PR_COMMENT: ${{ github.event.comment.body }}
           
@@ -99,4 +99,4 @@ jobs:
             $URL \
             -H "Content-Type: application/json" \
             -H "Authorization: token $GITHUB_TOKEN" \
-            --data '{ "body": "[**Code scanning has finished for '${{ matrix.language }}'**](https://github.com/'$GITHUB_REPOSITORY'/security/code-scanning)" }'
+            --data '{ "body": "[**Code scanning has finished for '${{ matrix.language }}'**](https://github.com/'$GITHUB_REPOSITORY'/security/code-scanning?query=ref%3A'${{ steps.branchName.outputs.branch }}')" }'


### PR DESCRIPTION
### Summary of work
* Run earlier on Monday's to make sure code scanning is complete before starting work.
* Removed on push event to master because 2nd warning here #990 states that on PR event needs to be added too.
* Removed `git checkout HEAD^2` because of warning here  #990
* Removed `/scan-code` PR comment feature in place of workflow [dispatch event](https://github.blog/changelog/2020-07-06-github-actions-manual-triggers-with-workflow_dispatch/).

### How to test your work
* Code review
* Merge and test features above

Fixes #990