### PR TITLE
Adds ARCHIVE_ROOT in QP settings to make changing the archive root folder easier

### DIFF
--- a/queue_processors/queue_processor/settings.py
+++ b/queue_processors/queue_processor/settings.py
@@ -21,26 +21,29 @@ if DEBUG:
 else:
     LOG_LEVEL = 'INFO'
 
-# Directory Locations
-if os.name == 'nt':
-    # Adding this as we no longer have any nodes running on Windows.
-    # The change will appear in https://github.com/ISISScientificComputing/autoreduce/pull/1033
-    # If Windows must be used you will have to redefine the variables from below
-    raise RuntimeError("Running the queue processor on Windows is no longer expected, nor actively supported.")
-else:
-    # %(instrument)
-    # REDUCTION_DIRECTORY = '/isis/NDX%s/user/scripts/autoreduction'
-    REDUCTION_DIRECTORY = os.path.join(PROJECT_ROOT, 'data-archive', 'NDX%s', 'user', 'scripts', 'autoreduction')
-    # %(instrument, cycle, experiment_number, run_number)
-    # ARCHIVE_DIRECTORY = '/isis/NDX%s/Instrument/data/cycle_%s/autoreduced/%s/%s'
-    ARCHIVE_DIRECTORY = os.path.join(PROJECT_ROOT, 'data-archive', 'NDX%s', 'Instrument', 'data', 'cycle_%s',
-                                     'autoreduced', '%s', '%s')
-TEST_REDUCTION_DIRECTORY = '/reducedev/isis/output/NDX%s/user/scripts/autoreduction'
-TEST_ARCHIVE_DIRECTORY = '/isis/NDX%s/Instrument/data/cycle_%s/autoreduced/%s/%s'
+# The reduction outputs are saved there. If you want to avoid writing to the real CEPH then
+# change this to a local directory - the reductions should process fine regardless.
+# %(instrument, experiment_number, run_number)
+# CEPH_DIRECTORY = "/instrument/%s/RBNumber/RB%s/autoreduced/%s"
+CEPH_DIRECTORY = f"{PROJECT_ROOT}/reduced-data/%s/RB%s/autoreduced/%s/"
+
+# for development/prod or when connecting to the real archive, mounted locally
+# ARCHIVE_ROOT = "/isis"
+# for testing which uses a local folder to simulate an archive
+ARCHIVE_ROOT = os.path.join(PROJECT_ROOT, 'data-archive')
+
+# Variables that get changes less
+# %(instrument)
+# ONLY USED IN THE WebApp and should be removed in https://github.com/ISISScientificComputing/autoreduce/issues/1042
+REDUCTION_DIRECTORY = os.path.join(ARCHIVE_ROOT, 'NDX%s', 'user', 'scripts', 'autoreduction')
+# %(instrument, cycle, experiment_number, run_number)
+ARCHIVE_DIRECTORY = os.path.join(ARCHIVE_ROOT, 'NDX%s', 'Instrument', 'data', 'cycle_%s', 'autoreduced', '%s', '%s')
+SCRIPTS_DIRECTORY = f"{ARCHIVE_ROOT}/NDX%s/user/scripts/autoreduction/"
 
 SCRIPT_TIMEOUT = 3600  # The max time to wait for a user script to finish running (seconds)
 MANTID_PATH = "/opt/Mantid/lib"
-SCRIPTS_DIRECTORY = f"{PROJECT_ROOT}/data-archive/NDX%s/user/scripts/autoreduction/"
-CEPH_DIRECTORY = f"{PROJECT_ROOT}/reduced-data/%s/RB%s/autoreduced/%s/"
 TEMP_ROOT_DIRECTORY = "/autoreducetmp"
 FLAT_OUTPUT_INSTRUMENTS = ["LET", "MARI", "MAPS", "MERLIN", "WISH", "GEM"]
+
+TEST_REDUCTION_DIRECTORY = '/reducedev/isis/output/NDX%s/user/scripts/autoreduction'
+TEST_ARCHIVE_DIRECTORY = '/isis/NDX%s/Instrument/data/cycle_%s/autoreduced/%s/%s'


### PR DESCRIPTION
### Summary of work
Adds ARCHIVE_ROOT in QP settings to make changing the archive root folder easier - for testing leave as it is, but if you want to use the real archive just uncomment the one with /isis.

Also Reorders the variables and removes NT branch

### How to test your work
- Start ActiveMQ
- Run the queue listener with the settings.py in this PR, without changes. 
- Submit a run (e.g. `python scripts/manual_operations/manual_submission.py MARI 27877`)
- The reduction should fail to find reduce.py and reduce_vars.py at the specified directory
- Uncomment ARCHIVE_ROOT="/isis"
- The reduction should either pass, if you have Mantid, or fail with "Unable to import mantid" if you don't. Both are fine
	- Note it might still fail the first time because the MARI reduce.py has a bug in that it doesn't wait for the ScriptRepository to finish the download, but it works 2nd time around

Fixes #1089