### PR TITLE
Removes Run end from Configure New Runs

### DIFF
--- a/WebApp/autoreduce_webapp/instrument/views/runs.py
+++ b/WebApp/autoreduce_webapp/instrument/views/runs.py
@@ -240,7 +240,6 @@ def configure_new_runs_post(request, instrument_name):
     or for experiment reference (when experiment_reference is given).
     """
     start = int(request.POST.get("run_start")) if request.POST.get("run_start", None) else None
-    end = int(request.POST.get("run_end")) if request.POST.get("run_end", None) else None
     experiment_reference = int(request.POST.get("experiment_reference_number")) if request.POST.get(
         "experiment_reference_number", None) else None
 

--- a/WebApp/autoreduce_webapp/instrument/views/runs.py
+++ b/WebApp/autoreduce_webapp/instrument/views/runs.py
@@ -282,8 +282,7 @@ def configure_new_runs_post(request, instrument_name):
                                                         args_for_range,
                                                         start,
                                                         from_webapp=True)
-    elif experiment_reference != 0:
-        experiment_reference = int(request.POST.get("experiment_reference_number", 1))
+    else:
         possible_variables = InstrumentVariable.objects.filter(experiment_reference=experiment_reference,
                                                                instrument__name=instrument_name)
         InstrumentVariablesUtils.find_or_make_variables(possible_variables,

--- a/WebApp/autoreduce_webapp/instrument/views/runs.py
+++ b/WebApp/autoreduce_webapp/instrument/views/runs.py
@@ -283,18 +283,7 @@ def configure_new_runs_post(request, instrument_name):
                                                         args_for_range,
                                                         start,
                                                         from_webapp=True)
-        if end:
-            possible_variables = InstrumentVariable.objects.filter(start_run__lte=end + 1,
-                                                                   instrument__name=instrument_name)
-            post_range_args = InstrumentVariablesUtils.merge_arguments({
-                'standard_vars': {},
-                'advanced_vars': {}
-            }, reduce_vars_module)
-
-            # Makes the variables that will be active for the range END + 1 -> onwards
-            InstrumentVariablesUtils.find_or_make_variables(possible_variables, instrument.id, post_range_args, end + 1)
-
-    else:
+    elif experiment_reference != 0:
         experiment_reference = int(request.POST.get("experiment_reference_number", 1))
         possible_variables = InstrumentVariable.objects.filter(experiment_reference=experiment_reference,
                                                                instrument__name=instrument_name)
@@ -372,7 +361,6 @@ def configure_new_runs_get(instrument_name, start=0, end=0, experiment_reference
         'current_standard_variables': current_standard_variables,
         'current_advanced_variables': current_advanced_variables,
         'run_start': run_start,
-        'run_end': end,
         # used to determine whether the current form is for an experiment reference
         'current_experiment_reference': experiment_reference,
         # used to create the link to an experiment reference form, using this number

--- a/WebApp/autoreduce_webapp/instrument/views/variables.py
+++ b/WebApp/autoreduce_webapp/instrument/views/variables.py
@@ -112,6 +112,11 @@ def summarize_variables(request, instrument, last_run_object):
 def delete_instrument_variables(request, instrument=None, start=0, end=0, experiment_reference=None):
     """
     Handles request for deleting instrument variables
+
+    :param instrument: Name of the instrument for which variables are being deleted
+    :param start: The start run from which variables are being deleted
+    :param end: Used to limit how many variables get deleted, otherwise a delete would wipe ALL variables > start
+    :param experiment_reference: If provided - use the experiment reference to delete variables instead of start_run
     """
 
     # We "save" an empty list to delete the previous variables.

--- a/WebApp/autoreduce_webapp/selenium_tests/pages/configure_new_runs_page.py
+++ b/WebApp/autoreduce_webapp/selenium_tests/pages/configure_new_runs_page.py
@@ -19,11 +19,10 @@ class ConfigureNewRunsPage(Page, RerunFormMixin, NavbarMixin, FooterMixin, TourM
     """
     Page model class for run summary page
     """
-    def __init__(self, driver, instrument, run_start=None, run_end=None, experiment_reference=None):
+    def __init__(self, driver, instrument, run_start=None, experiment_reference=None):
         super().__init__(driver)
         self.instrument = instrument
         self._run_start_number = run_start
-        self._run_end_number = run_end
         self._experiment_reference = experiment_reference
 
     def url_path(self) -> str:
@@ -40,10 +39,6 @@ class ConfigureNewRunsPage(Page, RerunFormMixin, NavbarMixin, FooterMixin, TourM
         else:
             if self._run_start_number:
                 kwargs["start"] = self._run_start_number
-
-            if self._run_end_number:
-                kwargs["end"] = self._run_end_number
-
             return reverse("instrument:variables", kwargs=kwargs)
 
     @property

--- a/WebApp/autoreduce_webapp/selenium_tests/tests/test_configure_new_runs.py
+++ b/WebApp/autoreduce_webapp/selenium_tests/tests/test_configure_new_runs.py
@@ -75,7 +75,7 @@ class TestConfigureNewRunsPage(NavbarTestMixin, BaseTestCase, FooterTestMixin):
         self.page.launch()
 
         self.page.go_to_other.click()
-        url = reverse("instrument:variables", kwargs={"instrument": self.instrument_name, "start": 100001, "end": 0})
+        url = reverse("instrument:variables", kwargs={"instrument": self.instrument_name, "start": 100001})
         assert url in self.driver.current_url
 
 

--- a/WebApp/autoreduce_webapp/selenium_tests/tests/test_see_instrument_variables.py
+++ b/WebApp/autoreduce_webapp/selenium_tests/tests/test_see_instrument_variables.py
@@ -82,8 +82,6 @@ class TestSeeInstrumentVariablesPage(BaseTestCase):
 
         new_runs_page = ConfigureNewRunsPage(self.driver, self.instrument_name, start, end)
         assert new_runs_page.run_start_val == str(start)
-        if end > 0:
-            assert new_runs_page.run_end_val == str(end)
 
         assert new_runs_page.variable1_field_val == value_to_modify
         new_runs_page.variable1_field = "some new value"

--- a/WebApp/autoreduce_webapp/static/javascript/run_variables.js
+++ b/WebApp/autoreduce_webapp/static/javascript/run_variables.js
@@ -67,6 +67,8 @@
                 if (start_val !== "" && !isNumber(start_val)) {
                     addInvalid($(start), '<strong>Run start</strong> must be a number.')
                 }
+            } else {
+                validateBatchRunRange();
             }
         };
 

--- a/WebApp/autoreduce_webapp/static/javascript/run_variables.js
+++ b/WebApp/autoreduce_webapp/static/javascript/run_variables.js
@@ -55,9 +55,8 @@
         };
 
         var validateRunRange = function validateRunRange() {
-            const start = document.getElementById('run_start');
-            const end = document.getElementById('run_end');
-            const experiment_reference = document.getElementById('experiment_reference_number');
+            var start = document.getElementById('run_start');
+            var experiment_reference = document.getElementById('experiment_reference_number');
 
             if (experiment_reference) {
                 if (!isNumber(experiment_reference.value)) {
@@ -65,18 +64,9 @@
                 }
             } else if (start) {
                 var start_val = start.value;
-                var end_val = end.value;
                 if (start_val !== "" && !isNumber(start_val)) {
                     addInvalid($(start), '<strong>Run start</strong> must be a number.')
                 }
-                if (end_val !== '' && !isNumber(end_val)) {
-                    addInvalid($(end), '<strong>Run finish</strong> can only be a number.')
-                }
-                if (parseInt(end_val) < parseInt(start_val) && parseInt(end_val) != 0) {
-                    addInvalid($(end), '<strong>Run finish</strong> must be greater than the run start.')
-                }
-            } else {
-                validateBatchRunRange();
             }
         };
 

--- a/WebApp/autoreduce_webapp/templates/configure_new_runs.html
+++ b/WebApp/autoreduce_webapp/templates/configure_new_runs.html
@@ -36,7 +36,7 @@
                 <div class="col-md-12 text-center">
                     <p>
                         {% if current_experiment_reference > 0 %}
-                        <a href="{% url 'instrument:variables' instrument=instrument.name start=run_start end=run_end %}" id="go_to_other">Click here to submit variables for a run range</a>
+                        <a href="{% url 'instrument:variables' instrument=instrument.name start=run_start %}" id="go_to_other">Click here to submit variables for a run range</a>
                         {% else %}
                         <a href="{% url 'instrument:variables_by_experiment' instrument=instrument.name experiment_reference=submit_for_experiment_reference %}" id="go_to_other">Click here to submit variables for an experiment reference</a>
                         {% endif %}
@@ -71,20 +71,11 @@
                 {% else %}
                 <div class="js-variable-by-run">
                     <div class="row">
-                        <div class="col-md-6">
+                        <div class="col-md-12">
                             <div class="form-group">
-                                <label for="run_start" class="control-label col-md-6">Run Number Start</label>
-                                <div class="col-md-6">
+                                <label for="run_start" class="control-label col-md-3">Run Number Start</label>
+                                <div class="col-md-9">
                                     <input type="number" id="run_start" name="run_start" value="{{ run_start }}" min="{{ minimum_run_start }}" class="form-control"/>
-                                </div>
-                            </div>
-                        </div>
-                        <div class="col-md-6">
-                            <div class="form-group">
-                                <label for="run_end" class="control-label col-md-6">Finished
-                                    <small>(Optional)</small></label>
-                                <div class="col-md-6">
-                                    <input type="number" id="run_end" name="run_end" value="{% if run_end %}{{ run_end }}{% endif %}" min="{{ minimum_run_end }}" class="form-control"/>
                                 </div>
                             </div>
                         </div>


### PR DESCRIPTION
### Summary of work
Removes the run end field and the creation of a variable signifying "run end".

This should make the variable handling a bit more robust.

### How to test your work
Tests should pass and code inspection.

Submit a few variables with different start runs and check that they are active for the correct ranges.

### Additional comments

Fixes #1209


**Before merging ensure the release notes have been updated**