### PR TITLE
Removes MySQL requirements from setup.py

### DIFF
--- a/scripts/nagios_checks/autoreduce_checklastrun.py
+++ b/scripts/nagios_checks/autoreduce_checklastrun.py
@@ -7,11 +7,15 @@
 #! /usr/bin/env python
 """
 Check that the last run is correct
+
+Issue to convert this to use the ORM is at
+https://github.com/ISISScientificComputing/autoreduce/issues/1096
 """
 from __future__ import print_function
 import sys
 from os import path
 
+# pylint:disable=import-error
 import MySQLdb
 import MySQLdb.cursors
 

--- a/setup.py
+++ b/setup.py
@@ -29,8 +29,9 @@ setup_requires = [
     'filelock==3.0.12',
     'fire==0.4.0',
     'gitpython==3.1.12',
-    'mysqlclient==2.0.3',
-    'mysql-connector==2.2.9',
+    # this is the highest available version that pip can find on CentOS - be careful when updating
+    # because GitHub Actions runs Ubuntu so even if the build pass, the installation could fail
+    'IPython==7.20.0',
     'nexusformat==0.6.0',
     'numpy==1.20.1',
     'pandas==1.2.1',

--- a/setup.py
+++ b/setup.py
@@ -29,9 +29,6 @@ setup_requires = [
     'filelock==3.0.12',
     'fire==0.4.0',
     'gitpython==3.1.12',
-    # this is the highest available version that pip can find on CentOS - be careful when updating
-    # because GitHub Actions runs Ubuntu so even if the build pass, the installation could fail
-    'IPython==7.20.0',
     'nexusformat==0.6.0',
     'numpy==1.20.1',
     'pandas==1.2.1',


### PR DESCRIPTION
### Summary of work
Removes MySQL requirements from setup.py, this means you should be able to install Autoreduction without installing any MySQL dependencies.

```
python3 -m pip install --user -e autoreduction
```


### How to test your work
- Delete `mysql-server` and `libmysqlclient-dev` 
- Create a new virtual environment
- Install Autoreduction again, it should install fine without MySQL being present


Fixes #1103