### PR TITLE
Removes duplicate run_description ids

### DIFF
--- a/WebApp/autoreduce_webapp/templates/snippets/run_variables.html
+++ b/WebApp/autoreduce_webapp/templates/snippets/run_variables.html
@@ -24,7 +24,7 @@
                             </a>
                         </label>
                         <div class="col-md-10">
-                            <input type="text" id="run_description" name="run_description" class="form-control" />
+                            <input type="text" name="run_description" class="form-control" />
                         </div>
                     </div>
                     <div class="js-variables-container">

--- a/WebApp/autoreduce_webapp/templates/submit_runs.html
+++ b/WebApp/autoreduce_webapp/templates/submit_runs.html
@@ -70,7 +70,7 @@
                                         class="fa fa-info-circle"></i></a>
                             </label>
                             <div class="col-md-9">
-                                <input type="text" id="run_description" name="run_description" class="form-control"/>
+                                <input type="text" name="run_description" class="form-control"/>
                             </div>
                         </div>
                         <div class="js-variables-container">


### PR DESCRIPTION
### Summary of work
Removes duplicate run_description ids inside the form field. The `name="run_description"` is important for the POST method.

### How to test your work
Tests should pass.

Submit a re-run locally and test that the description is properly set