### PR TITLE
Fixes retrieving plots from CEPH

### DIFF
--- a/plotting/plot_handler.py
+++ b/plotting/plot_handler.py
@@ -115,7 +115,7 @@ class PlotHandler:
             client = SFTPClient()
             for plot_file in _existing_plot_files:
                 # Generate paths to data on server and destination on local machine
-                _server_path = self.server_dir + plot_file
+                _server_path = f"{self.server_dir}/{plot_file}"
                 _local_path = os.path.join(self.static_graph_dir, plot_file)
 
                 try:

--- a/plotting/tests/test_plot_handler.py
+++ b/plotting/tests/test_plot_handler.py
@@ -38,7 +38,7 @@ class TestPlotHandler(unittest.TestCase):
         self.expected_mari_file_regex = f'{self.expected_mari_data_filename}.*.{self.expected_file_extension_regex}'
         self.input_data_filepath = "\\\\isis\\inst$\\NDXMARI\\Instrument\\data\\cycle_test\\MARI1234.nxs"
         self.expected_mari_rb_number = 12345678
-        self.expected_mari_rb_folder = "/instrument/MARI/RBNumber/RB12345678/1234/autoreduced/"
+        self.expected_mari_rb_folder = "/instrument/MARI/RBNumber/RB12345678/1234/autoreduced"
 
         self.test_plot_handler = PlotHandler(data_filepath=self.input_data_filepath,
                                              server_dir=self.expected_mari_rb_folder,

--- a/plotting/tests/test_plot_handler.py
+++ b/plotting/tests/test_plot_handler.py
@@ -169,7 +169,7 @@ class TestPlotHandler(unittest.TestCase):
         expected_files = ['expected.png']
         mock_find_files.return_value = expected_files
         expected_local = os.path.join(self.expected_static_graph_dir, expected_files[0])
-        expected_server = self.expected_mari_rb_folder + expected_files[0]
+        expected_server = os.path.join(self.expected_mari_rb_folder, expected_files[0])
 
         actual_path = self.test_plot_handler.get_plot_file()
         mock_client_init.assert_called_once()


### PR DESCRIPTION
Instead of joining the paths it was just appending, leading to malformed URI
such as: `[20/Jan/2021 16:25:05] ERROR [app:127] File '/instrument/MARI/RBNumber/RB2000159/autoreducedMAR27877_Ei40.10meV.png' does not exist` - we've dropped a `/` somewhere in #793 

### Summary of work
Just adds the dropped `/`. 

`os.path.join` doesn't work as it's on Windows so it makes the path like this: `'/instrument/MARI/RBNumber/RB2000159/autoreduced\MAR27877_Ei40.10meV.png'`

### How to test your work
Hard one to test as this only happens when on a Windows machine and accessing the SFTP client which is Linux. Code review should be enough