### PR TITLE
Configure New Runs page now shows the correct values for the selected range/experiment

### DIFF
--- a/WebApp/autoreduce_webapp/autoreduce_webapp/fixtures/two_runs_two_vars.json
+++ b/WebApp/autoreduce_webapp/autoreduce_webapp/fixtures/two_runs_two_vars.json
@@ -32,22 +32,6 @@
         }
     },
     {
-        "model": "reduction_viewer.reductionrun",
-        "pk": 3,
-        "fields": {
-            "run_number": 100001,
-            "status_id": 5,
-            "run_version": 0,
-            "last_updated": "2020-10-19 17:35:04+00:00",
-            "created": "2020-10-19 17:30:04+00:00",
-            "reduction_log": "test_log",
-            "admin_log": "log",
-            "hidden_in_failviewer": 0,
-            "experiment_id": 1,
-            "instrument_id": 1
-        }
-    },
-    {
         "pk": 1,
         "model": "reduction_viewer.datalocation",
         "fields": {
@@ -199,20 +183,4 @@
             "reduction_run_id": 2
         }
     },
-    {
-        "model": "instrument.runvariable",
-        "pk": 5,
-        "fields": {
-            "variable_id": 1,
-            "reduction_run_id": 3
-        }
-    },
-    {
-        "model": "instrument.runvariable",
-        "pk": 6,
-        "fields": {
-            "variable_id": 2,
-            "reduction_run_id": 3
-        }
-    }
 ]

--- a/WebApp/autoreduce_webapp/autoreduce_webapp/fixtures/two_runs_two_vars.json
+++ b/WebApp/autoreduce_webapp/autoreduce_webapp/fixtures/two_runs_two_vars.json
@@ -182,5 +182,5 @@
             "variable_id": 4,
             "reduction_run_id": 2
         }
-    },
+    }
 ]

--- a/WebApp/autoreduce_webapp/autoreduce_webapp/fixtures/two_runs_two_vars.json
+++ b/WebApp/autoreduce_webapp/autoreduce_webapp/fixtures/two_runs_two_vars.json
@@ -1,0 +1,218 @@
+[
+    {
+        "model": "reduction_viewer.reductionrun",
+        "pk": 1,
+        "fields": {
+            "run_number": 99999,
+            "status_id": 5,
+            "run_version": 0,
+            "last_updated": "2020-10-19 17:35:04+00:00",
+            "created": "2020-10-19 17:30:04+00:00",
+            "reduction_log": "test_log",
+            "admin_log": "log",
+            "hidden_in_failviewer": 0,
+            "experiment_id": 1,
+            "instrument_id": 1
+        }
+    },
+    {
+        "model": "reduction_viewer.reductionrun",
+        "pk": 2,
+        "fields": {
+            "run_number": 100000,
+            "status_id": 5,
+            "run_version": 0,
+            "last_updated": "2020-10-19 17:35:04+00:00",
+            "created": "2020-10-19 17:30:04+00:00",
+            "reduction_log": "test_log",
+            "admin_log": "log",
+            "hidden_in_failviewer": 0,
+            "experiment_id": 1,
+            "instrument_id": 1
+        }
+    },
+    {
+        "model": "reduction_viewer.reductionrun",
+        "pk": 3,
+        "fields": {
+            "run_number": 100001,
+            "status_id": 5,
+            "run_version": 0,
+            "last_updated": "2020-10-19 17:35:04+00:00",
+            "created": "2020-10-19 17:30:04+00:00",
+            "reduction_log": "test_log",
+            "admin_log": "log",
+            "hidden_in_failviewer": 0,
+            "experiment_id": 1,
+            "instrument_id": 1
+        }
+    },
+    {
+        "pk": 1,
+        "model": "reduction_viewer.datalocation",
+        "fields": {
+            "file_path": "/tmp",
+            "reduction_run_id": 1
+        }
+    },
+    {
+        "pk": 2,
+        "model": "reduction_viewer.datalocation",
+        "fields": {
+            "file_path": "/tmp",
+            "reduction_run_id": 2
+        }
+    },
+    {
+        "model": "reduction_viewer.experiment",
+        "pk": 1,
+        "fields": {
+            "reference_number": 1234567
+        }
+    },
+    {
+        "model": "reduction_viewer.instrument",
+        "pk": 1,
+        "fields": {
+            "name": "TestInstrument",
+            "is_active": true,
+            "is_paused": false
+        }
+    },
+    {
+        "model": "instrument.variable",
+        "pk": 1,
+        "fields": {
+            "name": "std_var",
+            "value": "value1",
+            "type": "text",
+            "is_advanced": false,
+            "help_text": ""
+        }
+    },
+    {
+        "model": "instrument.variable",
+        "pk": 2,
+        "fields": {
+            "name": "adv_var",
+            "value": "advanced value1",
+            "type": "text",
+            "is_advanced": true,
+            "help_text": ""
+        }
+    },
+    {
+        "model": "instrument.variable",
+        "pk": 3,
+        "fields": {
+            "name": "std_var",
+            "value": "value2",
+            "type": "text",
+            "is_advanced": false,
+            "help_text": ""
+        }
+    },
+    {
+        "model": "instrument.variable",
+        "pk": 4,
+        "fields": {
+            "name": "adv_var",
+            "value": "advanced value2",
+            "type": "text",
+            "is_advanced": true,
+            "help_text": ""
+        }
+    },
+    {
+        "model": "instrument.instrumentvariable",
+        "pk": 1,
+        "fields": {
+            "variable_ptr_id": 1,
+            "instrument_id": 1,
+            "experiment_reference": null,
+            "start_run": 99999,
+            "tracks_script": true
+        }
+    },
+    {
+        "model": "instrument.instrumentvariable",
+        "pk": 2,
+        "fields": {
+            "variable_ptr_id": 2,
+            "instrument_id": 1,
+            "experiment_reference": null,
+            "start_run": 99999,
+            "tracks_script": true
+        }
+    },
+    {
+        "model": "instrument.instrumentvariable",
+        "pk": 3,
+        "fields": {
+            "variable_ptr_id": 3,
+            "instrument_id": 1,
+            "experiment_reference": null,
+            "start_run": 100000,
+            "tracks_script": true
+        }
+    },
+    {
+        "model": "instrument.instrumentvariable",
+        "pk": 4,
+        "fields": {
+            "variable_ptr_id": 4,
+            "instrument_id": 1,
+            "experiment_reference": null,
+            "start_run": 100000,
+            "tracks_script": true
+        }
+    },
+    {
+        "model": "instrument.runvariable",
+        "pk": 1,
+        "fields": {
+            "variable_id": 1,
+            "reduction_run_id": 1
+        }
+    },
+    {
+        "model": "instrument.runvariable",
+        "pk": 2,
+        "fields": {
+            "variable_id": 2,
+            "reduction_run_id": 1
+        }
+    },
+    {
+        "model": "instrument.runvariable",
+        "pk": 3,
+        "fields": {
+            "variable_id": 3,
+            "reduction_run_id": 2
+        }
+    },
+    {
+        "model": "instrument.runvariable",
+        "pk": 4,
+        "fields": {
+            "variable_id": 4,
+            "reduction_run_id": 2
+        }
+    },
+    {
+        "model": "instrument.runvariable",
+        "pk": 5,
+        "fields": {
+            "variable_id": 1,
+            "reduction_run_id": 3
+        }
+    },
+    {
+        "model": "instrument.runvariable",
+        "pk": 6,
+        "fields": {
+            "variable_id": 2,
+            "reduction_run_id": 3
+        }
+    }
+]

--- a/WebApp/autoreduce_webapp/instrument/views/runs.py
+++ b/WebApp/autoreduce_webapp/instrument/views/runs.py
@@ -379,7 +379,8 @@ def configure_new_runs_get(instrument_name, start=0, end=0, experiment_reference
         'current_experiment_reference': experiment_reference,
         # used to create the link to an experiment reference form, using this number
         'submit_for_experiment_reference': last_run.experiment.reference_number,
-        'minimum_run_start': last_run.run_number,
+        'minimum_run_start': run_start,
+        'minimum_run_end': run_start + 1,
         'upcoming_run_variables': upcoming_run_variables,
         'editing': editing,
         'tracks_script': '',

--- a/WebApp/autoreduce_webapp/selenium_tests/pages/variables_summary_page.py
+++ b/WebApp/autoreduce_webapp/selenium_tests/pages/variables_summary_page.py
@@ -5,7 +5,7 @@
 # SPDX - License - Identifier: GPL-3.0-or-later
 # ############################################################################### #
 
-from typing import List, Tuple
+from typing import List
 from functools import partial
 
 from django.urls import reverse

--- a/WebApp/autoreduce_webapp/selenium_tests/pages/variables_summary_page.py
+++ b/WebApp/autoreduce_webapp/selenium_tests/pages/variables_summary_page.py
@@ -70,14 +70,31 @@ class VariableSummaryPage(Page, NavbarMixin, FooterMixin, TourMixin):
         WebDriverWait(self.driver, 10).until(partial(delete_button_clicked_successfully, button))
 
     def click_run_edit_button_for(self, start: int, end: int):
+        """
+        Click the edit button for the given run start and end
+        :param start: The start run
+        :param end: The end run
+        :return: The edit button
+        """
         url = reverse("instrument:variables", kwargs={"instrument": self.instrument, "start": start, "end": end})
         self._do_run_button(url)
 
     def click_run_delete_button_for(self, start: int, end: int):
+        """
+        Click the delete button for the given run start and run end
+        :param start: The start run
+        :param end: The end run
+        :return: The delete button
+        """
         url = reverse("instrument:delete_variables", kwargs={"instrument": self.instrument, "start": start, "end": end})
         self._do_delete_button(url)
 
     def click_experiment_edit_button_for(self, experiment_reference: int):
+        """
+        Get the edit button for the given experiment reference
+        :param experiment_reference: The experiment reference
+        :return: The edit button
+        """
         url = reverse("instrument:variables_by_experiment",
                       kwargs={
                           "instrument": self.instrument,
@@ -86,6 +103,11 @@ class VariableSummaryPage(Page, NavbarMixin, FooterMixin, TourMixin):
         self._do_run_button(url)
 
     def click_experiment_delete_button_for(self, experiment_reference: int):
+        """
+        Get the delete button for the given experiment reference
+        :param experiment_reference: The experiment refence
+        :return: The delete button
+        """
         url = reverse("instrument:delete_variables_by_experiment",
                       kwargs={
                           "instrument": self.instrument,

--- a/WebApp/autoreduce_webapp/selenium_tests/tests/test_configure_new_runs_integration.py
+++ b/WebApp/autoreduce_webapp/selenium_tests/tests/test_configure_new_runs_integration.py
@@ -223,7 +223,7 @@ class TestConfigureNewRunsPageIntegration(NavbarTestMixin, BaseTestCase, FooterT
 
         summary = VariableSummaryPage(self.driver, self.instrument_name)
 
-        summary.run_edit_button_for(self.run_number + 1, self.run_number + 101)[0].click()
+        summary.click_run_edit_button_for(self.run_number + 1, self.run_number + 101)
 
         self.page.variable1_field = "a new test value 123"
         self.page.submit_button.click()
@@ -234,7 +234,7 @@ class TestConfigureNewRunsPageIntegration(NavbarTestMixin, BaseTestCase, FooterT
         assert "new_value" not in upcoming_panel.get_attribute("textContent")
         assert "a new test value 123" in upcoming_panel.get_attribute("textContent")
 
-        summary.run_delete_button_for(self.run_number + 1, self.run_number + 101)[0].click()
+        summary.click_run_delete_button_for(self.run_number + 1, self.run_number + 101)
 
         upcoming_panel = summary.panels[1]
         assert "a new test value 123" not in upcoming_panel.get_attribute("textContent")
@@ -249,16 +249,17 @@ class TestConfigureNewRunsPageIntegration(NavbarTestMixin, BaseTestCase, FooterT
         assert "Ongoing" in incoming_run_numbers[2].text
 
         # now for the 2nd variable we made
-        summary.run_edit_button_for(self.run_number + 201, self.run_number + 401)[0].click()
+        summary.click_run_edit_button_for(self.run_number + 201, self.run_number + 401)
         self.page.variable1_field = "another new test value 321"
         self.page.submit_button.click()
+        self.page.replace_confirm.click()
 
         upcoming_panel = summary.panels[1]
 
         assert "new_value" not in upcoming_panel.get_attribute("textContent")
         assert "another new test value 321" in upcoming_panel.get_attribute("textContent")
 
-        summary.run_delete_button_for(self.run_number + 201, self.run_number + 401)[0].click()
+        summary.click_run_delete_button_for(self.run_number + 201, self.run_number + 401)
 
         upcoming_panel = summary.panels[1]
         assert "another new test value 321" not in upcoming_panel.get_attribute("textContent")

--- a/WebApp/autoreduce_webapp/selenium_tests/tests/test_configure_new_runs_integration.py
+++ b/WebApp/autoreduce_webapp/selenium_tests/tests/test_configure_new_runs_integration.py
@@ -5,14 +5,15 @@
 # SPDX - License - Identifier: GPL-3.0-or-later
 # ############################################################################### #
 
-from instrument.models import InstrumentVariable
 from selenium.common.exceptions import NoSuchElementException
 from selenium_tests.pages.configure_new_runs_page import ConfigureNewRunsPage
 from selenium_tests.pages.variables_summary_page import VariableSummaryPage
 from selenium_tests.tests.base_tests import (BaseTestCase, FooterTestMixin, NavbarTestMixin)
 
-from WebApp.autoreduce_webapp.selenium_tests.utils import setup_external_services
+from instrument.models import InstrumentVariable
 from model.database import access as db
+from WebApp.autoreduce_webapp.selenium_tests.utils import \
+    setup_external_services
 
 REDUCE_VARS_DEFAULT_VALUE = "default value from reduce_vars"
 
@@ -277,7 +278,7 @@ class TestConfigureNewRunsPageIntegration(NavbarTestMixin, BaseTestCase, FooterT
         self._submit_var_value("new_value", experiment_number=1234567)
         self._submit_var_value("the newest value", experiment_number=2345678)
         summary = VariableSummaryPage(self.driver, self.instrument_name)
-        summary.experiment_edit_button_for(1234567)[0].click()
+        summary.click_experiment_edit_button_for(1234567)
 
         self.page.variable1_field = "a new test value 123"
         self.page.submit_button.click()
@@ -287,14 +288,14 @@ class TestConfigureNewRunsPageIntegration(NavbarTestMixin, BaseTestCase, FooterT
         assert "new_value" not in experiment_panel.get_attribute("textContent")
         assert "a new test value 123" in experiment_panel.get_attribute("textContent")
 
-        summary.experiment_delete_button_for(1234567)[0].click()
+        summary.click_experiment_delete_button_for(1234567)
 
         experiment_panel = summary.panels[1]
         incoming_exp_numbers = experiment_panel.find_elements_by_class_name("run-numbers")
 
         assert "2345678" in incoming_exp_numbers[0].text
 
-        summary.experiment_edit_button_for(2345678)[0].click()
+        summary.click_experiment_edit_button_for(2345678)
 
         self.page.variable1_field = "a new value for experiment 2345678"
         self.page.submit_button.click()
@@ -304,7 +305,7 @@ class TestConfigureNewRunsPageIntegration(NavbarTestMixin, BaseTestCase, FooterT
         assert "the newest value" not in experiment_panel.get_attribute("textContent")
         assert "a new value for experiment 2345678" in experiment_panel.get_attribute("textContent")
 
-        summary.experiment_delete_button_for(2345678)[0].click()
+        summary.click_experiment_delete_button_for(2345678)
 
         # only the current variables panel left
         assert len(summary.panels) == 1

--- a/WebApp/autoreduce_webapp/selenium_tests/tests/test_run_summary.py
+++ b/WebApp/autoreduce_webapp/selenium_tests/tests/test_run_summary.py
@@ -58,8 +58,7 @@ class TestRunSummaryPageNoArchive(NavbarTestMixin, BaseTestCase, FooterTestMixin
         assert self.page.run_description_text() == "Run description: This is the test run_description"
 
 
-class TestRunSummaryPage(BaseTestCase):
-    # class TestRunSummaryPage(NavbarTestMixin, BaseTestCase, FooterTestMixin):
+class TestRunSummaryPage(NavbarTestMixin, BaseTestCase, FooterTestMixin):
     """
     Test cases for the InstrumentSummary page when the Rerun form is NOT visible
     """

--- a/WebApp/autoreduce_webapp/selenium_tests/tests/test_see_instrument_variables.py
+++ b/WebApp/autoreduce_webapp/selenium_tests/tests/test_see_instrument_variables.py
@@ -33,9 +33,7 @@ class TestSeeInstrumentVariablesPageWithMissingFiles(BaseTestCase, NavbarTestMix
 
     def test_edit_no_reduce_vars_shows_error(self):
         """Tests: Error is shown when no reduce_vars.py exists and edit variables is clicked."""
-        btn, url = self.page.run_edit_button_for(100100, 100150)
-        btn.click()
-        assert url in self.driver.current_url
+        self.page.click_run_edit_button_for(100100, 100150)
         message = self.page.message
         assert message.is_displayed()
         assert "No such file or directory" in message.text
@@ -80,9 +78,8 @@ class TestSeeInstrumentVariablesPage(BaseTestCase):
         # makes sure the value we are going to modify is present in the initial values
         assert value_to_modify in upcoming_panel.get_attribute("textContent")
 
-        btn, url = self.page.run_edit_button_for(start, end)
-        btn.click()
-        assert url in self.driver.current_url
+        self.page.click_run_edit_button_for(100100, 100150)
+
         new_runs_page = ConfigureNewRunsPage(self.driver, self.instrument_name, start, end)
         assert new_runs_page.run_start_val == str(start)
         if end > 0:
@@ -118,8 +115,7 @@ class TestSeeInstrumentVariablesPage(BaseTestCase):
         assert "100200" in incoming_run_numbers[2].text
         assert "Ongoing" in incoming_run_numbers[2].text
 
-        btn, _ = self.page.run_delete_button_for(start, end)
-        btn.click()
+        self.page.click_run_delete_button_for(start, end)
 
         current_panel_runs = self.page.panels[0].find_element_by_class_name("run-numbers")
         # check that the current variables end at the correct run

--- a/WebApp/autoreduce_webapp/selenium_tests/tests/test_see_instrument_variables.py
+++ b/WebApp/autoreduce_webapp/selenium_tests/tests/test_see_instrument_variables.py
@@ -88,14 +88,10 @@ class TestSeeInstrumentVariablesPage(BaseTestCase):
         if end > 0:
             assert new_runs_page.run_end_val == str(end)
 
-        # this is actually the wrong value - known issue and documented at
-        # https://github.com/ISISScientificComputing/autoreduce/issues/1133
-        # Once it's fixed this test should fail - the correct assertion would be
-        # assert new_runs_page.variable1_field_val == "value2"
-        assert new_runs_page.variable1_field_val == "value1"
-
+        assert new_runs_page.variable1_field_val == value_to_modify
         new_runs_page.variable1_field = "some new value"
         new_runs_page.submit_button.click()
+        new_runs_page.replace_confirm.click()
 
         upcoming_panel = self.page.panels[1]
         # make sure the value we are modifying is no longer visible
@@ -146,11 +142,7 @@ class TestSeeInstrumentVariablesPage(BaseTestCase):
                                              self.instrument_name,
                                              experiment_reference=experiment_reference)
 
-        # this is actually the wrong value - known issue and documented at
-        # https://github.com/ISISScientificComputing/autoreduce/issues/1133
-        # Once it's fixed this test should fail - the correct assertion would be
-        # assert new_runs_page.variable1_field_val == f"experiment {experiment_reference} var"
-        assert new_runs_page.variable1_field_val == "value1"
+        assert new_runs_page.variable1_field_val == f"experiment {experiment_reference} var"
 
         new_runs_page.variable1_field = "some new value"
         new_runs_page.submit_button.click()

--- a/WebApp/autoreduce_webapp/selenium_tests/tests/test_see_instrument_variables.py
+++ b/WebApp/autoreduce_webapp/selenium_tests/tests/test_see_instrument_variables.py
@@ -78,7 +78,7 @@ class TestSeeInstrumentVariablesPage(BaseTestCase):
         # makes sure the value we are going to modify is present in the initial values
         assert value_to_modify in upcoming_panel.get_attribute("textContent")
 
-        self.page.click_run_edit_button_for(100100, 100150)
+        self.page.click_run_edit_button_for(start, end)
 
         new_runs_page = ConfigureNewRunsPage(self.driver, self.instrument_name, start, end)
         assert new_runs_page.run_start_val == str(start)
@@ -131,9 +131,7 @@ class TestSeeInstrumentVariablesPage(BaseTestCase):
         # makes sure the value we are going to modify is present in the initial values
         assert f"experiment {experiment_reference} var" in experiment_panel.get_attribute("textContent")
 
-        btn, url = self.page.experiment_edit_button_for(experiment_reference)
-        btn.click()
-        assert url in self.driver.current_url
+        self.page.click_experiment_edit_button_for(experiment_reference)
         new_runs_page = ConfigureNewRunsPage(self.driver,
                                              self.instrument_name,
                                              experiment_reference=experiment_reference)
@@ -154,7 +152,6 @@ class TestSeeInstrumentVariablesPage(BaseTestCase):
         # makes sure the value we are going to modify is present in the initial values
         assert f"experiment {experiment_reference} var" in experiment_panel.get_attribute("textContent")
 
-        btn, _ = self.page.experiment_delete_button_for(experiment_reference)
-        btn.click()
+        self.page.click_experiment_delete_button_for(experiment_reference)
         experiment_panel = self.page.panels[2]
         assert f"experiment {experiment_reference} var" not in experiment_panel.get_attribute("textContent")

--- a/WebApp/autoreduce_webapp/templates/configure_new_runs.html
+++ b/WebApp/autoreduce_webapp/templates/configure_new_runs.html
@@ -88,8 +88,7 @@
                                 <label for="run_end" class="control-label col-md-6">Finished
                                     <small>(Optional)</small></label>
                                 <div class="col-md-6">
-                                    <input type="number" id="run_end" name="run_end"
-                                           value="{% if run_end %}{{ run_end }}{% endif %}" class="form-control"/>
+                                    <input type="number" id="run_end" name="run_end" value="{% if run_end %}{{ run_end }}{% endif %}" min="{{ minimum_run_end }}" class="form-control"/>
                                 </div>
                             </div>
                         </div>

--- a/WebApp/autoreduce_webapp/templates/configure_new_runs.html
+++ b/WebApp/autoreduce_webapp/templates/configure_new_runs.html
@@ -3,8 +3,16 @@
 {% load view %}
 {% load static %}
 {% block body %}
-    {% if instrument %}
-        {% if instrument.is_active %}
+    {% if not instrument or message %}
+        <div class="text-center col-md-6 col-md-offset-3 well well-small" id="message">
+            {{ message }}
+        </div>
+        {% else %}
+        {% if not instrument.is_active %}
+            <div class="text-center col-md-6 col-md-offset-3 well well-small">
+                Instrument is not active.
+            </div>
+        {% else %}
             <title>{{ instrument.name }} - Configure New Runs</title>
 
             <div class="row">
@@ -184,15 +192,7 @@
                     {% include "snippets/edit_variables.html" with standard_variables=current_standard_variables advanced_variables=current_advanced_variables instrument=instrument.name only %}
                 </div>
             </div>
-        {% else %}
-            <div class="text-center col-md-6 col-md-offset-3 well well-small">
-                Instrument is not active.
-            </div>
         {% endif %}
-    {% else %}
-        <div class="text-center col-md-6 col-md-offset-3 well well-small" id="message">
-            {{ message }}
-        </div>
     {% endif %}
 {% endblock %}
 


### PR DESCRIPTION
PR based on https://github.com/ISISScientificComputing/autoreduce/pull/1174 - some of the changes are from it.

### Summary of work
Configure New Runs now shows the correct values for the selected range/experiment.

- Tests are adjusted to expect the correct values (this was previously recorded as comments, e.g. see [here](https://github.com/ISISScientificComputing/autoreduce/pull/1194/files#diff-397f33f8e038ea162756f39b1b6c560e33aac6a47245f3a5cf9d99ecddf81d3eL83-L87))

- Some of the clicks are changed to a `WebDriverWait` to make the tests more reliable.
- Adds fixture `two_runs_two_vars.json` that has 3 runs:
	- Run 99999 using variable 1 & 2
	- Run 100000 using variable 3 & 4
	- This is not used in the tests. 
	- The goal is easier testing on PR reviews


### How to test your work
```
python setup.py database
python WebApp/autoreduce_webapp/manage.py loaddata super_user_fixture status_fixture two_runs_two_vars

```
Go to "Configure New Runs"
- Add new variables
- Repeat some of the "See instrument variables" at your choice. Try to break it - we need this to work robustly!

Go to "See instrument variables" 
- Edit some variables, make sure the initial values shown are the **SAME** as in the instrument variables page
- Change the value, resubmit, check that the value is updated correctly
- Repeat for variables for experiment number

Fixes #1133


**Before merging ensure the release notes have been updated**