### PR TITLE
Modify STATICFILES_DIRS so web app can be started from any directory

### DIFF
--- a/WebApp/autoreduce_webapp/autoreduce_webapp/settings.py
+++ b/WebApp/autoreduce_webapp/autoreduce_webapp/settings.py
@@ -139,7 +139,7 @@ USE_TZ = True
 STATIC_URL = '/static/'
 STATIC_PATH = os.path.join(BASE_DIR, 'static')
 STATICFILES_DIRS = [
-    os.path.join('BASE_DIR, static'),
+    os.path.join(BASE_DIR, 'static'),
 ]
 
 # Logging

--- a/WebApp/autoreduce_webapp/autoreduce_webapp/settings.py
+++ b/WebApp/autoreduce_webapp/autoreduce_webapp/settings.py
@@ -139,7 +139,7 @@ USE_TZ = True
 STATIC_URL = '/static/'
 STATIC_PATH = os.path.join(BASE_DIR, 'static')
 STATICFILES_DIRS = [
-    os.path.join('static'),
+    os.path.join('BASE_DIR, static'),
 ]
 
 # Logging


### PR DESCRIPTION
### Summary of work
<!---The changes you have made--->
Changed STATICFILES_DIRS to 'BASE_DIR, static' so that the web app can be run from any directory (rather than having to run from autoreduction/WebApp/autoreduce_webapp)

### How to test your work
<!---This can be a link to the---> 

- [ ] `cd autoreduction/WebApp/autoreduce_webapp` then `python manage.py runserver` then check web app works correctly
- [ ] `cd autoreduction` then `python WebApp/autoreduce_webapp/manage.py runserver` then check web app works correctly

### Additional comments
<!---Anything else: e.g. was the estimate reasonable for this issue?---> 

Fixes #xyz


**Before merging ensure the release notes have been updated**