### PR TITLE
Makes the message.description default = ""

### DIFF
--- a/model/message/message.py
+++ b/model/message/message.py
@@ -21,7 +21,7 @@ class Message:
     A class that represents an AMQ Message.
     Messages can be serialized and deserialized for sending messages to and from AMQ
     """
-    description = attr.ib(default=None)
+    description = attr.ib(default="")
     facility = attr.ib(default="ISIS")
     run_number = attr.ib(default=None)
     instrument = attr.ib(default=None)

--- a/model/message/tests/test_message.py
+++ b/model/message/tests/test_message.py
@@ -79,7 +79,7 @@ class TestMessage(unittest.TestCase):
         When: The class is initialised
         """
         empty_msg, _ = self._empty()
-        self.assertIsNone(empty_msg.description)
+        self.assertEqual(empty_msg.description, "")
         self.assertEqual(empty_msg.facility, "ISIS")
         self.assertIsNone(empty_msg.run_number)
         self.assertIsNone(empty_msg.instrument)


### PR DESCRIPTION
### Summary of work
Makes the message.description default = ""

This does not break the Run Summary description visualisation in the web app as empty string is does not pass the `{% if run_description %}` check and that field is not rendered, just like before.

### How to test your work
Check https://github.com/ISISScientificComputing/autoreduce/issues/1198

Fixes #1198


**Before merging ensure the release notes have been updated**