### PR TITLE
Remove SFTP Client from plot_handler, add whitenoise to serve staticfiles AR-1291

### DIFF
--- a/.github/actions/build-autoreduction/action.yml
+++ b/.github/actions/build-autoreduction/action.yml
@@ -24,4 +24,5 @@ runs:
         cat build.log
         _LOCAL_PYTHON_PATH=$(which python)
         sudo $_LOCAL_PYTHON_PATH setup.py start
+        python WebApp/autoreduce_webapp/manage.py collectstatic
       shell: bash

--- a/.gitignore
+++ b/.gitignore
@@ -44,8 +44,11 @@ vault.yml
 .DS_Store
 
 # Ignore downloaded graphs
-Webapp/autoreduce_webapp/static/graphs/
+!Webapp/autoreduce_webapp/static/graphs
 !Webapp/autoreduce_webapp/static/graphs/.keep
+
+# Ignore collected staticfiles
+WebApp/autoreduce_webapp/staticfiles
 
 # Ignore The screenshot folder in Selenium tests
 WebApp/autoreduce_webapp/selenium_tests/screenshots
@@ -63,3 +66,4 @@ data-archive/
 test-archive/
 
 autoreduce.code-workspace
+

--- a/WebApp/autoreduce_webapp/autoreduce_webapp/settings.py
+++ b/WebApp/autoreduce_webapp/autoreduce_webapp/settings.py
@@ -79,9 +79,14 @@ if not DEBUG:
     MIDDLEWARE.insert(0, 'whitenoise.middleware.WhiteNoiseMiddleware')
     STATICFILES_STORAGE = 'whitenoise.storage.CompressedManifestStaticFilesStorage'
 else:
-    # Add debug toolbar only if in DEBUG mode
-    INSTALLED_APPS.append('debug_toolbar')
-    MIDDLEWARE.insert(3, 'debug_toolbar.middleware.DebugToolbarMiddleware')
+    # Add debug toolbar only if in DEBUG mode and installed
+    try:
+        import debug_toolbar
+        INSTALLED_APPS.append('debug_toolbar')
+        MIDDLEWARE.insert(3, 'debug_toolbar.middleware.DebugToolbarMiddleware')
+    except ModuleNotFoundError:
+        # debug_toolbar not installed - just run without it
+        pass
 
 AUTHENTICATION_BACKENDS = [
     'autoreduce_webapp.backends.UOWSAuthenticationBackend',

--- a/WebApp/autoreduce_webapp/autoreduce_webapp/settings.py
+++ b/WebApp/autoreduce_webapp/autoreduce_webapp/settings.py
@@ -64,7 +64,6 @@ INSTALLED_APPS = [
 INSTALLED_APPS = INSTALLED_APPS + ORM_INSTALL
 
 MIDDLEWARE = [
-    'whitenoise.middleware.WhiteNoiseMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
@@ -74,9 +73,13 @@ MIDDLEWARE = [
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
     'django_plotly_dash.middleware.BaseMiddleware',
 ]
-
-# Add debug toolbar only if in DEBUG mode
-if DEBUG:
+if not DEBUG:
+    # sets up whitenoise for providing staticfiles when the app is running outside of DEBUG mode
+    # In this mode if you see errors with files not found, you probably have to run `manage.py collectstatic` first
+    MIDDLEWARE.insert(0, 'whitenoise.middleware.WhiteNoiseMiddleware')
+    STATICFILES_STORAGE = 'whitenoise.storage.CompressedManifestStaticFilesStorage'
+else:
+    # Add debug toolbar only if in DEBUG mode
     INSTALLED_APPS.append('debug_toolbar')
     MIDDLEWARE.insert(3, 'debug_toolbar.middleware.DebugToolbarMiddleware')
 
@@ -154,56 +157,13 @@ USE_TZ = True
 # https://docs.djangoproject.com/en/dev/howto/static-files/
 
 STATIC_URL = '/static/'
-STATIC_ROOT = os.path.join(BASE_DIR, 'staticfiles')
+if not DEBUG:
+    STATIC_ROOT = os.path.join(BASE_DIR, 'staticfiles')
+else:
+    STATIC_ROOT = os.path.join(BASE_DIR, 'static')
 STATICFILES_DIRS = [
     os.path.join(BASE_DIR, 'static'),
 ]
-STATICFILES_STORAGE = 'whitenoise.storage.CompressedManifestStaticFilesStorage'
-
-# Logging
-# https://docs.python.org/2/howto/logging.html
-
-LOG_FILE = os.path.join(BASE_DIR, 'autoreduction.log')
-if DEBUG:
-    LOG_LEVEL = 'INFO'
-else:
-    LOG_LEVEL = 'INFO'
-
-LOGGING = {
-    'version': 1,
-    'disable_existing_loggers': False,
-    'formatters': {
-        'verbose': {
-            'format': "[%(asctime)s] %(levelname)s [%(name)s:%(lineno)s] %(message)s",
-            'datefmt': "%d/%b/%Y %H:%M:%S"
-        },
-        'simple': {
-            'format': '%(levelname)s %(message)s'
-        },
-    },
-    'handlers': {
-        'webapp_file': {
-            'level': LOG_LEVEL,
-            'class': 'logging.handlers.RotatingFileHandler',
-            'filename': os.path.join(PROJECT_ROOT, 'logs', 'webapp.log'),
-            'formatter': 'verbose',
-            'maxBytes': 104857600,
-            'backupCount': 20,
-        },
-    },
-    'loggers': {
-        'django': {
-            'handlers': ['webapp_file'],
-            'propagate': True,
-            'level': LOG_LEVEL,
-        },
-        'app': {
-            'handlers': ['webapp_file'],
-            'propagate': True,
-            'level': 'DEBUG',
-        },
-    }
-}
 
 # ActiveMQ
 

--- a/WebApp/autoreduce_webapp/autoreduce_webapp/settings.py
+++ b/WebApp/autoreduce_webapp/autoreduce_webapp/settings.py
@@ -64,6 +64,7 @@ INSTALLED_APPS = [
 INSTALLED_APPS = INSTALLED_APPS + ORM_INSTALL
 
 MIDDLEWARE = [
+    'whitenoise.middleware.WhiteNoiseMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
@@ -153,10 +154,11 @@ USE_TZ = True
 # https://docs.djangoproject.com/en/dev/howto/static-files/
 
 STATIC_URL = '/static/'
-STATIC_PATH = os.path.join(BASE_DIR, 'static')
+STATIC_ROOT = os.path.join(BASE_DIR, 'static')
 STATICFILES_DIRS = [
     os.path.join(BASE_DIR, 'static'),
 ]
+STATICFILES_STORAGE = 'whitenoise.storage.CompressedManifestStaticFilesStorage'
 
 # Logging
 # https://docs.python.org/2/howto/logging.html

--- a/WebApp/autoreduce_webapp/autoreduce_webapp/settings.py
+++ b/WebApp/autoreduce_webapp/autoreduce_webapp/settings.py
@@ -154,7 +154,7 @@ USE_TZ = True
 # https://docs.djangoproject.com/en/dev/howto/static-files/
 
 STATIC_URL = '/static/'
-STATIC_ROOT = os.path.join(BASE_DIR, 'static')
+STATIC_ROOT = os.path.join(BASE_DIR, 'staticfiles')
 STATICFILES_DIRS = [
     os.path.join(BASE_DIR, 'static'),
 ]

--- a/WebApp/autoreduce_webapp/autoreduce_webapp/settings.py
+++ b/WebApp/autoreduce_webapp/autoreduce_webapp/settings.py
@@ -157,10 +157,7 @@ USE_TZ = True
 # https://docs.djangoproject.com/en/dev/howto/static-files/
 
 STATIC_URL = '/static/'
-if not DEBUG:
-    STATIC_ROOT = os.path.join(BASE_DIR, 'staticfiles')
-else:
-    STATIC_ROOT = os.path.join(BASE_DIR, 'static')
+STATIC_ROOT = os.path.join(BASE_DIR, 'staticfiles')
 STATICFILES_DIRS = [
     os.path.join(BASE_DIR, 'static'),
 ]

--- a/WebApp/autoreduce_webapp/autoreduce_webapp/urls.py
+++ b/WebApp/autoreduce_webapp/autoreduce_webapp/urls.py
@@ -8,8 +8,7 @@
 from django.conf import settings
 from django.conf.urls import include
 from django.contrib import admin
-from django.urls import register_converter, path
-
+from django.urls import path, register_converter
 from instrument.views import runs
 from reduction_viewer import views as reduction_viewer_views
 
@@ -68,7 +67,12 @@ urlpatterns = [
 ]
 
 if settings.DEBUG:
-    import debug_toolbar
-    urlpatterns = [
-        path('__debug__/', include(debug_toolbar.urls)),
-    ] + urlpatterns
+    try:
+        import debug_toolbar
+
+        urlpatterns = [
+            path('__debug__/', include(debug_toolbar.urls)),
+        ] + urlpatterns
+    except ModuleNotFoundError:
+        # debug_toolbar not installed - just run without it
+        pass

--- a/build/commands/database.py
+++ b/build/commands/database.py
@@ -8,6 +8,7 @@
 Module to generate a testing database to be used for local testing of the project
 """
 import os
+import sys
 # pylint:disable=no-name-in-module
 from distutils.core import Command
 
@@ -39,7 +40,8 @@ class InitialiseTestDatabase(Command):
         BUILD_LOGGER.print_and_log("==================== Building Database ======================")
         BUILD_LOGGER.print_and_log("Migrating databases from django model")
         if generate_schema(ROOT_DIR, BUILD_LOGGER.logger) is False:
-            return
+            print("ERROR: Failed generating schema", file=sys.stderr)
+            sys.exit(1)
         BUILD_LOGGER.print_and_log("Test database successfully initialised\n")
 
 

--- a/plotting/plot_handler.py
+++ b/plotting/plot_handler.py
@@ -87,6 +87,7 @@ class PlotHandler:
                     matches.append(name)
 
             return matches
+        return []
 
     def get_plot_file(self):
         """

--- a/plotting/plot_handler.py
+++ b/plotting/plot_handler.py
@@ -13,6 +13,7 @@ Instructing the Plotting factory to build an IFrame based on the above
 """
 import logging
 import os
+import traceback
 import re
 import shutil
 from WebApp.autoreduce_webapp.autoreduce_webapp.settings import STATIC_ROOT
@@ -89,6 +90,10 @@ class PlotHandler:
             return matches
         return []
 
+    def _ensure_staticfiles_graphs_exists(self):
+        if not os.path.exists(self.static_graph_dir):
+            os.makedirs(self.static_graph_dir, exist_ok=True)
+
     def get_plot_file(self):
         """
         Searches for and retrieves a plot file from CEPH.
@@ -97,6 +102,7 @@ class PlotHandler:
         :return: (str) local path to downloaded files OR None if no files found
         """
         _existing_plot_files = self._check_for_plot_files()
+        self._ensure_staticfiles_graphs_exists()
         local_plot_paths = []
         if _existing_plot_files:
             for plot_file in _existing_plot_files:
@@ -109,9 +115,10 @@ class PlotHandler:
                     # URL to retrieve the static assert from the static dir - only if succesful
                     local_plot_paths.append(f'/static/graphs/{plot_file}')
                 except FileNotFoundError:
-                    LOGGER.error("File \'%s\' does not exist", _server_path)
+                    LOGGER.error("File \'%s\' does not exist. Error: %s", _server_path, traceback.format_exc())
                 except PermissionError:
-                    LOGGER.error("Insufficient permissions to read \'%s\' ", _server_path)
+                    LOGGER.error("Insufficient permissions to read \'%s\'. Error: %s", _server_path,
+                                 traceback.format_exc())
             return local_plot_paths
         # No files found
         return None

--- a/plotting/plot_handler.py
+++ b/plotting/plot_handler.py
@@ -16,7 +16,7 @@ import os
 import re
 import shutil
 from typing import List
-from utils.project.structure import get_project_root
+from WebApp.autoreduce_webapp.autoreduce_webapp.settings import STATIC_ROOT
 
 LOGGER = logging.getLogger('app')
 
@@ -34,7 +34,7 @@ class PlotHandler:
         self.server_dir = server_dir
         self.file_extensions = ["png", "jpg", "bmp", "gif", "tiff"]
         # Directory to place fetched data files / images
-        self.static_graph_dir = os.path.join(get_project_root(), 'WebApp', 'autoreduce_webapp', 'static', 'graphs')
+        self.static_graph_dir = os.path.join(STATIC_ROOT, 'graphs')
 
     @staticmethod
     def _get_only_data_file_name(data_filepath: str) -> str:

--- a/plotting/plot_handler.py
+++ b/plotting/plot_handler.py
@@ -30,7 +30,9 @@ class PlotHandler:
     """
     def __init__(self, data_filepath: str, server_dir: str, rb_number: str = None):
         self.data_filename: str = self._get_only_data_file_name(data_filepath)
-        self.rb_number = rb_number  # Used when searching for full Experiment graph
+        # Used when searching for full Experiment graph. TODO: not actually used right now
+        self.rb_number = rb_number
+        # this is a path somewhere on CEPH
         self.server_dir = server_dir
         self.file_extensions = ["png", "jpg", "bmp", "gif", "tiff"]
         # Directory to place fetched data files / images
@@ -118,7 +120,8 @@ class PlotHandler:
                 except RuntimeError:
                     LOGGER.error("File \'%s\' does not exist", _server_path)
                     return None
-                local_plot_paths.append(f'/static/graphs/{plot_file}')  # shortcut to static dir
+                # URL to retrieve the static assert from the static dir
+                local_plot_paths.append(f'/static/graphs/{plot_file}')
             return local_plot_paths
         # No files found
         return None

--- a/plotting/plot_handler.py
+++ b/plotting/plot_handler.py
@@ -105,15 +105,10 @@ class PlotHandler:
         but will only copy over one.
         :return: (str) local path to downloaded files OR None if no files found
         """
-        _existing_plot_files = self._get_plot_files_locally()
-        if _existing_plot_files:
-            return _existing_plot_files
-
         _existing_plot_files = self._check_for_plot_files()
         local_plot_paths = []
         if _existing_plot_files:
             for plot_file in _existing_plot_files:
-                # Generate paths to data on server and destination on local machine
                 _server_path = f"{self.server_dir}/{plot_file}"
                 _local_path = os.path.join(self.static_graph_dir, plot_file)
 

--- a/plotting/tests/test_plot_handler.py
+++ b/plotting/tests/test_plot_handler.py
@@ -105,6 +105,16 @@ class TestPlotHandler(unittest.TestCase):
         # check that only the valid matches have been found
         assert mock_os.listdir.return_value[0:2] == self.test_plot_handler._check_for_plot_files()
 
+    @patch('plotting.plot_handler.os')
+    def test_check_for_plot_files_path_doesnt_exist(self, mock_os):
+        """
+        Test: sftpclient.get_filenames is called with the correct parameters if only one plot_type is used
+        When: sftpclient.get_filenames is used to look for existing plot files
+        """
+        mock_os.path.exists.return_value = False
+        # check that only the valid matches have been found
+        assert [] == self.test_plot_handler._check_for_plot_files()
+
     @patch('plotting.plot_handler.PlotHandler._check_for_plot_files')
     @patch('plotting.plot_handler.shutil.copy')
     def test_get_plot_files(self, mock_copy: Mock, mock_find_files):

--- a/plotting/tests/test_plot_handler.py
+++ b/plotting/tests/test_plot_handler.py
@@ -13,10 +13,10 @@ calling the SFTPClient with correct parameters
 """
 import os
 import unittest
-from unittest.mock import patch
+from parameterized import parameterized
+from unittest.mock import Mock, patch
 
 from plotting.plot_handler import PlotHandler
-from utils.project.structure import get_project_root
 
 
 # pylint:disable=line-too-long, protected-access
@@ -35,15 +35,13 @@ class TestPlotHandler(unittest.TestCase):
         self.expected_mari_data_filename = "MARI1234"
         self.expected_mari_file_regex = f'{self.expected_mari_data_filename}.*.{self.expected_file_extension_regex}'
         self.input_data_filepath = "\\\\isis\\inst$\\NDXMARI\\Instrument\\data\\cycle_test\\MARI1234.nxs"
+        self.mari_base = "/instrument/MARI/RBNumber/RB12345678/1234"
         self.expected_mari_rb_number = 12345678
-        self.expected_mari_rb_folder = "/instrument/MARI/RBNumber/RB12345678/1234/autoreduced"
+        self.expected_mari_rb_folder = f"{self.mari_base}/autoreduced"
 
         self.test_plot_handler = PlotHandler(data_filepath=self.input_data_filepath,
                                              server_dir=self.expected_mari_rb_folder,
                                              rb_number=self.expected_mari_rb_number)
-
-        self.expected_static_graph_dir = os.path.join(get_project_root(), 'WebApp', 'autoreduce_webapp', 'static',
-                                                      'graphs')
 
     def test_init(self):
         """
@@ -54,7 +52,6 @@ class TestPlotHandler(unittest.TestCase):
         self.assertEqual(self.test_plot_handler.server_dir, self.expected_mari_rb_folder)
         self.assertEqual(self.test_plot_handler.file_extensions, ["png", "jpg", "bmp", "gif", "tiff"])
         self.assertEqual(self.test_plot_handler.rb_number, self.expected_mari_rb_number)
-        self.assertEqual(self.test_plot_handler.static_graph_dir, self.expected_static_graph_dir)
 
     def test_get_only_data_file_name(self):
         """
@@ -94,94 +91,39 @@ class TestPlotHandler(unittest.TestCase):
         actual_pattern = self.test_plot_handler._generate_file_extension_regex()
         self.assertEqual(expected_pattern, actual_pattern)
 
-    @patch("os.listdir", return_value=["MARI1234_123.456.png", "MARI1234_124.png", "MARI123.nxs"])
-    @patch("plotting.plot_handler.PlotHandler._generate_file_name_regex")
-    def test_get_plot_files_locally_files_exist_returns_list(self, mock_gfn_regex, mock_listdir):
-        """
-        Test: Correct file paths are returned
-        When: Multiple matching files exist
-        """
-        mock_gfn_regex.return_value = self.expected_mari_file_regex
-
-        expected_files = ["/static/graphs/MARI1234_123.456.png", "/static/graphs/MARI1234_124.png"]
-        actual = self.test_plot_handler._get_plot_files_locally()
-        self.assertEqual(expected_files, actual)
-
-        mock_listdir.assert_called()
-        mock_gfn_regex.assert_called()
-
-    @patch("os.listdir", return_value=["MARI1234.png"])
-    @patch("plotting.plot_handler.PlotHandler._generate_file_name_regex")
-    def test_get_plot_files_locally_single_file_returns_list(self, mock_gfn_regex, mock_listdir):
-        """
-        Test: Correct file path is returned
-        When: Single matching file exists
-        """
-        mock_gfn_regex.return_value = self.expected_mari_file_regex
-
-        expected_files = ["/static/graphs/MARI1234.png"]
-        actual = self.test_plot_handler._get_plot_files_locally()
-        self.assertEqual(expected_files, actual)
-
-        mock_listdir.assert_called()
-        mock_gfn_regex.assert_called()
-
-    @patch("os.listdir", return_value=["MARI1234.nxs"])
-    @patch("plotting.plot_handler.PlotHandler._generate_file_name_regex")
-    def test_get_plot_files_no_matching_file_returns_empty_list(self, mock_gfn_regex, mock_listdir):
-        """
-        Test: Empty list is returned
-        When: No matching file exists
-        """
-        mock_gfn_regex.return_value = self.expected_mari_file_regex
-
-        expected_files = []
-        actual = self.test_plot_handler._get_plot_files_locally()
-        self.assertEqual(expected_files, actual)
-
-        mock_listdir.assert_called()
-        mock_gfn_regex.assert_called()
-
-    @patch('utils.clients.sftp_client.SFTPClient.__init__', return_value=None)
-    @patch('utils.clients.sftp_client.SFTPClient.get_filenames')
-    def test_check_for_plot_files(self, mock_get_filenames, mock_client_init):
+    @patch('plotting.plot_handler.os')
+    def test_check_for_plot_files_path_exists(self, mock_os):
         """
         Test: sftpclient.get_filenames is called with the correct parameters if only one plot_type is used
         When: sftpclient.get_filenames is used to look for existing plot files
         """
-        self.test_plot_handler._check_for_plot_files()
-        mock_client_init.assert_called_once()
-        mock_get_filenames.assert_called_once_with(server_dir_path=self.expected_mari_rb_folder,
-                                                   regex=self.expected_mari_file_regex)
+        mock_os.path.exists.return_value = True
+        mock_os.listdir.return_value = [
+            "MARI1234_sometext_1.png", "MARI1234_sometext_2.png", "MARI1234.nxs", "MARI1234_sometext.nxs"
+        ]
+
+        # check that only the valid matches have been found
+        assert mock_os.listdir.return_value[0:2] == self.test_plot_handler._check_for_plot_files()
 
     @patch('plotting.plot_handler.PlotHandler._check_for_plot_files')
-    @patch('utils.clients.sftp_client.SFTPClient.__init__', return_value=None)
-    @patch('utils.clients.sftp_client.SFTPClient.retrieve')
-    @patch("plotting.plot_handler.PlotHandler._get_plot_files_locally", return_value=[])
-    def test_get_plot_files_no_local_files(self, mock_gpfl, mock_retrieve, mock_client_init, mock_find_files):
+    @patch('plotting.plot_handler.shutil.copy')
+    def test_get_plot_files(self, mock_copy: Mock, mock_find_files):
         """
         Test: get_plot_files returns the expected plot files
         When: called with valid arguments and files exist on server and none exist locally
         """
         expected_files = ['expected.png']
         mock_find_files.return_value = expected_files
-        expected_local = os.path.join(self.expected_static_graph_dir, expected_files[0])
+        expected_local = os.path.join(self.test_plot_handler.static_graph_dir, expected_files[0])
         expected_server = os.path.join(self.expected_mari_rb_folder, expected_files[0])
 
         actual_path = self.test_plot_handler.get_plot_file()
-        mock_client_init.assert_called_once()
-        mock_retrieve.assert_called_once_with(server_file_path=expected_server,
-                                              local_file_path=expected_local,
-                                              override=True)
+        mock_copy.assert_called_once_with(expected_server, expected_local)
         self.assertEqual([f'/static/graphs/{expected_files[0]}'], actual_path)
 
-        mock_gpfl.assert_called()
-
-    @patch('utils.clients.sftp_client.SFTPClient.retrieve')
     @patch('plotting.plot_handler.PlotHandler._check_for_plot_files')
-    @patch('utils.clients.sftp_client.SFTPClient.__init__', return_value=None)
-    @patch("plotting.plot_handler.PlotHandler._get_plot_files_locally", return_value=[])
-    def test_get_plot_files_multiple_none_local(self, mock_gpfl, mock_client_init, mock_find_files, _):
+    @patch('plotting.plot_handler.shutil.copy')
+    def test_get_plot_files_multiple(self, mock_copy: Mock, mock_find_files):
         """
         Test: Multiple file paths are returned as a list
         When: Multiple image files exist on the server relating to the same run and none exist
@@ -193,52 +135,41 @@ class TestPlotHandler(unittest.TestCase):
         expected_paths = [f'/static/graphs/{expected_files[0]}', f'/static/graphs/{expected_files[1]}']
 
         actual_paths = self.test_plot_handler.get_plot_file()
-        mock_client_init.assert_called_once()  # Ensure this is not initialised more than once
+        self.assertEqual(mock_copy.call_count, len(expected_files))
         self.assertEqual(expected_paths, actual_paths)
 
-        mock_gpfl.assert_called()
-
     @patch('plotting.plot_handler.PlotHandler._check_for_plot_files', return_value=[])
-    @patch("plotting.plot_handler.PlotHandler._get_plot_files_locally", return_value=[])
-    def test_get_plot_file_none_found(self, mock_gpfl, _):
+    def test_get_plot_file_none_found(self, mock_cfpl: Mock):
         """
         Test: None is returned
         When: No files can be found on the server or locally
         """
         self.assertIsNone(self.test_plot_handler.get_plot_file())
-        mock_gpfl.assert_called()
+        mock_cfpl.assert_called_once()
 
+    @parameterized.expand([[FileNotFoundError, "does not exist"], [PermissionError, "Insufficient permissions"]])
+    @patch('plotting.plot_handler.LOGGER')
     @patch('plotting.plot_handler.PlotHandler._check_for_plot_files')
-    @patch('utils.clients.sftp_client.SFTPClient.__init__', return_value=None)
-    @patch('utils.clients.sftp_client.SFTPClient.retrieve')
-    @patch("plotting.plot_handler.PlotHandler._get_plot_files_locally", return_value=[])
-    def test_get_plot_files_cant_download_none_local(self, mock_gpfl, mock_retrieve, mock_client_init, mock_find_files):
+    @patch('plotting.plot_handler.shutil.copy')
+    def test_get_plot_files_cant_download_none_local(
+        self,
+        exc_type: Exception,
+        expected_log_message: str,
+        mock_copy: Mock,
+        mock_find_files,
+        mock_logger,
+    ):
         """
         Test: get_plot_files returns the expected plot files
         When: called with valid arguments and files exist on server and not locally
         """
         expected_files = ['expected.png']
         mock_find_files.return_value = expected_files
-        mock_retrieve.side_effect = RuntimeError
-        self.assertIsNone(self.test_plot_handler.get_plot_file())
-        mock_gpfl.assert_called()
-        mock_client_init.assert_called_once()
-
-    @patch("plotting.plot_handler.PlotHandler._check_for_plot_files")
-    @patch("plotting.plot_handler.PlotHandler._get_plot_files_locally")
-    def test_get_plot_file_from_local_storage(self, mock_gpfl, mock_cfpf):
-        """
-        Test: Correct files returned from local storage
-        When: When files exist already exist locally
-        """
-        mock_gpfl.return_value = ["/static/graphs/expected.png"]
-
-        expected = ["/static/graphs/expected.png"]
-        actual = self.test_plot_handler.get_plot_file()
-        self.assertEqual(expected, actual)
-
-        mock_gpfl.assert_called()
-        mock_cfpf.assert_not_called()
+        mock_copy.side_effect = exc_type
+        assert not self.test_plot_handler.get_plot_file()
+        mock_logger.error.assert_called_once()
+        assert expected_log_message in mock_logger.error.call_args[0][0]
+        assert self.mari_base in mock_logger.error.call_args[0][1]
 
 
 if __name__ == '__main__':

--- a/plotting/tests/test_plot_handler.py
+++ b/plotting/tests/test_plot_handler.py
@@ -13,8 +13,8 @@ calling the SFTPClient with correct parameters
 """
 import os
 import unittest
-from parameterized import parameterized
 from unittest.mock import Mock, patch
+from parameterized import parameterized
 
 from plotting.plot_handler import PlotHandler
 

--- a/plotting/tests/test_plot_handler.py
+++ b/plotting/tests/test_plot_handler.py
@@ -12,6 +12,7 @@ construction of regular expression for looking up existing files
 calling the SFTPClient with correct parameters
 """
 import os
+import shutil
 import unittest
 from unittest.mock import Mock, patch
 from parameterized import parameterized
@@ -161,7 +162,7 @@ class TestPlotHandler(unittest.TestCase):
     @patch('plotting.plot_handler.LOGGER')
     @patch('plotting.plot_handler.PlotHandler._check_for_plot_files')
     @patch('plotting.plot_handler.shutil.copy')
-    def test_get_plot_files_cant_download_none_local(
+    def test_get_plot_files_exception_raised(
         self,
         exc_type: Exception,
         expected_log_message: str,
@@ -180,6 +181,18 @@ class TestPlotHandler(unittest.TestCase):
         mock_logger.error.assert_called_once()
         assert expected_log_message in mock_logger.error.call_args[0][0]
         assert self.mari_base in mock_logger.error.call_args[0][1]
+
+    def test_ensure_staticfiles_graphs_exists(self):
+        """
+        Test that the plot handler makes the subfolders necessary for copying to succeed.
+        """
+        self.test_plot_handler.static_graph_dir = "/tmp/test_static_graph_dir/"
+        try:
+            assert not os.path.exists(self.test_plot_handler.static_graph_dir)
+            self.test_plot_handler._ensure_staticfiles_graphs_exists()
+            assert os.path.exists(self.test_plot_handler.static_graph_dir)
+        finally:
+            shutil.rmtree(self.test_plot_handler.static_graph_dir, ignore_errors=True)
 
 
 if __name__ == '__main__':

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,8 @@ setup_requires = [
     'service_identity==18.1.0',
     'stomp.py==6.1.0',
     'suds-py3==1.4.4.1',
-    'PyYAML==5.4.1'
+    'PyYAML==5.4.1',
+    'whitenoise==5.2.0'
 ]
 
 if platform.system() == 'Windows':


### PR DESCRIPTION
### Summary of work
Removes SFTP Client from plot_handler - a benefit of hosting the webapp on CentOS is that we can just copy the files from CEPH without a need for SFTPing. This could be bad if we move away from hosting on Linux/SCD Cloud but that's probably not worth worrying about.

Also adds Whitenoise as Django middleware to serve staticfiles (CSS/JS/plot images). This is a workaround to:
- Plot files being copied locally to render in the web app. 
- Apache not being able to access that location anymore, as the web app is on a different machine

The proper fix would be to move the staticfiles storage on a separate, common location. This would be necessary when we have >1 hosts for the web app.


### How to test your work
These changes are currently live on the production env. 

Check that the production website loads assets and plots OK. Do Shift + F5 to clear the cache.
