### PR TITLE
Removes method scope imports and other import related issues

### DIFF
--- a/WebApp/autoreduce_webapp/autoreduce_webapp/management/commands/add_super.py
+++ b/WebApp/autoreduce_webapp/autoreduce_webapp/management/commands/add_super.py
@@ -8,6 +8,7 @@
 Custom manage.py command to add a super user to the database
 """
 from django.core.management.base import BaseCommand
+from django.contrib.auth.models import User
 
 
 class Command(BaseCommand):
@@ -21,6 +22,5 @@ class Command(BaseCommand):
         (THIS SHOULD ONLY BE USED FOR DEVELOPMENT)
         handler to add super user to database
         """
-        from django.contrib.auth.models import User
         User.objects.filter(username='super').delete()
         User.objects.create_superuser('super', '', 'super')

--- a/WebApp/autoreduce_webapp/reduction_variables/views.py
+++ b/WebApp/autoreduce_webapp/reduction_variables/views.py
@@ -8,17 +8,13 @@
 View functions for displaying Variable data
 This imports into another view, thus no middleware
 """
-import json
 import logging
 
 from django.shortcuts import redirect
-from django.core.exceptions import PermissionDenied
 from django.shortcuts import render
-from django.http import HttpResponse, HttpResponseForbidden
-from autoreduce_webapp.view_utils import (login_and_uows_valid, render_with, has_valid_login,
-                                          handle_redirect, check_permissions)
+from autoreduce_webapp.view_utils import (login_and_uows_valid, render_with, check_permissions)
 from reduction_variables.models import InstrumentVariable, RunVariable
-from reduction_variables.utils import VariableUtils, InstrumentVariablesUtils, MessagingUtils
+from reduction_variables.utils import InstrumentVariablesUtils, MessagingUtils
 from reduction_viewer.models import Instrument, ReductionRun
 from reduction_viewer.utils import InstrumentUtils, StatusUtils, ReductionRunUtils
 from utilities import input_processing

--- a/model/database/tests/test_records.py
+++ b/model/database/tests/test_records.py
@@ -9,12 +9,11 @@
 Unit tests for the record helper module
 """
 
-import unittest
-from unittest import mock
+from unittest import TestCase, mock
 import model.database.records as records
 
 
-class TestDatabaseRecords(unittest.TestCase):
+class TestDatabaseRecords(TestCase):
     """
     Tests the Record helpers for the ORM layer
     """

--- a/model/message/validation/tests/test_stages.py
+++ b/model/message/validation/tests/test_stages.py
@@ -7,14 +7,13 @@
 """
 Exercise the functions that handle validating a message at each pipeline stage
 """
-import unittest
-from unittest import mock
+from unittest import TestCase, mock
 
 from model.message.validation import stages, validators
 from model.message.message import Message
 
 
-class TestStages(unittest.TestCase):
+class TestStages(TestCase):
     """
     Assert the stages return the correct bool value based on if they are valid
     """

--- a/plotting/plot_factory/tests/test_trace.py
+++ b/plotting/plot_factory/tests/test_trace.py
@@ -13,7 +13,6 @@ Unit tests for plot factory Trace
 import unittest
 import plotly
 import pandas
-import logging
 
 # Mocked values
 from plotting.plot_factory.tests.mocked_values import MockPlotVariables

--- a/queue_processors/queue_processor/tests/test_handle_message.py
+++ b/queue_processors/queue_processor/tests/test_handle_message.py
@@ -12,7 +12,7 @@ Tests message handling for the queue processor
 from functools import partial
 import random
 from unittest import TestCase, mock, main
-from mock import Mock, patch
+from unittest.mock import Mock, patch
 
 from django.db.utils import IntegrityError
 from parameterized import parameterized

--- a/queue_processors/queue_processor/tests/test_handle_message.py
+++ b/queue_processors/queue_processor/tests/test_handle_message.py
@@ -11,9 +11,8 @@ Tests message handling for the queue processor
 
 from functools import partial
 import random
-import unittest
-from unittest import mock
-from unittest.mock import Mock, patch
+from unittest import TestCase, mock, main
+from mock import Mock, patch
 
 from django.db.utils import IntegrityError
 from parameterized import parameterized
@@ -55,7 +54,7 @@ class FakeMessage:
     message = "I am a message"
 
 
-class TestHandleMessage(unittest.TestCase):
+class TestHandleMessage(TestCase):
     """
     Directly tests the message handling classes
     """
@@ -366,4 +365,4 @@ class TestHandleMessage(unittest.TestCase):
 
 
 if __name__ == '__main__':
-    unittest.main()
+    main()

--- a/queue_processors/queue_processor/tests/test_queue_listener.py
+++ b/queue_processors/queue_processor/tests/test_queue_listener.py
@@ -9,11 +9,10 @@
 Test cases for the queue processor
 """
 
-import unittest
 import uuid
+from unittest import TestCase, mock
 from copy import deepcopy
-from unittest import mock
-from unittest.mock import patch
+from mock import patch
 
 from model.message.message import Message
 from queue_processors.queue_processor import queue_listener
@@ -22,7 +21,7 @@ from queue_processors.queue_processor.queue_listener import QueueListener
 from utils.clients.queue_client import QueueClient
 
 
-class TestQueueProcessor(unittest.TestCase):
+class TestQueueProcessor(TestCase):
     """
     Exercises the functions within listener.py
     """
@@ -49,7 +48,7 @@ class TestQueueProcessor(unittest.TestCase):
         self.assertIsInstance(args[1].client, QueueClient)
 
 
-class TestQueueListener(unittest.TestCase):
+class TestQueueListener(TestCase):
     # We have too many public methods as our Class Under Test does too much...
     # pylint: disable=too-many-public-methods
     """

--- a/queue_processors/queue_processor/tests/test_queue_listener.py
+++ b/queue_processors/queue_processor/tests/test_queue_listener.py
@@ -11,8 +11,8 @@ Test cases for the queue processor
 
 import uuid
 from unittest import TestCase, mock
+from unittest.mock import patch
 from copy import deepcopy
-from mock import patch
 
 from model.message.message import Message
 from queue_processors.queue_processor import queue_listener

--- a/queue_processors/queue_processor/tests/test_queue_listener_daemon.py
+++ b/queue_processors/queue_processor/tests/test_queue_listener_daemon.py
@@ -7,8 +7,7 @@
 """
 Tests the Queue Listener Daemon
 """
-import unittest
-from unittest import mock
+from unittest import main, mock
 import pytest
 
 from queue_processors.queue_processor import queue_listener_daemon
@@ -135,4 +134,4 @@ def test_main_daemon_start(patched_logging, patched_daemon, patched_sys):
 
 
 if __name__ == '__main__':
-    unittest.main()
+    main()

--- a/scripts/backup_reduction_scripts.py
+++ b/scripts/backup_reduction_scripts.py
@@ -33,8 +33,7 @@ import shutil
 import traceback
 from pathlib import Path
 
-import git
-from git import Git
+from git import Git, exc
 
 from utils.project.static_content import LOG_FORMAT
 from utils.project.structure import get_log_file
@@ -110,7 +109,7 @@ def main(args):
 
     try:
         check_if_git_directory(STORAGE_DIR)
-    except git.exc.GitCommandError as err:  # pylint: disable=no-member
+    except exc.GitCommandError as err:  # pylint: disable=no-member
         log.error(
             "Destination folder %s is not a Git repository. "
             "Please configure it manually before running this script.", str(STORAGE_DIR))

--- a/utils/clients/settings/tests/test_client_settings.py
+++ b/utils/clients/settings/tests/test_client_settings.py
@@ -7,14 +7,13 @@
 """
 Test the ClientSettings package
 """
-import unittest
-from unittest import mock
+from unittest import TestCase, mock
 
 from utils.clients.settings.client_settings import ClientSettings
 
 
 # pylint:disable=missing-docstring
-class TestClientSettings(unittest.TestCase):
+class TestClientSettings(TestCase):
 
     def test_valid_init(self):
         settings = ClientSettings(username='user',

--- a/utils/clients/tests/test_queue_client.py
+++ b/utils/clients/tests/test_queue_client.py
@@ -8,7 +8,7 @@
 Test functionality for the activemq client
 """
 from unittest import TestCase, mock
-from mock import patch
+from unittest.mock import patch
 
 from model.message.message import Message
 from utils.clients.connection_exception import ConnectionException

--- a/utils/clients/tests/test_queue_client.py
+++ b/utils/clients/tests/test_queue_client.py
@@ -7,10 +7,8 @@
 """
 Test functionality for the activemq client
 """
-import unittest
-from unittest import mock
-
-from unittest.mock import patch
+from unittest import TestCase, mock
+from mock import patch
 
 from model.message.message import Message
 from utils.clients.connection_exception import ConnectionException
@@ -19,7 +17,7 @@ from utils.clients.settings.client_settings_factory import ClientSettingsFactory
 
 
 # pylint:disable=protected-access,invalid-name,missing-docstring
-class TestQueueClient(unittest.TestCase):
+class TestQueueClient(TestCase):
     """
     Exercises the queue client
     """

--- a/utils/project/structure.py
+++ b/utils/project/structure.py
@@ -9,6 +9,7 @@ Helper functions for navigating the project
 """
 
 import os
+import git
 
 
 def get_project_root() -> str:
@@ -17,7 +18,6 @@ def get_project_root() -> str:
     :return: file path to root of the project folder
     """
     # pylint:disable=import-outside-toplevel
-    import git
     git_repo = git.Repo(os.path.dirname(os.path.realpath(__file__)), search_parent_directories=True)
     git_root = git_repo.git.rev_parse("--show-toplevel")
 


### PR DESCRIPTION
### Summary of work
* Removed method scope imports.
* Fixed code scanning alerts for: Module is imported with 'import' and 'import from'
* Fixed code scanning alerts for: Unused import
 
### How to test your work
* Tests pass
* Code review

### Additional comments
* Surely there's a better way of getting the project root without using git in `get_project_root()`? 

Fixes #307