### PR TITLE
Make notifications visible to admins

### DIFF
--- a/WebApp/autoreduce_webapp/autoreduce_webapp/fixtures/notification_fixture.json
+++ b/WebApp/autoreduce_webapp/autoreduce_webapp/fixtures/notification_fixture.json
@@ -1,0 +1,22 @@
+[
+  {
+    "model": "reduction_viewer.notification",
+    "pk": 1,
+    "fields": {
+      "message": "This notification should only be visible to admins",
+      "is_active": 1,
+      "is_staff_only": 1,
+      "severity": "e"
+    }
+  },
+  {
+  "model": "reduction_viewer.notification",
+  "pk": 2,
+  "fields": {
+    "message": "This notification should be visible to everyone",
+    "is_active": 1,
+    "is_staff_only": 0,
+    "severity": "e"
+    }
+  }
+]

--- a/WebApp/autoreduce_webapp/autoreduce_webapp/view_utils.py
+++ b/WebApp/autoreduce_webapp/autoreduce_webapp/view_utils.py
@@ -118,9 +118,11 @@ def render_with(template):
                 output['request'] = request
 
             # pylint: disable=no-member
-            notifications = Notification.objects.filter(is_active=True,
-                                                        is_staff_only=(request.user.is_authenticated
-                                                                       and request.user.is_staff))
+            if request.user.is_staff and request.user.is_authenticated:
+                notifications = Notification.objects.filter(is_active=True)
+            else:
+                notifications = Notification.objects.filter(is_active=True, is_staff_only=False)
+
             if 'notifications' not in output:
                 output['notifications'] = notifications
             else:

--- a/WebApp/autoreduce_webapp/selenium_tests/pages/component_mixins/navbar_mixin.py
+++ b/WebApp/autoreduce_webapp/selenium_tests/pages/component_mixins/navbar_mixin.py
@@ -98,4 +98,3 @@ class NavbarMixin:
         :return: The text of the notifications messages
         """
         return [notification.text for notification in self.driver.find_elements_by_class_name("notification-message")]
-

--- a/WebApp/autoreduce_webapp/selenium_tests/pages/component_mixins/navbar_mixin.py
+++ b/WebApp/autoreduce_webapp/selenium_tests/pages/component_mixins/navbar_mixin.py
@@ -95,6 +95,6 @@ class NavbarMixin:
     def get_notification_messages(self) -> List[str]:
         """
         Get the notification messages on the page.
-        :return: The text of the notifications messages
+        :return: (list of str) The text of the notifications messages
         """
         return [notification.text for notification in self.driver.find_elements_by_class_name("notification-message")]

--- a/WebApp/autoreduce_webapp/selenium_tests/pages/component_mixins/navbar_mixin.py
+++ b/WebApp/autoreduce_webapp/selenium_tests/pages/component_mixins/navbar_mixin.py
@@ -7,6 +7,9 @@
 """
 Module containing the NavbarMixin
 """
+from typing import List
+
+from selenium.webdriver.remote.webelement import WebElement
 
 
 class NavbarMixin:
@@ -59,32 +62,40 @@ class NavbarMixin:
         """
         self.driver.find_element_by_xpath(self.HELP_XPATH).click()
 
-    def _get_navbar(self):
+    def _get_navbar(self) -> WebElement:
         return self.driver.find_element_by_class_name(self.NAVBAR_CLASS)
 
-    def _get_logo(self):
+    def _get_logo(self) -> WebElement:
         return self.driver.find_element_by_class_name(self.LOGO_CLASS)
 
-    def _get_navbar_links(self):
+    def _get_navbar_links(self) -> WebElement:
         return self.driver.find_element_by_id(self.LINKS_ID)
 
-    def is_navbar_logo_visible(self):
+    def is_navbar_logo_visible(self) -> bool:
         """
         Check if the brand logo is visible in the navbar
         :return: (bool) True if logo is visible, otherwise False
         """
         return self._get_logo().is_displayed()
 
-    def is_navbar_visible(self):
+    def is_navbar_visible(self) -> bool:
         """
         Check if the navbar is visible on a page
         :return: (bool) True if navbar is visible, otherwise False
         """
         return self._get_navbar().is_displayed()
 
-    def is_navbar_links_visible(self):
+    def is_navbar_links_visible(self) -> bool:
         """
         Check if the navbar links are visible
         :return: (bool) True if links are visible, otherwise False
         """
         return self._get_navbar_links().is_displayed()
+
+    def get_notification_messages(self) -> List[str]:
+        """
+        Get the notification messages on the page.
+        :return: The text of the notifications messages
+        """
+        return [notification.text for notification in self.driver.find_elements_by_class_name("notification-message")]
+

--- a/WebApp/autoreduce_webapp/selenium_tests/tests/base_tests.py
+++ b/WebApp/autoreduce_webapp/selenium_tests/tests/base_tests.py
@@ -160,8 +160,6 @@ class NavbarTestMixin:
         self.assertNotIn(self.ADMIN_NOTIFICATION_MESSAGE, notifications)
 
 
-
-
 class FooterTestMixin:
     """
     Contains test cases for pages with the FooterMixin

--- a/WebApp/autoreduce_webapp/selenium_tests/tests/base_tests.py
+++ b/WebApp/autoreduce_webapp/selenium_tests/tests/base_tests.py
@@ -28,7 +28,7 @@ class BaseTestCase(StaticLiveServerTestCase):
     Base test class that provides setup and teardown of driver aswell as screenshotting capability
     on failed tests
     """
-    fixtures = ["super_user_fixture", "status_fixture"]
+    fixtures = ["super_user_fixture", "status_fixture", "notification_fixture"]
 
     def setUp(self) -> None:
         """
@@ -64,6 +64,9 @@ class NavbarTestMixin:
     """
     Contains test cases for pages with the NavbarMixin
     """
+    ADMIN_NOTIFICATION_MESSAGE = "This notification should only be visible to admins"
+    NON_ADMIN_NOTIFICATION_MESSAGE = "This notification should be visible to everyone"
+
     def test_navbar_visible(self):
         """
         Test: Navbar is visible on current page
@@ -133,6 +136,30 @@ class NavbarTestMixin:
             .launch() \
             .click_navbar_help()
         self.assertEqual(HelpPage.url(), self.driver.current_url)
+
+    def test_admin_notification_visible_to_admins(self):
+        """
+        Tests: Admin notifications visible to admins
+        """
+        notifications = self.page.launch().get_notification_messages()
+        self.assertIn(self.ADMIN_NOTIFICATION_MESSAGE, notifications)
+
+    def test_non_admin_notifications_visible_to_admins(self):
+        """
+        Tests: non admin notifications visible to admins
+        """
+        notifications = self.page.launch().get_notification_messages()
+        self.assertIn(self.NON_ADMIN_NOTIFICATION_MESSAGE, notifications)
+
+    def test_admin_notifications_not_visible_to_non_admin(self):
+        """
+        Tests: Admin notifications not visible for non admins
+        """
+        self.driver.get(self.live_server_url + "/overview")
+        notifications = self.page.get_notification_messages()
+        self.assertNotIn(self.ADMIN_NOTIFICATION_MESSAGE, notifications)
+
+
 
 
 class FooterTestMixin:

--- a/WebApp/autoreduce_webapp/selenium_tests/tests/base_tests.py
+++ b/WebApp/autoreduce_webapp/selenium_tests/tests/base_tests.py
@@ -155,7 +155,7 @@ class NavbarTestMixin:
         """
         Tests: Admin notifications not visible for non admins
         """
-        self.driver.get(self.live_server_url + "/overview")
+        self.driver.get(self.live_server_url + "/overview")  # We do this due to issues with logging in. see README
         notifications = self.page.get_notification_messages()
         self.assertNotIn(self.ADMIN_NOTIFICATION_MESSAGE, notifications)
 

--- a/WebApp/autoreduce_webapp/templates/header.html
+++ b/WebApp/autoreduce_webapp/templates/header.html
@@ -5,7 +5,7 @@
         {% for notification in notifications %}
             <div class="alert alert-{% replace notification.severity_verbose 'error' 'danger' %} hide" role="alert" data-notification-id="{{ notification.id }}">
                 <button type="button" class="close" data-dismiss="alert"><span aria-hidden="true">&times;</span><span class="sr-only">Close</span></button>
-                    <p class="notification-message"><i class="fa fa-{% replace notification.severity_verbose 'error' 'exclamation' %} fa-{% replace notification.severity_verbose 'error' 'exclamation' %}-circle fa-lg"></i> {{ notification.message }}</p>
+                <p class="notification-message"><i class="fa fa-{% replace notification.severity_verbose 'error' 'exclamation' %} fa-{% replace notification.severity_verbose 'error' 'exclamation' %}-circle fa-lg"></i> {{ notification.message }}</p>
             </div>
         {% endfor %}
     {% endif %}

--- a/WebApp/autoreduce_webapp/templates/header.html
+++ b/WebApp/autoreduce_webapp/templates/header.html
@@ -5,7 +5,7 @@
         {% for notification in notifications %}
             <div class="alert alert-{% replace notification.severity_verbose 'error' 'danger' %} hide" role="alert" data-notification-id="{{ notification.id }}">
                 <button type="button" class="close" data-dismiss="alert"><span aria-hidden="true">&times;</span><span class="sr-only">Close</span></button>
-                <i class="fa fa-{% replace notification.severity_verbose 'error' 'exclamation' %} fa-{% replace notification.severity_verbose 'error' 'exclamation' %}-circle fa-lg"></i> {{ notification.message }}
+                    <p class="notification-message"><i class="fa fa-{% replace notification.severity_verbose 'error' 'exclamation' %} fa-{% replace notification.severity_verbose 'error' 'exclamation' %}-circle fa-lg"></i> {{ notification.message }}</p>
             </div>
         {% endfor %}
     {% endif %}


### PR DESCRIPTION
### Summary of work
Changes which queries were run to get notifications and added regression tests.

Strictly speaking the notifications are loaded in the header and not the navbar, however whenever the navbar is imported so is the header.

### How to test your work
Add notifications and verify they display correctly whether logged in or not. Same as in the tests


Fixes #897


**Before merging ensure the release notes have been updated**