### PR TITLE
Fixes wrong exception being thrown on Timeout, adds args to the handle_timeout func

### DIFF
--- a/queue_processors/queue_processor/reduction/timeout.py
+++ b/queue_processors/queue_processor/reduction/timeout.py
@@ -18,7 +18,7 @@ class TimeOut:
         self.seconds = seconds
         self.error_message = error_message
 
-    def handle_timeout(self):
+    def handle_timeout(self, *args):
         """ Handle timeout. """
         raise Exception(self.error_message)
 


### PR DESCRIPTION
### Summary of work
Adds `*args` to the handle_timeout function, this fixes the exception to be:

```
Exception('Script ran for more than 60 seconds - timed out')
```

rather than

```
TypeError('handle_timeout() takes 1 positional argument but 3 were given')
```

TODO:
- [ ] Try adding a test for this

### How to test your work
Tests should pass.

Change `SCRIPT_TIMEOUT` to 60 or 5 or 1 and run a reduction, it should timeout.

I just put this infinite loop in a reduce.py and ran a reduction

```
import time


def main(input_file, output_dir):
    while True:
        time.sleep(1)
```