### PR TITLE
Further improve error capture in runner.py

### DIFF
--- a/queue_processors/queue_processor/reduction/runner.py
+++ b/queue_processors/queue_processor/reduction/runner.py
@@ -68,9 +68,10 @@ class ReductionRunner:
         # Attempt to read the datafile
         try:
             datafile = Datafile(self.data_file)
-        except DatafileError as exp:
+        except DatafileError as err:
             logger.error("Problem reading datafile: %s", traceback.format_exc())
-            self.message.message = "REDUCTION Error: %s" % exp
+            self.message.message = "Error encountered when trying to access the datafile %s" % self.data_file
+            self.message.reduction_log = "Exception:\n%s" % (err)
             return  # stops the reduction and allows the parent to read the outcome in the message
 
         # Attempt to read the reduction script
@@ -99,14 +100,14 @@ class ReductionRunner:
             reduce(reduction_dir, temp_dir, datafile, reduction_script, reduction_log_stream)
             self.message.reduction_log = reduction_log_stream.getvalue()
             self.message.reduction_data = str(reduction_dir.path)
-        except ReductionScriptError as exp:
+        except ReductionScriptError as err:
             logger.error("Reduction script path: %s", reduction_script_path)
             self.message.message = "Error encountered when running the reduction script"
             self.message.reduction_log = "Exception:\n%s\n\n%s\n\n## Script output ##\n%s" % (
-                reduction_script_path, exp, reduction_log_stream.getvalue())
-        except Exception as exp:
+                reduction_script_path, err, reduction_log_stream.getvalue())
+        except Exception as err:
             logger.error(traceback.format_exc())
-            self.message.message = "REDUCTION Error: %s" % exp
+            self.message.message = "REDUCTION Error: %s" % err
 
     @staticmethod
     def _get_mantid_version():

--- a/queue_processors/queue_processor/reduction/tests/test_runner.py
+++ b/queue_processors/queue_processor/reduction/tests/test_runner.py
@@ -158,6 +158,36 @@ class TestReductionRunner(unittest.TestCase):
         _get_mantid_version.assert_called_once()
         assert runner.message.message == 'Error encountered when trying to access the datafile /isis/data.nxs'
 
+    @patch(f'{DIR}.runner.ReductionScript', side_effect=PermissionError("error message"))
+    def test_reduce_reductionscript_any_raise(self, _: Mock):
+        """
+        Test: ReductionDirectory raising any exception
+        """
+        with tempfile.NamedTemporaryFile() as tmpfile:
+            self.message.data = tmpfile.name
+
+            runner = ReductionRunner(self.message)
+            runner.reduce()
+
+        assert runner.message.message == "Error encountered when trying to read the reduction script"
+        assert "Exception:" in runner.message.reduction_log
+        assert "error message" in runner.message.reduction_log
+
+    @patch(f'{DIR}.runner.ReductionDirectory', side_effect=PermissionError("error message"))
+    def test_reduce_reductiondirectory_any_raise(self, _: Mock):
+        """
+        Test: ReductionDirectory raising any exception
+        """
+        with tempfile.NamedTemporaryFile() as tmpfile:
+            self.message.data = tmpfile.name
+
+            runner = ReductionRunner(self.message)
+            runner.reduce()
+
+        assert runner.message.message == "Error encountered when trying to read the reduction directory"
+        assert "Exception:" in runner.message.reduction_log
+        assert "error message" in runner.message.reduction_log
+
     @patch(f'{DIR}.runner.ReductionRunner._get_mantid_version', return_value="5.1.0")
     @patch(f'{DIR}.runner.reduce')
     def test_reduce_throws_reductionscripterror(self, reduce: Mock, _get_mantid_version: Mock):

--- a/queue_processors/queue_processor/reduction/tests/test_runner.py
+++ b/queue_processors/queue_processor/reduction/tests/test_runner.py
@@ -156,7 +156,7 @@ class TestReductionRunner(unittest.TestCase):
         assert mock_logger_info.call_count == 2
         assert mock_logger_info.call_args[0][1] == "testdescription"
         _get_mantid_version.assert_called_once()
-        assert runner.message.message == 'REDUCTION Error: Problem reading datafile: /isis/data.nxs'
+        assert runner.message.message == 'Error encountered when trying to access the datafile /isis/data.nxs'
 
     @patch(f'{DIR}.runner.ReductionRunner._get_mantid_version', return_value="5.1.0")
     @patch(f'{DIR}.runner.reduce')


### PR DESCRIPTION
### Summary of work
Stops usage of `message.message` as primary error carrier, because it causes this:

![image](https://user-images.githubusercontent.com/9135965/112468048-b8fe1180-8d5f-11eb-8d79-566c672672d6.png)


Now properly adds error in `message.reduction_log` which makes it look neater, and allows you to view the error in more detail after clicking:
![image](https://user-images.githubusercontent.com/9135965/112468100-cb784b00-8d5f-11eb-831d-99f89c2a2d9a.png)


### How to test your work
Tests should pass

