### PR TITLE
Remove mock dependency

### DIFF
--- a/WebApp/autoreduce_webapp/tests/test_pagination.py
+++ b/WebApp/autoreduce_webapp/tests/test_pagination.py
@@ -4,7 +4,7 @@ Unit tests for the Custom pagination module
 
 import unittest
 from datetime import datetime, timedelta
-from mock import patch
+from unittest.mock import patch
 
 
 from utilities.pagination import CustomPage, RunPage, CustomPaginator, PageLimitException

--- a/build/database/tests/test_generate_database.py
+++ b/build/database/tests/test_generate_database.py
@@ -9,8 +9,8 @@ Tests for code that generates a working local database for autoredction
 """
 import os
 import unittest
-
 from unittest.mock import Mock
+
 from sqlalchemy.exc import OperationalError
 
 from build.database.generate_database import (get_test_user_sql, get_sql_from_file,

--- a/build/database/tests/test_generate_database.py
+++ b/build/database/tests/test_generate_database.py
@@ -10,7 +10,7 @@ Tests for code that generates a working local database for autoredction
 import os
 import unittest
 
-from mock import Mock
+from unittest.mock import Mock
 from sqlalchemy.exc import OperationalError
 
 from build.database.generate_database import (get_test_user_sql, get_sql_from_file,

--- a/docker_reduction/mantid/tests/test_mantid_docker_container.py
+++ b/docker_reduction/mantid/tests/test_mantid_docker_container.py
@@ -10,7 +10,7 @@ Tests that the mantid docker container can be built and can run a simple reducti
 import unittest
 import os
 
-from mock import patch, MagicMock
+from unittest.mock import patch, MagicMock
 
 from docker_reduction.mount import Mount
 from docker_reduction.mantid.operations import MantidDocker

--- a/model/database/tests/test_access.py
+++ b/model/database/tests/test_access.py
@@ -9,7 +9,8 @@ Unit tests to exercise the code responsible for common database access methods
 """
 import unittest
 
-from mock import Mock, patch
+from unittest.mock import patch, Mock
+
 from model.database import access
 from model.database.records import create_reduction_run_record
 from queue_processors.queue_processor.tests.test_handle_message import FakeMessage

--- a/model/database/tests/test_orm.py
+++ b/model/database/tests/test_orm.py
@@ -11,7 +11,7 @@ import sys
 import unittest
 import os
 
-from mock import patch
+from unittest.mock import patch
 
 from model.database import DjangoORM
 from utils.project.structure import get_project_root

--- a/model/message/validation/tests/test_process.py
+++ b/model/message/validation/tests/test_process.py
@@ -9,7 +9,7 @@ Exercise the helper functions that process the validation results
 """
 import unittest
 
-from mock import patch
+from unittest.mock import patch
 from model.message.validation import process
 
 

--- a/monitors/tests/test_run_detection.py
+++ b/monitors/tests/test_run_detection.py
@@ -1,17 +1,18 @@
 """
 Unit tests for the end of run monitor
 """
-import unittest
-import os
 import csv
-from filelock import FileLock
+import os
+import unittest
 from unittest.mock import (Mock, patch, call)
 
-from model.message.message import Message
-from monitors.settings import (CYCLE_FOLDER, LAST_RUNS_CSV)
+from filelock import FileLock
+
 import monitors.run_detection as eorm
+from model.message.message import Message
 from monitors.run_detection import (InstrumentMonitor,
                                     InstrumentMonitorError)
+from monitors.settings import (CYCLE_FOLDER, LAST_RUNS_CSV)
 
 # Test data
 SUMMARY_FILE = ("WIS44731Smith,Smith,"

--- a/monitors/tests/test_run_detection.py
+++ b/monitors/tests/test_run_detection.py
@@ -5,7 +5,7 @@ import unittest
 import os
 import csv
 from filelock import FileLock
-from mock import (Mock, patch, call)
+from unittest.mock import (Mock, patch, call)
 
 from model.message.message import Message
 from monitors.settings import (CYCLE_FOLDER, LAST_RUNS_CSV)

--- a/plotting/_plot_handler/tests/test_plot_handler.py
+++ b/plotting/_plot_handler/tests/test_plot_handler.py
@@ -11,7 +11,7 @@ Unit tests for _plot_handler
 # Core Dependencies
 import unittest
 
-from mock import patch, Mock
+from unittest.mock import patch, Mock
 
 # Internal Dependencies
 from plotting._plot_handler.plot_handler import DjangoDashApp

--- a/plotting/plot_factory/tests/test_dashapp.py
+++ b/plotting/plot_factory/tests/test_dashapp.py
@@ -10,7 +10,7 @@ Unit tests for plot factory DashApp
 
 # Core Dependencies
 import unittest
-from mock import patch, Mock
+from unittest.mock import patch, Mock
 
 # Internal Dependencies
 from plotting.plot_factory.dashapp import DashApp

--- a/plotting/plot_factory/tests/test_layout.py
+++ b/plotting/plot_factory/tests/test_layout.py
@@ -8,7 +8,7 @@
 
 # Core Dependencies
 import unittest
-from mock import patch
+from unittest.mock import patch
 
 
 # Internal Dependencies

--- a/plotting/plot_factory/tests/test_plot_factory.py
+++ b/plotting/plot_factory/tests/test_plot_factory.py
@@ -8,7 +8,7 @@
 
 # Core Dependencies
 import unittest
-from mock import patch, PropertyMock
+from unittest.mock import patch, PropertyMock
 
 # Internal Dependencies
 from plotting.plot_factory.plot_factory import PlotFactory

--- a/plotting/plot_meta_language/tests/test_interpreter.py
+++ b/plotting/plot_meta_language/tests/test_interpreter.py
@@ -10,7 +10,7 @@ Test cases for the meta-language interpreter
 import unittest
 
 from unittest.mock import MagicMock
-from mock import patch
+from unittest.mock import patch
 from plotting.plot_meta_language.interpreter import Interpreter
 
 

--- a/plotting/tests/test_plot_handler.py
+++ b/plotting/tests/test_plot_handler.py
@@ -13,7 +13,7 @@ calling the SFTPClient with correct parameters
 """
 import os
 import unittest
-from mock import patch
+from unittest.mock import patch
 
 from plotting.plot_handler import PlotHandler
 from utils.project.structure import get_project_root

--- a/plotting/tests/test_prepare_data.py
+++ b/plotting/tests/test_prepare_data.py
@@ -11,7 +11,7 @@ import os
 import unittest
 
 import pandas as pd
-from mock import patch
+from unittest.mock import patch
 
 from plotting.prepare_data import PrepareData
 

--- a/plotting/tests/test_prepare_data.py
+++ b/plotting/tests/test_prepare_data.py
@@ -9,9 +9,9 @@ Test cases for the data preparation class
 """
 import os
 import unittest
+from unittest.mock import patch
 
 import pandas as pd
-from unittest.mock import patch
 
 from plotting.prepare_data import PrepareData
 

--- a/queue_processors/queue_processor/tests/test_queue_listener.py
+++ b/queue_processors/queue_processor/tests/test_queue_listener.py
@@ -13,8 +13,8 @@ import unittest
 import uuid
 from copy import deepcopy
 from unittest import mock
-
 from unittest.mock import patch
+
 from model.message.message import Message
 from queue_processors.queue_processor import queue_listener
 from queue_processors.queue_processor.handle_message import HandleMessage

--- a/queue_processors/queue_processor/tests/test_queue_listener_daemon.py
+++ b/queue_processors/queue_processor/tests/test_queue_listener_daemon.py
@@ -9,8 +9,8 @@ Tests the Queue Listener Daemon
 """
 import unittest
 from unittest import mock
-
 import pytest
+
 from queue_processors.queue_processor import queue_listener_daemon
 
 from queue_processors.queue_processor.queue_listener_daemon import QueueListenerDaemon

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,9 +9,8 @@ gitpython==3.1.12
 # because GitHub Actions runs Ubuntu so even if the build pass, the installation could fail
 ipython==7.20.0
 lxml==4.6.2
-mock==4.0.2
-pandas==1.2.1
-plotly==4.14.3
+pandas==1.1.5
+plotly==4.12.0
 pylint==2.6.0
 pytest==6.2.2
 pytest-cov==2.11.1

--- a/scripts/manual_operations/tests/test_manual_remove.py
+++ b/scripts/manual_operations/tests/test_manual_remove.py
@@ -11,7 +11,7 @@ import builtins
 import unittest
 
 from django.db import IntegrityError
-from mock import DEFAULT, Mock, call, patch
+from unittest.mock import DEFAULT, Mock, call, patch
 from scripts.manual_operations.manual_remove import (ManualRemove, main, remove, user_input_check)
 from utils.clients.django_database_client import DatabaseClient
 

--- a/scripts/manual_operations/tests/test_manual_remove.py
+++ b/scripts/manual_operations/tests/test_manual_remove.py
@@ -9,9 +9,10 @@ Test cases for the manual job submission script
 """
 import builtins
 import unittest
+from unittest.mock import DEFAULT, Mock, call, patch
 
 from django.db import IntegrityError
-from unittest.mock import DEFAULT, Mock, call, patch
+
 from scripts.manual_operations.manual_remove import (ManualRemove, main, remove, user_input_check)
 from utils.clients.django_database_client import DatabaseClient
 

--- a/scripts/manual_operations/tests/test_manual_submission.py
+++ b/scripts/manual_operations/tests/test_manual_submission.py
@@ -8,7 +8,7 @@
 Test cases for the manual job submission script
 """
 import unittest
-from mock import patch, Mock, MagicMock
+from unittest.mock import patch, Mock, MagicMock
 import scripts.manual_operations.manual_submission as ms
 
 from utils.clients.django_database_client import DatabaseClient

--- a/scripts/tests/test_scheduler_ingest.py
+++ b/scripts/tests/test_scheduler_ingest.py
@@ -12,7 +12,7 @@ from datetime import datetime
 import unittest
 
 from dateutil.relativedelta import relativedelta
-from mock import patch
+from unittest.mock import patch
 
 from scripts.scheduler_ingest import Cycle, MaintenanceDay, SchedulerDataProcessor
 

--- a/scripts/tests/test_scheduler_ingest.py
+++ b/scripts/tests/test_scheduler_ingest.py
@@ -7,12 +7,11 @@
 """
 Tests the functionality within scheduler_ingest.py
 """
-from datetime import datetime
-
 import unittest
+from datetime import datetime
+from unittest.mock import patch
 
 from dateutil.relativedelta import relativedelta
-from unittest.mock import patch
 
 from scripts.scheduler_ingest import Cycle, MaintenanceDay, SchedulerDataProcessor
 

--- a/utils/clients/tests/test_cycle_ingestion_client.py
+++ b/utils/clients/tests/test_cycle_ingestion_client.py
@@ -12,7 +12,7 @@ from urllib.error import URLError
 
 import unittest
 
-from mock import patch, MagicMock
+from unittest.mock import patch, MagicMock
 
 import suds
 

--- a/utils/clients/tests/test_database_client.py
+++ b/utils/clients/tests/test_database_client.py
@@ -9,7 +9,7 @@ Test cases for the database client
 """
 import unittest
 
-from mock import patch
+from unittest.mock import patch
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm.session import Session
 

--- a/utils/clients/tests/test_django_database_client.py
+++ b/utils/clients/tests/test_django_database_client.py
@@ -9,7 +9,7 @@ Test cases for the django database client
 """
 import unittest
 
-from mock import patch
+from unittest.mock import patch
 
 from utils.clients.connection_exception import ConnectionException
 from utils.clients.django_database_client import DatabaseClient

--- a/utils/clients/tests/test_icat_client.py
+++ b/utils/clients/tests/test_icat_client.py
@@ -11,7 +11,7 @@ This is because we can not connect to icat for testing and it is not feasible
 to set up a local version for testing at this point.
 """
 import unittest
-from mock import patch
+from unittest.mock import patch
 
 import icat
 

--- a/utils/clients/tests/test_queue_client.py
+++ b/utils/clients/tests/test_queue_client.py
@@ -10,7 +10,7 @@ Test functionality for the activemq client
 import unittest
 from unittest import mock
 
-from mock import patch
+from unittest.mock import patch
 
 from model.message.message import Message
 from utils.clients.connection_exception import ConnectionException

--- a/utils/clients/tests/test_sftp_client.py
+++ b/utils/clients/tests/test_sftp_client.py
@@ -10,7 +10,7 @@ Test SFTP client
 import unittest
 from unittest.mock import MagicMock
 
-from mock import patch
+from unittest.mock import patch
 
 from utils.clients.connection_exception import ConnectionException
 from utils.clients.sftp_client import SFTPClient


### PR DESCRIPTION
### Summary of work
Mock is part of the standard library. since `3.3` This removes the dependency from `requirements.txt`

### How to test your works
CI Passes

**Before merging ensure the release notes have been updated**