### PR TITLE
Add on push event to master for code scanning workflow

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,6 +1,9 @@
 name: "Code Scanning"
 
 on:
+  push:
+    branches:
+      - main
   workflow_dispatch:
   schedule:
     - cron: '0 5 * * 1' # Runs at 05:00 UTC on Monday


### PR DESCRIPTION
### Summary of work
* Add on push to master event for code scanning workflow
* Fixes `Missing analysis for base commit` warning