### PR TITLE
Convert TemporaryReductionDirectory path to property and append /

### DIFF
--- a/queue_processors/queue_processor/reduction/service.py
+++ b/queue_processors/queue_processor/reduction/service.py
@@ -73,8 +73,8 @@ class TemporaryReductionDirectory:
     """
     def __init__(self, rb_number, run_number):
         self._temp_dir = TemporaryDirectory()
-        self.path = Path(self._temp_dir.name)
-        self.log_path = self.path / "reduction_log"
+        self._path = Path(self._temp_dir.name)
+        self.log_path = self._path / "reduction_log"
         self.mantid_log = self.log_path / f"RB_{rb_number}_Run_{run_number}_Mantid.log"
         self.script_log = self.log_path / f"RB_{rb_number}_Run_{run_number}_Script.out"
         self._create()
@@ -90,7 +90,7 @@ class TemporaryReductionDirectory:
         """
         self._temp_dir.cleanup()
 
-    def copy(self, destination):
+    def copy(self, destination: Path):
         """
         Copy the contents of the temporary directory to the given destination, overwriting what is
         already present.
@@ -98,6 +98,15 @@ class TemporaryReductionDirectory:
         """
         logger.info("Copying %s to %s", self.path, destination)
         copy_tree(self.path, str(destination))  # We have to convert path objects to str
+
+    @property
+    def path(self) -> str:
+        """
+        Returns the path string with a slash at the end. This is because some reduction scripts just do
+        `output_dir + str` resulting in broken output copying, as all output files end up being /tmp/abcedfgFILENAME.nxs
+        rather than /tmp/abcedfg/FILENAME.nxs
+        """
+        return f"{self._path}/"
 
 
 class Datafile:

--- a/queue_processors/queue_processor/reduction/service.py
+++ b/queue_processors/queue_processor/reduction/service.py
@@ -108,6 +108,10 @@ class TemporaryReductionDirectory:
         """
         return f"{self._path}/"
 
+    def exists(self) -> bool:
+        """Checks that the path for the TemporaryReductionDirectory exists"""
+        return self._path.exists()
+
 
 class Datafile:
     """

--- a/queue_processors/queue_processor/reduction/tests/test_service.py
+++ b/queue_processors/queue_processor/reduction/tests/test_service.py
@@ -159,7 +159,7 @@ class TestReductionService(unittest.TestCase):
         When: object is created
         """
         temp_dir = TemporaryReductionDirectory(self.rb_number, self.run_number)
-        self.assertTrue(temp_dir.path.exists())
+        self.assertTrue(temp_dir.exists())
         self.assertTrue(temp_dir.log_path.exists())
         self.assertTrue(temp_dir.mantid_log.exists())
         self.assertTrue(temp_dir.script_log.exists())
@@ -167,7 +167,7 @@ class TestReductionService(unittest.TestCase):
         self.assertEqual(f"RB_{self.rb_number}_Run_{self.run_number}_Mantid.log", temp_dir.mantid_log.name)
         self.assertEqual(f"RB_{self.rb_number}_Run_{self.run_number}_Script.out", temp_dir.script_log.name)
         temp_dir.delete()
-        self.assertFalse(temp_dir.path.exists())
+        self.assertFalse(temp_dir.exists())
 
     def test_temp_reduction_directory_delete(self):
         """
@@ -175,9 +175,9 @@ class TestReductionService(unittest.TestCase):
         When: Delete is called
         """
         temp_dir = TemporaryReductionDirectory(self.rb_number, self.rb_number)
-        self.assertTrue(temp_dir.path.exists())
+        self.assertTrue(temp_dir.exists())
         temp_dir.delete()
-        self.assertFalse(temp_dir.path.exists())
+        self.assertFalse(temp_dir.exists())
 
     def test_temporary_reduction_directory_copy(self):
         """
@@ -188,10 +188,10 @@ class TestReductionService(unittest.TestCase):
             temp_reduction_dir = TemporaryReductionDirectory(self.instrument, self.rb_number)
             dest_folder = Path(dest)
             src_folder = Path(src)
-            temp_reduction_dir.path = src_folder
-            fill_mockup_directory(temp_reduction_dir.path)
+            temp_reduction_dir._path = src_folder
+            fill_mockup_directory(temp_reduction_dir._path)
 
-            temp_reduction_dir.copy(dest)
+            temp_reduction_dir.copy(dest_folder)
             self.assertTrue((dest_folder / "myfile.nxs").exists())
             self.assertTrue((dest_folder / "reduction_log").exists())
             self.assertTrue((dest_folder / "reduction_log" / "script.out"))


### PR DESCRIPTION
### Summary of work
Adds a / at the end of the temp_dir path.  Some reduction scripts just do `output_dir + str` which breaks output copying, as all output files end up being `/tmp/abcedfgFILENAME.nxs` rather than `/tmp/abcedfg/FILENAME.nxs`

### How to test your work
Tests should pass

### Additional comments
<!---Anything else: e.g. was the estimate reasonable for this issue?---> 

Fixes #1286


**Before merging ensure the release notes have been updated**