### PR TITLE
Moves driver start and quit in setUpClass/tearDownClass

### DIFF
--- a/WebApp/autoreduce_webapp/selenium_tests/driver.py
+++ b/WebApp/autoreduce_webapp/selenium_tests/driver.py
@@ -8,6 +8,7 @@
 Module containing functions for obtaining webdrivers
 """
 import os
+import atexit
 
 from selenium import webdriver
 from selenium_tests import configuration
@@ -34,4 +35,6 @@ def get_chrome_driver() -> webdriver.Chrome:
     driver = webdriver.Chrome(options=options)
     driver.implicitly_wait(10)
     driver.set_page_load_timeout(30)
+    # register the close function to run on process exit - this will close the Chrome window
+    atexit.register(driver.close)
     return driver

--- a/WebApp/autoreduce_webapp/selenium_tests/tests/base_tests.py
+++ b/WebApp/autoreduce_webapp/selenium_tests/tests/base_tests.py
@@ -7,7 +7,6 @@
 """
 Module containing the base test cases for a page and componenets
 """
-
 import datetime
 from pathlib import Path
 
@@ -26,21 +25,27 @@ class BaseTestCase(StaticLiveServerTestCase):
     """
     fixtures = ["super_user_fixture", "status_fixture", "notification_fixture"]
 
-    def setUp(self) -> None:
+    @classmethod
+    def setUpClass(cls) -> None:
         """
         Obtain the webdriver to be used in a testcase
         """
-        self.driver = get_chrome_driver()
-        set_url(self.live_server_url)
+        super().setUpClass()
+        cls.driver = get_chrome_driver()
+        set_url(cls.live_server_url)
 
-    def tearDown(self) -> None:
+    @classmethod
+    def tearDownClass(cls) -> None:
         """
         Quit the webdriver and screenshot the contents if there was a test failure
         """
+        super().tearDownClass()
+        cls.driver.quit()
+        set_url("http://localhost:0000")
+
+    def tearDown(self) -> None:
         if self._is_test_failure():
             self._screenshot_driver()
-        self.driver.quit()
-        set_url("http://localhost:0000")
 
     def _screenshot_driver(self):
         now = datetime.datetime.now()


### PR DESCRIPTION
### Summary of work
- Moves driver start and quit in setUpClass/tearDownClass
- Adds atexit register that will close the driver window

This means that only one Chrome/WebDriver instance will be started per test class. Should make tests run a bit faster. I wonder if this will cause any issues for parallel running though? Is it worth worrying about when it's not currently working anyway?

### How to test your work
CI tests should pass.

### Additional comments
<!---Anything else: e.g. was the estimate reasonable for this issue?---> 

Fixes #xyz


**Before merging ensure the release notes have been updated**