### PR TITLE
Fix adding signing key comes before adding repo

### DIFF
--- a/build/install/mantid.sh
+++ b/build/install/mantid.sh
@@ -10,10 +10,11 @@ fi
 
 set -e
 
-# Add GPG key and upstream Mantid repo
-sudo apt-add-repository "deb [arch=amd64] http://apt.isis.rl.ac.uk $(lsb_release -c | cut -f 2) main" -y
 # add the signing key
 wget -O - http://apt.isis.rl.ac.uk/2E10C193726B7213.asc -q | sudo apt-key add -
+
+# Add GPG key and upstream Mantid repo
+sudo apt-add-repository "deb [arch=amd64] http://apt.isis.rl.ac.uk $(lsb_release -c | cut -f 2) main" -y
 sudo apt-add-repository ppa:mantid/mantid -y
 
 sudo apt-get update


### PR DESCRIPTION
### Summary of work
Swapped the order of two lines. Before, adding the repo came before adding the mantid signing key. Now, adding the signing key comes before adding the repo.

### How to test your work
Test by installing mantid:
sudo python setup.py externals -s mantid

### Additional comments

**Before merging ensure the release notes have been updated**