### PR TITLE
Automatic production path configuration based on environment var

### DIFF
--- a/WebApp/autoreduce_webapp/autoreduce_webapp/settings.py
+++ b/WebApp/autoreduce_webapp/autoreduce_webapp/settings.py
@@ -113,18 +113,24 @@ if "RUNNING_VIA_PYTEST" in os.environ:
             'NAME': ':memory:',
         }
     }
-else:
+elif "AUTOREDUCTION_PRODUCTION" in os.environ:
     DATABASES = {
         'default': {
-            #     'ENGINE': 'django.db.backends.mysql',
-            #     'NAME': get_str('DATABASE', 'name'),
-            #     'USER': get_str('DATABASE', 'user'),
-            #     'PASSWORD': get_str('DATABASE', 'password'),
-            #     'HOST': get_str('DATABASE', 'host'),
-            #     'PORT': get_str('DATABASE', 'port'),
-            #     'OPTIONS': {
-            #         'init_command': "SET sql_mode='STRICT_TRANS_TABLES'",
-            #     },
+            'ENGINE': 'django.db.backends.mysql',
+            'NAME': get_str('DATABASE', 'name'),
+            'USER': get_str('DATABASE', 'user'),
+            'PASSWORD': get_str('DATABASE', 'password'),
+            'HOST': get_str('DATABASE', 'host'),
+            'PORT': get_str('DATABASE', 'port'),
+            'OPTIONS': {
+                'init_command': "SET sql_mode='STRICT_TRANS_TABLES'",
+            },
+        }
+    }
+
+else:  # the default development DB backend
+    DATABASES = {
+        'default': {
             'ENGINE': 'django.db.backends.sqlite3',  # Add 'postgresql_psycopg2', 'mysql', 'sqlite3' or 'oracle'.
             'NAME': f'{PROJECT_ROOT}/sqlite3.db',  # Or path to database file if using sqlite3.
         }

--- a/queue_processors/queue_processor/settings.py
+++ b/queue_processors/queue_processor/settings.py
@@ -24,15 +24,19 @@ else:
 # The reduction outputs are saved there. If you want to avoid writing to the real CEPH then
 # change this to a local directory - the reductions should process fine regardless.
 # %(instrument, experiment_number, run_number)
-# CEPH_DIRECTORY = "/instrument/%s/RBNumber/RB%s/autoreduced/%s"
-CEPH_DIRECTORY = f"{PROJECT_ROOT}/reduced-data/%s/RB%s/autoreduced/%s/"
+if "AUTOREDUCTION_PRODUCTION" in os.environ:
+    CEPH_DIRECTORY = "/instrument/%s/RBNumber/RB%s/autoreduced/%s"
+else:
+    CEPH_DIRECTORY = f"{PROJECT_ROOT}/reduced-data/%s/RB%s/autoreduced/%s/"
 
-# for development/prod or when connecting to the real archive, mounted locally
-# ARCHIVE_ROOT = "/isis"
-# for testing which uses a local folder to simulate an archive
-if "RUNNING_VIA_PYTEST" in os.environ:
+if "AUTOREDUCTION_PRODUCTION" in os.environ:
+    # for when deploying on production - this is the real path where the mounts are
+    ARCHIVE_ROOT = "/isis"
+elif "RUNNING_VIA_PYTEST" in os.environ:
+    # for testing which uses a local folder to simulate an archive
     ARCHIVE_ROOT = os.path.join(PROJECT_ROOT, 'test-archive')
 else:
+    # the default development path
     ARCHIVE_ROOT = os.path.join(PROJECT_ROOT, 'data-archive')
 
 # Variables that get changes less


### PR DESCRIPTION
### Summary of work
Settings now check for `AUTOREDUCTION_PRODUCTION` environment variable, and if so default to the correct production paths.

### How to test your work
Code review

Fixes #1121 
