### PR TITLE
Show run description in Run Summary

### DIFF
--- a/WebApp/autoreduce_webapp/autoreduce_webapp/fixtures/run_with_one_variable.json
+++ b/WebApp/autoreduce_webapp/autoreduce_webapp/fixtures/run_with_one_variable.json
@@ -6,13 +6,15 @@
             "run_number": 99999,
             "status_id": 2,
             "run_version": 0,
+            "run_name": "This is the test run_name",
             "last_updated": "2020-10-19 17:35:04+00:00",
             "created": "2020-10-19 17:30:04+00:00",
             "reduction_log": "test_log",
             "admin_log": "log",
             "hidden_in_failviewer": 0,
             "experiment_id": 1,
-            "instrument_id": 1
+            "instrument_id": 1,
+            "started_by": -1
         }
     },
     {

--- a/WebApp/autoreduce_webapp/selenium_tests/pages/run_summary_page.py
+++ b/WebApp/autoreduce_webapp/selenium_tests/pages/run_summary_page.py
@@ -88,3 +88,39 @@ class RunSummaryPage(Page, RerunFormMixin, NavbarMixin, FooterMixin, TourMixin):
         Finds and returns the "warning_message" box
         """
         return self.driver.find_element_by_id("warning_message")
+
+    def run_description_text(self) -> str:
+        """
+        Finds and returns the text of the run_description field
+        """
+        return self.driver.find_element_by_id("run_description").text
+
+    def started_by_text(self) -> str:
+        """
+        Finds and returns the text of the started_by field
+        """
+        return self.driver.find_element_by_id("started_by").text
+
+    def status_text(self) -> str:
+        """
+        Finds and returns the text of the status field
+        """
+        return self.driver.find_element_by_id("status").text
+
+    def instrument_text(self) -> str:
+        """
+        Finds and returns the text of the instrument field
+        """
+        return self.driver.find_element_by_id("instrument").text
+
+    def rb_number_text(self) -> str:
+        """
+        Finds and returns the text of the rb_number field
+        """
+        return self.driver.find_element_by_id("rb_number").text
+
+    def last_updated_text(self) -> str:
+        """
+        Finds and returns the text of the last_updated field
+        """
+        return self.driver.find_element_by_id("last_updated").text

--- a/WebApp/autoreduce_webapp/templates/run_summary.html
+++ b/WebApp/autoreduce_webapp/templates/run_summary.html
@@ -61,29 +61,29 @@
                     <div class="panel-body">
                         <div class="row">
                             <div class="col-md-6">
+                                <div id="run_description">
                                 {% if run.run_name %}
-                                <div>
                                     <strong>Run description: </strong> {{ run.run_name }}
+                                    {% endif %}
                                 </div>
-                                {% endif %}
+                                <div id="started_by">
                                 {% if started_by is not null %}
-                                    <div>
-                                        <strong>Started by:</strong> {{ started_by }}
-                                    </div>
-                                {% endif %}
-                                <div>
+                                    <strong>Started by:</strong> {{ started_by }}
+                                    {% endif %}
+                                </div>
+                                <div id="status">
                                     <strong>Status:</strong> <strong
                                         class="text-{% colour_table_row run.status.value_verbose %}">{{ run.status.value_verbose }}</strong>
                                 </div>
-                                <div>
+                                <div id="instrument">
                                     <strong>Instrument:</strong> <a
                                         href="{% url 'runs:list' instrument=run.instrument.name %}">{{ run.instrument.name }}</a>
                                 </div>
-                                <div>
+                                <div id="rb_number">
                                     <strong>RB Number:</strong> <a
                                         href="{% url 'experiment_summary' reference_number=run.experiment.reference_number %}">{{ run.experiment.reference_number }}</a>
                                 </div>
-                                <div>
+                                <div id="last_updated">
                                     <strong>Last Updated:</strong> {{ run.last_updated }}
                                 </div>
                             </div>

--- a/WebApp/autoreduce_webapp/templates/run_summary.html
+++ b/WebApp/autoreduce_webapp/templates/run_summary.html
@@ -61,11 +61,16 @@
                     <div class="panel-body">
                         <div class="row">
                             <div class="col-md-6">
+                                {% if run.run_name %}
                                 <div>
-                                    {% if started_by is not null %}
-                                        <strong>Started by:</strong> {{ started_by }}
-                                    {% endif %}
+                                    <strong>Run description: </strong> {{ run.run_name }}
                                 </div>
+                                {% endif %}
+                                {% if started_by is not null %}
+                                    <div>
+                                        <strong>Started by:</strong> {{ started_by }}
+                                    </div>
+                                {% endif %}
                                 <div>
                                     <strong>Status:</strong> <strong
                                         class="text-{% colour_table_row run.status.value_verbose %}">{{ run.status.value_verbose }}</strong>

--- a/utils/clients/tests/test_queue_client.py
+++ b/utils/clients/tests/test_queue_client.py
@@ -21,13 +21,6 @@ class TestQueueClient(TestCase):
     """
     Exercises the queue client
     """
-    def setUp(self):
-        self.incorrect_credentials = ClientSettingsFactory().create('queue',
-                                                                    username='not-user',
-                                                                    password='not-pass',
-                                                                    host='not-host',
-                                                                    port='1234')
-
     def test_default_init(self):
         """
         Test: Class variables are created and set
@@ -55,22 +48,17 @@ class TestQueueClient(TestCase):
         client.connect()
         self.assertTrue(client._test_connection())
 
-    @patch('stomp.connect.StompConnection11.is_connected', return_value=False)
-    def test_invalid_connection_raises_on_test(self, _):
-        """
-        Test: A ConnectionException is raised
-        When: _test_connection is called while a valid connection is not held
-        """
-        client = QueueClient()
-        client.connect()
-        self.assertRaises(ConnectionException, client._test_connection)
-
-    def test_invalid_credentials(self):
+    def test_connection_failed_invalid_credentials(self):
         """
         Test: A ConnectionException is raised
         When: _test_connection is called while invalid credentials are held
         """
-        client = QueueClient(self.incorrect_credentials)
+        incorrect_credentials = ClientSettingsFactory().create('queue',
+                                                               username='not-user',
+                                                               password='not-pass',
+                                                               host='not-host',
+                                                               port='1234')
+        client = QueueClient(incorrect_credentials)
         with self.assertRaises(ConnectionException):
             client.connect()
 


### PR DESCRIPTION
This is based on #1042 and should be merged after

### Summary of work
Shows run description in Run Summary. Does NOT rename `run_name` to `run_description`.

### How to test your work
Rerun a run with a run description. The description should show up like:

![image](https://user-images.githubusercontent.com/9135965/109955446-67bbae80-7cda-11eb-8c0e-68707300e0e6.png)

Fixes #1180