### PR TITLE
Adds stdout logger & a check in queue client to prevent accidental connections to production

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -94,8 +94,16 @@
             "name": "Attach",
             "type": "python",
             "request": "attach",
-            "host": "127.0.0.1", // replace this with remote machine name
-            "port": 5678
+            "connect": {
+                "host": "127.0.0.1",
+                "port": 5678
+            },
+            "pathMappings": [
+                {
+                    "localRoot": "${workspaceFolder}",
+                    "remoteRoot": "/autoreduce"
+                }
+            ]
         }
     ]
 }

--- a/autoreduce.code-workspace
+++ b/autoreduce.code-workspace
@@ -2,6 +2,12 @@
 	"folders": [
 		{
 			"path": "."
+		},
+		{
+			"path": "../autoreduce-ansible"
+		},
+		{
+			"path": "../autoreduce-containers"
 		}
 	],
 	"settings": {

--- a/queue_processors/queue_processor/__init__.py
+++ b/queue_processors/queue_processor/__init__.py
@@ -67,6 +67,11 @@ LOGGING = {
             'maxBytes': 104857600,
             'backupCount': 20,
         },
+        'stdout': {
+            'level': LOG_LEVEL,
+            'class': 'logging.StreamHandler',
+            'formatter': 'verbose',
+        },
     },
     'root': {
         'level': LOG_LEVEL,
@@ -75,37 +80,37 @@ LOGGING = {
     },
     'loggers': {
         'queue_processor': {
-            'handlers': ['queue_processor_file'],
+            'handlers': ['stdout', 'queue_processor_file'],
             'propagate': True,
             'level': LOG_LEVEL,
         },
         'queue_listener': {
-            'handlers': ['queue_processor_file'],
+            'handlers': ['stdout', 'queue_processor_file'],
             'propagate': True,
             'level': LOG_LEVEL,
         },
         'django.server': {
-            'handlers': ['webapp_file'],
+            'handlers': ['stdout', 'webapp_file'],
             'propagate': True,
             'level': 'DEBUG',
         },
         'app': {
-            'handlers': ['webapp_file'],
+            'handlers': ['stdout', 'webapp_file'],
             'propagate': True,
             'level': 'DEBUG',
         },
         'reduction_runner': {
-            'handlers': ['autoreduction_file'],
+            'handlers': ['stdout', 'autoreduction_file'],
             'propagate': True,
             'level': LOG_LEVEL,
         },
         'reduction_service': {
-            'handlers': ['autoreduction_file'],
+            'handlers': ['stdout', 'autoreduction_file'],
             'propagate': True,
             'level': LOG_LEVEL,
         },
         'handle_queue_message': {
-            'handlers': ['handle_queue_message_file'],
+            'handlers': ['stdout', 'handle_queue_message_file'],
             'propagate': True,
             'level': LOG_LEVEL,
         },

--- a/utils/clients/queue_client.py
+++ b/utils/clients/queue_client.py
@@ -69,7 +69,7 @@ class QueueClient(AbstractClient):
         :param listener: A ConnectionListener object to assign to the stomp connection, optionally
         """
         inteded_for_production = "AUTOREDUCTION_PRODUCTION" in os.environ
-        aimed_at_dev = self.credentials.host == "127.0.0.1" or "dev" in str(self.credentials.host)
+        aimed_at_dev = self.credentials.host.startswith("127") or "dev" in str(self.credentials.host)
         # Prevent unintentional submission to non-development envs
         if not inteded_for_production and not aimed_at_dev:
             raise RuntimeError(

--- a/utils/clients/queue_client.py
+++ b/utils/clients/queue_client.py
@@ -76,7 +76,7 @@ class QueueClient(AbstractClient):
                 f"Trying to submit to a potentially non-development environment at `{self.credentials.host}`. "
                 "You must declare AUTOREDUCTION_PRODUCTION in the environment "
                 "if you intend to submit to the production environment")
-        elif inteded_for_production and aimed_at_dev:
+        if inteded_for_production and aimed_at_dev:
             raise RuntimeError(f"Trying to submit to production environment but host is `{self.credentials.host}`. "
                                "Remove AUTOREDUCTION_PRODUCTION if that is unintentional.")
 

--- a/utils/clients/tests/test_queue_client.py
+++ b/utils/clients/tests/test_queue_client.py
@@ -56,7 +56,7 @@ class TestQueueClient(TestCase):
         incorrect_credentials = ClientSettingsFactory().create('queue',
                                                                username='not-user',
                                                                password='not-pass',
-                                                               host='not-host',
+                                                               host='127.does.not.exist',
                                                                port='1234')
         client = QueueClient(incorrect_credentials)
         with self.assertRaises(ConnectionException):


### PR DESCRIPTION
### Summary of work
Adds stdout logger handler - this means all output will now be printed to stdout as well. Can be quite handy now that the stdout is captured by Singularity.

Adds a check in queue client to prevent accidental connections to production. It will show an error if you have `AUTOREDUCTION_PRODUCTION` declared but are connecting to 127.0.0.1, as well as if you don't have it but aren't connecting to 127.0.0.1 or something with "dev" in the name.

Adds a Python attach configuration for vscode, and extends the workspace to include the ansible and containers repos.
