### PR TITLE
Removes DB call from reduction runner

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -404,7 +404,7 @@ valid-metaclass-classmethod-first-arg=mcs
 [DESIGN]
 
 # Maximum number of arguments for function / method
-max-args=5
+max-args=8
 
 # Maximum number of attributes for a class (see R0902).
 max-attributes=7

--- a/WebApp/autoreduce_webapp/reduction_viewer/utils.py
+++ b/WebApp/autoreduce_webapp/reduction_viewer/utils.py
@@ -57,7 +57,6 @@ class ReductionRunUtils:
 
         return {"standard_vars": standard_vars, "advanced_vars": advanced_vars}
 
-    # pylint: disable=too-many-arguments
     @staticmethod
     def send_retry_message(user_id: int, most_recent_run: ReductionRun, run_description: str, script_text: str,
                            new_script_arguments: dict, overwrite_previous_data: bool) -> None:

--- a/WebApp/autoreduce_webapp/selenium_tests/pages/configure_new_runs_page.py
+++ b/WebApp/autoreduce_webapp/selenium_tests/pages/configure_new_runs_page.py
@@ -19,8 +19,6 @@ class ConfigureNewRunsPage(Page, RerunFormMixin, NavbarMixin, FooterMixin, TourM
     """
     Page model class for run summary page
     """
-
-    # pylint:disable=too-many-arguments
     def __init__(self, driver, instrument, run_start=None, run_end=None, experiment_reference=None):
         super().__init__(driver)
         self.instrument = instrument

--- a/WebApp/autoreduce_webapp/selenium_tests/tests/test_run_summary_integration.py
+++ b/WebApp/autoreduce_webapp/selenium_tests/tests/test_run_summary_integration.py
@@ -133,3 +133,6 @@ class TestRunSummaryPageIntegration(BaseTestCase, FooterTestMixin, NavbarTestMix
         # wait until the message processing is complete before ending the test
         # otherwise the message handling can pollute the DB state for the next test
         assert len(result) == 2
+        # check that the error is because of missing Mantid
+        # if this fails then something else in the reduction caused an error instead!
+        assert "Mantid" in result[1].admin_log

--- a/WebApp/autoreduce_webapp/utilities/pagination.py
+++ b/WebApp/autoreduce_webapp/utilities/pagination.py
@@ -20,8 +20,6 @@ class CustomPaginator:
     CustomPaginator to allow for more complex functionality to be used without doing heavy
     lifting in the django template code
     """
-
-    # pylint:disable=too-many-arguments
     def __init__(self, page_type, query_set, items_per_page, page_tolerance, current_page):
         """
         :param query_set: All data to show

--- a/docker_reduction/mantid/operations.py
+++ b/docker_reduction/mantid/operations.py
@@ -18,8 +18,6 @@ class MantidDocker:
     Class that contains the information required to perform
     a data reduction inside the mantid docker container
     """
-
-    # pylint:disable=too-many-arguments
     def __init__(self, reduction_script, input_file, output_directory, input_mount=None, output_mount=None):
         self.image_name = 'mantid-reduction-container'
         self.reduction_script = reduction_script

--- a/model/database/records.py
+++ b/model/database/records.py
@@ -13,7 +13,6 @@ import datetime
 import model.database.access
 
 
-# pylint: disable=too-many-arguments
 def create_reduction_run_record(experiment, instrument, message, run_version, script_text, status):
     """
     Creates an ORM record for the given reduction run and returns

--- a/model/message/message.py
+++ b/model/message/message.py
@@ -38,6 +38,7 @@ class Message:
     retry_in = attr.ib(default=None)
     reduction_data = attr.ib(default=None)  # Required by reduction runner
     software = attr.ib(default=None)
+    flat_output = attr.ib(default=False)
 
     def serialize(self, indent=None, limit_reduction_script=False):
         """

--- a/model/message/tests/test_message.py
+++ b/model/message/tests/test_message.py
@@ -40,7 +40,8 @@ class TestMessage(unittest.TestCase):
             'admin_log': "",
             'return_message': None,
             'retry_in': None,
-            'software': None
+            'software': None,
+            'flat_output': False
         }
         return empty_msg, empty_dict
 
@@ -70,6 +71,7 @@ class TestMessage(unittest.TestCase):
             'retry_in': None,
             'reduction_data': None,
             'software': None,
+            'flat_output': False
         }
         return populated_msg, populated_dict
 
@@ -97,6 +99,7 @@ class TestMessage(unittest.TestCase):
         self.assertIsNone(empty_msg.retry_in)
         self.assertIsNone(empty_msg.reduction_data)
         self.assertIsNone(empty_msg.software)
+        self.assertFalse(empty_msg.flat_output)
 
     def test_to_dict_populated(self):
         """

--- a/plotting/plot_factory/trace.py
+++ b/plotting/plot_factory/trace.py
@@ -13,9 +13,9 @@ import sys
 import plotly.graph_objects as go  # pylint: disable=unused-import
 
 
-class Trace:  # pylint: disable=too-many-arguments, line-too-long
+class Trace:
     """Creates a trace object """
-    def __init__(self, data, plot_style, plot_name, mode=None, error_bars=None):  # pylint: disable=too-many-arguments, line-too-long
+    def __init__(self, data, plot_style, plot_name, mode=None, error_bars=None):
         """
         Trace Object
         :param data (pandas dataframe)
@@ -56,7 +56,6 @@ class Trace:  # pylint: disable=too-many-arguments, line-too-long
         """
         return getattr(sys.modules[go.__name__], classname)
 
-    # pylint: disable=too-many-arguments
     def create_trace(self, data, plot_style, name, error_bars, mode=None):
         """
         Creates a trace

--- a/queue_processors/queue_processor/handle_message.py
+++ b/queue_processors/queue_processor/handle_message.py
@@ -136,6 +136,7 @@ class HandleMessage:
             self.reduction_skipped(reduction_run, message)
         else:
             self.activate_db_inst(instrument)
+            message.flat_output = instrument.is_flat_output
             self.do_reduction(reduction_run, message)
 
     @staticmethod

--- a/queue_processors/queue_processor/instrument_variable_utils.py
+++ b/queue_processors/queue_processor/instrument_variable_utils.py
@@ -23,7 +23,7 @@ from model.database import access as db
 from queue_processors.queue_processor.variable_utils import VariableUtils
 from queue_processors.queue_processor.reduction.service import ReductionScript
 
-# pylint:disable=too-many-arguments,too-many-locals
+# pylint:disable=too-many-locals
 
 
 class DataTooLong(ValueError):

--- a/queue_processors/queue_processor/reduction/runner.py
+++ b/queue_processors/queue_processor/reduction/runner.py
@@ -68,7 +68,10 @@ class ReductionRunner:
         reduction_script = ReductionScript(self.instrument)
         reduction_script_path = reduction_script.script_path
 
-        reduction_dir = ReductionDirectory(self.instrument, self.proposal, self.run_number)
+        reduction_dir = ReductionDirectory(self.instrument,
+                                           self.proposal,
+                                           self.run_number,
+                                           flat_output=self.message.flat_output)
         temp_dir = TemporaryReductionDirectory(self.proposal, self.run_number)
         try:
             reduction_log_stream = reduce(reduction_dir, temp_dir, datafile, reduction_script)

--- a/queue_processors/queue_processor/reduction/service.py
+++ b/queue_processors/queue_processor/reduction/service.py
@@ -18,7 +18,6 @@ from tempfile import TemporaryDirectory
 
 import chardet
 
-from model.database.access import is_instrument_flat_output
 from .exceptions import DatafileError, ReductionScriptError
 from .timeout import TimeOut
 from .utilities import channels_redirected

--- a/queue_processors/queue_processor/reduction/service.py
+++ b/queue_processors/queue_processor/reduction/service.py
@@ -176,8 +176,7 @@ class ReductionScript:
             return self.module.main(input_file=str(input_file.path), output_dir=str(output_dir.path))
 
 
-# pylint:disable=too-many-arguments; We will remove the log_Stream once we look at logging in ppa
-# more closely
+# We will remove the log_Stream once we look at logging in Reduction Runner more closely
 def reduce(reduction_dir, temp_dir, datafile, script):
     """
     Performs a reduction on the given datafile using the given script, outputting to the given

--- a/queue_processors/queue_processor/reduction/service.py
+++ b/queue_processors/queue_processor/reduction/service.py
@@ -33,9 +33,9 @@ class ReductionDirectory:
     ReductionDirectory encapsulated directory creation, deletion and handling output type
     (flat or not)
     """
-    def __init__(self, instrument, rb_number, run_number, overwrite=False):
+    def __init__(self, instrument, rb_number, run_number, overwrite=False, flat_output=False):
         self.overwrite = overwrite
-        self._is_flat_directory = is_instrument_flat_output(instrument)
+        self._is_flat_directory = flat_output
         self.path = Path(CEPH_DIRECTORY % (instrument, rb_number, run_number))
         self._build_path()
         self.log_path = self.path / "reduction_log"

--- a/queue_processors/queue_processor/reduction/tests/test_runner.py
+++ b/queue_processors/queue_processor/reduction/tests/test_runner.py
@@ -89,6 +89,9 @@ class TestReductionRunner(unittest.TestCase):
         mock_reduce.assert_called_once()
 
     def test_main_bad_data_for_populate(self):
+        """
+        Test: Providing bad data for the `main` function, i.e. not enough arguments
+        """
         with tempfile.NamedTemporaryFile() as tmp_file:
             sys.argv = ['', json.dumps({"apples": 13}), tmp_file.name]
             self.assertRaises(ValueError, main)
@@ -144,6 +147,9 @@ class TestReductionRunner(unittest.TestCase):
     @patch(f'{DIR}.runner.logger.info')
     @patch(f'{DIR}.runner.ReductionRunner._get_mantid_version', return_value="5.1.0")
     def test_reduce_bad_datafile(self, _get_mantid_version: Mock, mock_logger_info: Mock):
+        """
+        Test: Bad datafile is provided
+        """
         self.message.description = "testdescription"
         runner = ReductionRunner(self.message)
         runner.reduce()
@@ -154,8 +160,10 @@ class TestReductionRunner(unittest.TestCase):
 
     @patch(f'{DIR}.runner.ReductionRunner._get_mantid_version', return_value="5.1.0")
     @patch(f'{DIR}.runner.reduce')
-    @patch(f'{DIR}.service.is_instrument_flat_output', return_value=False)
-    def test_reduce_throws_reductionscripterror(self, _, reduce: Mock, _get_mantid_version: Mock):
+    def test_reduce_throws_reductionscripterror(self, reduce: Mock, _get_mantid_version: Mock):
+        """
+        Test: reduce throwing an ReductionScriptError
+        """
         reduce.side_effect = ReductionScriptError
         with tempfile.NamedTemporaryFile() as tmpfile:
             self.message.data = tmpfile.name
@@ -172,8 +180,10 @@ class TestReductionRunner(unittest.TestCase):
 
     @patch(f'{DIR}.runner.ReductionRunner._get_mantid_version', return_value="5.1.0")
     @patch(f'{DIR}.runner.reduce')
-    @patch(f'{DIR}.service.is_instrument_flat_output', return_value=False)
-    def test_reduce_throws_any_exception(self, _, reduce: Mock, _get_mantid_version: Mock):
+    def test_reduce_throws_any_exception(self, reduce: Mock, _get_mantid_version: Mock):
+        """
+        Test: Reduce throwing any exception
+        """
         reduce.side_effect = Exception
         with tempfile.NamedTemporaryFile() as tmpfile:
             self.message.data = tmpfile.name
@@ -190,8 +200,10 @@ class TestReductionRunner(unittest.TestCase):
 
     @patch(f'{DIR}.runner.ReductionRunner._get_mantid_version', return_value="5.1.0")
     @patch(f'{DIR}.runner.reduce')
-    @patch(f'{DIR}.service.is_instrument_flat_output', return_value=False)
-    def test_reduce_ok(self, _, reduce: Mock, _get_mantid_version: Mock):
+    def test_reduce_ok(self, reduce: Mock, _get_mantid_version: Mock):
+        """
+        Test: An OK reduction
+        """
         with tempfile.NamedTemporaryFile() as tmpfile:
             self.message.data = tmpfile.name
 
@@ -208,5 +220,27 @@ class TestReductionRunner(unittest.TestCase):
 
     @patch(f'{DIR}.runner.logger')
     def test_get_mantid_version(self, logger: Mock):
+        """
+        Test: Getting the mantid version
+        """
         assert ReductionRunner._get_mantid_version() is None
         assert logger.error.call_count == 2
+
+    @patch(f'{DIR}.runner.ReductionRunner._get_mantid_version', return_value="5.1.0")
+    @patch(f'{DIR}.runner.reduce')
+    def test_flat_output_respected(self, reduce: Mock, _get_mantid_version: Mock):
+        """
+        Test: The flat_output state is respected
+        """
+        self.message.flat_output = True
+
+        with tempfile.NamedTemporaryFile() as tmpfile:
+            self.message.data = tmpfile.name
+
+            runner = ReductionRunner(self.message)
+            runner.reduce()
+
+        reduce.assert_called_once()
+        _get_mantid_version.assert_called_once()
+        assert str(reduce.call_args[0][2].path) == tmpfile.name
+        assert runner.message.flat_output is True

--- a/queue_processors/queue_processor/reduction/tests/test_service.py
+++ b/queue_processors/queue_processor/reduction/tests/test_service.py
@@ -50,8 +50,7 @@ class TestReductionService(unittest.TestCase):
         self.log_stream = MagicMock()
 
     @patch(f"{REDUCTION_SERVICE_DIR}.ReductionDirectory._build_path")
-    @patch(f"{REDUCTION_SERVICE_DIR}.is_instrument_flat_output", return_value=False)
-    def test_reduction_directory_init_(self, _, mock_build):
+    def test_reduction_directory_init_(self, mock_build):
         """
         Test: correct fields setup
         When: Object is created
@@ -71,8 +70,7 @@ class TestReductionService(unittest.TestCase):
 
     @patch(f"{REDUCTION_SERVICE_DIR}.Path")
     @patch(f"{REDUCTION_SERVICE_DIR}.ReductionDirectory._build_path")
-    @patch(f"{REDUCTION_SERVICE_DIR}.is_instrument_flat_output", return_value=False)
-    def test_reduction_directory_create(self, _, __, ___):
+    def test_reduction_directory_create(self, _, __):
         """
         Test: Directory is created
         When: create is called
@@ -89,21 +87,19 @@ class TestReductionService(unittest.TestCase):
             self.assertTrue(reduction_dir.mantid_log.exists())
             self.assertTrue(reduction_dir.script_log.exists())
 
-    @patch(f"{REDUCTION_SERVICE_DIR}.is_instrument_flat_output", return_value=True)
     @patch(f"{REDUCTION_SERVICE_DIR}.CEPH_DIRECTORY",
            new_callable=PropertyMock(return_value="/instrument/%s/RBNumber/RB%s/autoreduced/%s"))
-    def test_reduction_directory_build_path_flat_output_removes_run_number(self, _, __):
+    def test_reduction_directory_build_path_flat_output_removes_run_number(self, _):
         """
         Tests: Run number is removed from path
         When: _build_path is called for flat output instrument
         """
-        reduction_dir = ReductionDirectory(self.instrument, self.rb_number, self.run_number)
+        reduction_dir = ReductionDirectory(self.instrument, self.rb_number, self.run_number, flat_output=True)
         expected = Path(f"/instrument/{self.instrument}/RBNumber/RB{self.rb_number}/autoreduced")
         self.assertEqual(expected, reduction_dir.path)
 
-    @patch(f"{REDUCTION_SERVICE_DIR}.is_instrument_flat_output", return_value=False)
     @patch(f"{REDUCTION_SERVICE_DIR}.ReductionDirectory._append_run_version")
-    def test_reduction_directory_build_path_non_flat_builds_path(self, mock_append, _):
+    def test_reduction_directory_build_path_non_flat_builds_path(self, mock_append):
         """
         Tests: _append_run_version is called
         When: _build_path is called for non flat output instrument
@@ -113,13 +109,16 @@ class TestReductionService(unittest.TestCase):
         expected = Path(CEPH_DIRECTORY % (self.instrument, self.rb_number, self.run_number))
         self.assertEqual(expected, reduction_dir.path)
 
-    @patch(f"{REDUCTION_SERVICE_DIR}.is_instrument_flat_output", return_value=True)
-    def test_reduction_directory_append_run_version_overwrite_true(self, _):
+    def test_reduction_directory_append_run_version_overwrite_true(self):
         """
         Tests: run-version-0 is appended
         When: overwrite is True
         """
-        reduction_dir = ReductionDirectory(self.instrument, self.rb_number, self.run_number, overwrite=True)
+        reduction_dir = ReductionDirectory(self.instrument,
+                                           self.rb_number,
+                                           self.run_number,
+                                           overwrite=True,
+                                           flat_output=True)
         with TemporaryDirectory() as directory:
             reduction_dir.path = Path(directory)
             reduction_dir._append_run_version()
@@ -127,8 +126,7 @@ class TestReductionService(unittest.TestCase):
             expected_path = Path(directory) / "run-version-0"
             self.assertEqual(expected_path, reduction_dir.path)
 
-    @patch(f"{REDUCTION_SERVICE_DIR}.is_instrument_flat_output", return_value=False)
-    def test_reduction_directory_append_run_version_existing_version(self, _):
+    def test_reduction_directory_append_run_version_existing_version(self):
         """
         Tests: Correct run-version appened
         When: a run-version already exists
@@ -141,8 +139,7 @@ class TestReductionService(unittest.TestCase):
             expected_path = Path(directory) / "run-version-1"
             self.assertEqual(expected_path, reduction_dir.path)
 
-    @patch(f"{REDUCTION_SERVICE_DIR}.is_instrument_flat_output", return_value=False)
-    def test_reduction_directory_append_run_version_no_existing_version(self, _):
+    def test_reduction_directory_append_run_version_no_existing_version(self):
         """
         Tests: run-version-0 is appended
         When: No versions currently exist

--- a/scripts/database_management/reset_database_post_cycle.py
+++ b/scripts/database_management/reset_database_post_cycle.py
@@ -17,7 +17,7 @@ import re
 import pymysql
 
 
-# pylint:disable=too-many-arguments,attribute-defined-outside-init
+# pylint:disable=attribute-defined-outside-init
 class DatabaseReset:
     """
     Handles resetting the database after cycle

--- a/scripts/manual_operations/tests/test_manual_remove.py
+++ b/scripts/manual_operations/tests/test_manual_remove.py
@@ -298,7 +298,7 @@ class TestManualRemove(unittest.TestCase):
         mock_process.assert_called_once()
         mock_delete.assert_called_once()
 
-    # pylint:disable=no-self-use, too-many-arguments
+    # pylint:disable=no-self-use
     @patch('scripts.manual_operations.manual_remove.ManualRemove.find_run_versions_in_database')
     @patch('scripts.manual_operations.manual_remove.ManualRemove.process_results')
     @patch('scripts.manual_operations.manual_remove.ManualRemove.delete_records')

--- a/scripts/manual_operations/tests/test_manual_submission.py
+++ b/scripts/manual_operations/tests/test_manual_submission.py
@@ -266,7 +266,6 @@ class TestManualSubmission(unittest.TestCase):
                           data_file_location=None,
                           run_number=None))
 
-    # pylint:disable=too-many-arguments
     @patch('scripts.manual_operations.manual_submission.login_icat')
     @patch('scripts.manual_operations.manual_submission.login_database')
     @patch('scripts.manual_operations.manual_submission.login_queue')

--- a/utils/clients/queue_client.py
+++ b/utils/clients/queue_client.py
@@ -115,7 +115,6 @@ class QueueClient(AbstractClient):
         # pylint:disable=no-value-for-parameter
         self._connection.ack(message_id, subscription)
 
-    # pylint:disable=too-many-arguments
     def send(self, destination, message, persistent='true', priority='4', delay=None):
         """
         Send a message via the open connection to a queue

--- a/utils/clients/settings/client_settings_factory.py
+++ b/utils/clients/settings/client_settings_factory.py
@@ -19,7 +19,6 @@ class ClientSettingsFactory:
     ignore_kwargs = ['username', 'password', 'host', 'port']
     valid_types = ['database', 'icat', 'queue', 'sftp', 'cycle']
 
-    # pylint:disable=too-many-arguments
     def create(self, settings_type, username, password, host, port, **kwargs):
         """
         Create a settings object to use with a client
@@ -138,7 +137,6 @@ class ActiveMQSettings(ClientSettings):
     data_ready = None
     all_subscriptions = None
 
-    # pylint:disable=too-many-arguments
     def __init__(self, data_ready='/queue/DataReady', **kwargs):
         # TODO explicitly state args
         super(ActiveMQSettings, self).__init__(**kwargs)  # pylint:disable=super-with-arguments


### PR DESCRIPTION
### Summary of work
_copied from issue text_

It seems accessing the DB during testing causes the Selenium tests to operate on 2 different DBs - one seems to be from Pytest, the other one the default from the settings. The cause seems to be that when the reduction runner starts it is a new process, so it doesn't inherit any environment settings that pytest might have changed.


I wasn't able to figure out how to fix that so the faster solution seemed to be to remove the DB access from the reduction runner, and move the required call inside handle_message instead, then pass that information through the Message object

### How to test your work
CI tests should pass

### Additional comments
<!---Anything else: e.g. was the estimate reasonable for this issue?---> 

Fixes #1231


**Before merging ensure the release notes have been updated**