### PR TITLE
Improves error message when manual_submission can't connect to ActiveMQ

### DIFF
--- a/scripts/manual_operations/manual_submission.py
+++ b/scripts/manual_operations/manual_submission.py
@@ -196,8 +196,9 @@ def login_queue():
     try:
         activemq_client.connect()
     except (ConnectionException, ValueError) as exp:
-        raise RuntimeError("Unable to proceed. Unable to log in to ActiveMQ."
-                           "This is required to perform a manual submission") from exp
+        raise RuntimeError(
+            "Cannot connect to ActiveMQ with provided credentials in credentials.ini\n"
+            "Check that the ActiveMQ service is running, and the username, password and host are correct.") from exp
     return activemq_client
 
 


### PR DESCRIPTION
### Summary of work
Improves error message when manual_submission can't connect to ActiveMQ. I think this is enough to address the 
issue, but suggestions for better error message are welcome.

### How to test your work
Check if new message is better/worse than the previous one

Fixes #785