### PR TITLE
Removes bootstrap-switch include

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -18,6 +18,10 @@
                 "hidden": false,
                 "group": "autoreduce",
             },
+            "env": {
+                "DISPLAY": ":1",
+                "RUNNING_VIA_PYTEST": "true"
+            }
         },
         {
             "name": "Pytest - Django",

--- a/WebApp/autoreduce_webapp/instrument/views/runs.py
+++ b/WebApp/autoreduce_webapp/instrument/views/runs.py
@@ -97,6 +97,10 @@ def run_confirmation(request, instrument: str):
         context_dictionary['error'] = exception.msg
         return context_dictionary
 
+    if not run_numbers:
+        context_dictionary['error'] = f"Could not correctly parse range input {range_string}"
+        return context_dictionary
+
     # Determine user level to set a maximum limit to the number of runs that can be re-queued
     if request.user.is_superuser:
         max_runs = 500

--- a/WebApp/autoreduce_webapp/static/javascript/run_variables.js
+++ b/WebApp/autoreduce_webapp/static/javascript/run_variables.js
@@ -136,6 +136,9 @@
         };
         var validateBatchRunRange = function validateBatchRunRange() {
             const run_range = document.getElementById('run_range');
+            if (!run_range) {
+                return
+            }
 
             // Check all comma and '-' seperated elements
             const comma_split_items = run_range.value.split(',');

--- a/WebApp/autoreduce_webapp/static/javascript/run_variables.js
+++ b/WebApp/autoreduce_webapp/static/javascript/run_variables.js
@@ -55,15 +55,15 @@
         };
 
         var validateRunRange = function validateRunRange() {
-            var start = document.getElementById('run_start');
-            var end = document.getElementById('run_end');
-            var experiment_reference = document.getElementById('experiment_reference_number');
+            const start = document.getElementById('run_start');
+            const end = document.getElementById('run_end');
+            const experiment_reference = document.getElementById('experiment_reference_number');
 
             if (experiment_reference) {
                 if (!isNumber(experiment_reference.value)) {
-                    addInvalid($experiment_reference, '<strong>Experiment Reference Number</strong> must be a number.')
+                    addInvalid($(experiment_reference), '<strong>Experiment Reference Number</strong> must be a number.')
                 }
-            } else {
+            } else if (start) {
                 var start_val = start.value;
                 var end_val = end.value;
                 if (start_val !== "" && !isNumber(start_val)) {
@@ -75,6 +75,8 @@
                 if (parseInt(end_val) < parseInt(start_val) && parseInt(end_val) != 0) {
                     addInvalid($(end), '<strong>Run finish</strong> must be greater than the run start.')
                 }
+            } else {
+                validateBatchRunRange();
             }
         };
 
@@ -133,21 +135,23 @@
             }
         };
         var validateBatchRunRange = function validateBatchRunRange() {
-            // Validates the batch re-run text
-            validateNotEmpty.call(this);
-            if ($(this).val().trim().endsWith(',')) {
-                addInvalid($(this), '<strong>Run Numbers</strong> must be a comma separated list of either numbers or ranges.');
-            }
+            debugger
+            const run_range = document.getElementById('run_range');
 
             // Check all comma and '-' seperated elements
-            comma_split_items = $(this).val().split(',');
-            var still_valid = true
-            for (i = 0; (i < comma_split_items.length) && still_valid; i++) {
+            const comma_split_items = run_range.value.split(',');
+            let still_valid = true
+            for (let i = 0; (i < comma_split_items.length) && still_valid; i++) {
                 var all_split_items = comma_split_items[i].split('-');
 
-                for (i = 0; i < all_split_items.length; i++) {
+                for (let i = 0; i < all_split_items.length; i++) {
                     if (!isNumber(all_split_items[i])) {
-                        addInvalid($(this), '<strong>Run Numbers</strong> must be a comma separated list of either numbers or ranges.');
+                        addInvalid($(run_range), '<strong>Run Numbers</strong> must be a comma separated list of either numbers or ranges.');
+                        still_valid = false
+                        break;
+                    }
+                    if (i > 0 && parseInt(all_split_items[i]) < parseInt(all_split_items[i - 1])) {
+                        addInvalid($(run_range), '<strong>Run Range</strong> must end in a later run.');
                         still_valid = false
                         break;
                     }
@@ -158,7 +162,6 @@
         // Finished validation at this point
         resetValidationStates();
         validateRunRange();
-        $('#run_range').each(validateBatchRunRange);
         $form.find('[data-type="text"]').each(validateText);
         $form.find('[data-type="number"]').each(validateNumber);
         $form.find('[data-type="boolean"]').each(validateBoolean);
@@ -170,7 +173,7 @@
             $('.js-form-validation-message').html('');
             $('.js-form-validation-message').append($('<p/>').text('Please fix the following error:'));
             $errorList = $('<ul/>');
-            for (var i = 0; i < errorMessages.length; i++) {
+            for (let i = 0; i < errorMessages.length; i++) {
                 $errorList.append($('<li/>').html(errorMessages[i]));
             }
             $('.js-form-validation-message').append($errorList).show();

--- a/WebApp/autoreduce_webapp/static/javascript/run_variables.js
+++ b/WebApp/autoreduce_webapp/static/javascript/run_variables.js
@@ -55,28 +55,25 @@
         };
 
         var validateRunRange = function validateRunRange() {
-            var $start = $('#run_start');
-            var $end = $('#run_end');
-            var $experiment_reference = $('#experiment_reference_number');
-            if ($start.length && $end.length && $experiment_reference.length) {
-                if ($('#variable-range-toggle').length > 0 && !$('#variable-range-toggle').bootstrapSwitch('state')) {
-                    validateNotEmpty.call($experiment_reference[0]);
-                    if (!isNumber($experiment_reference.val())) {
-                        addInvalid($experiment_reference, '<strong>Experiment Reference Number</strong> must be a number.')
-                    }
-                } else {
-                    validateNotEmpty.call($start[0]);
-                    var start_val = $start.val();
-                    var end_val = $end.val();
-                    if (!isNumber(start_val)) {
-                        addInvalid($start, '<strong>Run start</strong> must be a number.')
-                    }
-                    if (end_val !== '' && !isNumber(end_val)) {
-                        addInvalid($end, '<strong>Run finish</strong> can only be a number.')
-                    }
-                    if (parseInt(end_val) < parseInt(start_val) && parseInt(end_val) != 0) {
-                        addInvalid($end, '<strong>Run finish</strong> must be greater than the run start.')
-                    }
+            var start = document.getElementById('run_start');
+            var end = document.getElementById('run_end');
+            var experiment_reference = document.getElementById('experiment_reference_number');
+
+            if (experiment_reference) {
+                if (!isNumber(experiment_reference.value)) {
+                    addInvalid($experiment_reference, '<strong>Experiment Reference Number</strong> must be a number.')
+                }
+            } else {
+                var start_val = start.value;
+                var end_val = end.value;
+                if (start_val !== "" && !isNumber(start_val)) {
+                    addInvalid($(start), '<strong>Run start</strong> must be a number.')
+                }
+                if (end_val !== '' && !isNumber(end_val)) {
+                    addInvalid($(end), '<strong>Run finish</strong> can only be a number.')
+                }
+                if (parseInt(end_val) < parseInt(start_val) && parseInt(end_val) != 0) {
+                    addInvalid($(end), '<strong>Run finish</strong> must be greater than the run start.')
                 }
             }
         };

--- a/WebApp/autoreduce_webapp/static/javascript/run_variables.js
+++ b/WebApp/autoreduce_webapp/static/javascript/run_variables.js
@@ -135,7 +135,6 @@
             }
         };
         var validateBatchRunRange = function validateBatchRunRange() {
-            debugger
             const run_range = document.getElementById('run_range');
 
             // Check all comma and '-' seperated elements

--- a/WebApp/autoreduce_webapp/templates/submit_runs.html
+++ b/WebApp/autoreduce_webapp/templates/submit_runs.html
@@ -169,10 +169,8 @@
 
 {% block stylesheets %}
     <link rel="stylesheet" href="{% static 'css/vendor/prettify.css' %}">
-    <link rel="stylesheet" href="{% static 'css/vendor/bootstrap-switch.min.css' %}">
 {% endblock %}
 {% block scripts %}
     <script src="{% static 'javascript/vendor/prettify.js' %}"></script>
-    <script src="{% static 'javascript/vendor/bootstrap-switch.min.js' %}"></script>
     <script src="{% static 'javascript/run_variables.js' %}"></script>
 {% endblock %}

--- a/WebApp/autoreduce_webapp/templates/variables_summary.html
+++ b/WebApp/autoreduce_webapp/templates/variables_summary.html
@@ -22,10 +22,8 @@
 
 {% block stylesheets %}
     <link rel="stylesheet" href="{% static "css/vendor/prettify.css" %}">
-    <link rel="stylesheet" href="{% static "css/vendor/bootstrap-switch.min.css" %}">
 {% endblock %}
 {% block scripts %}
     <script src="{% static "javascript/vendor/prettify.js" %}"></script>
-    <script src="{% static "javascript/vendor/bootstrap-switch.min.js" %}"></script>
     <script src="{% static "javascript/run_variables.js" %}"></script>
 {% endblock %}


### PR DESCRIPTION
### Summary of work
Removes unused JS and CSS imports of Bootstrap-Switch. Usage of this was removed in #1174 but it seems there's some leftover imports.

Refactors `validateRunRange` and `validateBatchRunRange` to not use as much JQuery and be more robust.

`validateBatchRunRange` now enforces `B > A` in a `A-B` range (i.e. B should be a later run)

### How to test your work
Tests should pass.

Fixes #1220


**Before merging ensure the release notes have been updated**