### PR TITLE
Prevent "MySQL server has gone away" timeout

### DIFF
--- a/WebApp/autoreduce_webapp/autoreduce_webapp/settings.py
+++ b/WebApp/autoreduce_webapp/autoreduce_webapp/settings.py
@@ -247,3 +247,4 @@ DEVELOPMENT_MODE = True  # If the installation is in a development environment, 
 # we are not constrained by having to log in through the user office. This will authenticate
 # anyone visiting the site as a super user
 X_FRAME_OPTIONS = 'SAMEORIGIN'  # Enables the use of frames within HTML
+CONN_MAX_AGE = 60


### PR DESCRIPTION
### Summary of work
Adds a check that will remove dead connections before actual access to the database is attempted.

This should prevent the "MySQL server has gone away" errors after the QP has remained connected to the DB for a long time - by default MySQL stops the connection after 8 hours.

The `CONN_MAX_AGE = 60` setting is also added to:
- Reduce the number of connections, now the DB connection will be alive for 1 min and should be reused in a large chunk of the reduction prep code (e.g. creating db objects etc). The default behaviour is 0 which means the connections get closed after every request
- The connection will now expire on the client and be removed, a long time before MySQL has a chance to time it out.

### How to test your work
Tests should pass. And we'll see production tomorrow