### PR TITLE
Drop unused requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,9 +5,6 @@ dash==1.16.3
 django-debug-toolbar==3.2
 django_plotly_dash==1.5.0
 gitpython==3.1.12
-# this is the highest available version that pip can find on CentOS - be careful when updating
-# because GitHub Actions runs Ubuntu so even if the build pass, the installation could fail
-ipython==7.20.0
 lxml==4.6.2
 pandas==1.1.5
 plotly==4.12.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,6 @@ dash==1.16.3
 django-debug-toolbar==3.2
 django_plotly_dash==1.5.0
 gitpython==3.1.12
-lxml==4.6.2
 pandas==1.1.5
 plotly==4.12.0
 pylint==2.6.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,6 @@ coveralls==3.0.0
 dash==1.16.3
 django-debug-toolbar==3.2
 django_plotly_dash==1.5.0
-gitpython==3.1.12
 pandas==1.1.5
 plotly==4.12.0
 pylint==2.6.0

--- a/setup.py
+++ b/setup.py
@@ -29,9 +29,6 @@ setup_requires = [
     'filelock==3.0.12',
     'fire==0.4.0',
     'gitpython==3.1.12',
-    # this is the highest available version that pip can find on CentOS - be careful when updating
-    # because GitHub Actions runs Ubuntu so even if the build pass, the installation could fail
-    'IPython==7.20.0',
     'mysqlclient==2.0.3',
     'mysql-connector==2.2.9',
     'nexusformat==0.6.0',


### PR DESCRIPTION
### Summary of work
There are apparently no usages of ipython or lxml within the project.
I have also removed git from `requirements.txt` as it is already installed via the setup. This is true for other requirements but there are discrepancies between versions which will need to be looked at at some point.
It seems they were both added in relation to a web scraping tool to get data from the beam line page that doesn't exist anymore? #427 


### How to test your work
Verify there are no uses of either library

### Additional comments
<!---Anything else: e.g. was the estimate reasonable for this issue?---> 

Fixes #1071


**Before merging ensure the release notes have been updated**