### PR TITLE
Update requirements and setup AR-1271

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -142,7 +142,7 @@ jobs:
           pylint --disable=django-not-configured,import-error,no-name-in-module --load-plugins pylint_django WebApp
 
       - name: YAPF
-        run: python -m yapf --exclude '**/migrations' --parallel --diff --recursive .
+        run: python -m yapf --parallel --diff --recursive .
 
       - name: Vulture
         run: vulture --min-confidence 100 build docker_reduction model monitors scripts queue_processors systemtests utils plotting

--- a/.yapfignore
+++ b/.yapfignore
@@ -1,0 +1,4 @@
+setup.py
+**/migrations
+venv/
+venv3/

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,19 +1,14 @@
 # Test Env. Requirements
 
 coveralls==3.0.1
-dash==1.16.3
 django-debug-toolbar==3.2
-django_plotly_dash==1.6.3
 parameterized==0.8.1
-plotly==4.14.3
 pylint==2.7.4
 pylint-django==2.4.3
 pytest==6.2.3
 pytest-cov==2.11.1
 pytest-django==4.2.0
 pytest-xdist==2.2.1
-requests==2.25.1
 selenium==3.141.0
-stomp.py==6.1.0
 vulture==2.3
 yapf==0.31.0

--- a/setup.py
+++ b/setup.py
@@ -17,10 +17,9 @@ from build.commands.start import Start
 
 setup_requires = [
     'attrs==20.3.0',
-    'dash==1.19.0',
-    'dash_html_components==1.1.2',
-    # dash 1.16.3 depends on dash-core-components 1.12.1
-    'dash_core_components==1.15.0',
+    'dash==1.20.0',
+    'dash_html_components==1.1.3',
+    'dash_core_components==1.16.0',
     'docker==5.0.0',
     'Django==3.2',
     'django_extensions==3.1.2',


### PR DESCRIPTION
### Summary of work
Updated all 3 dash libraries in one go to prevent clashes.
Remove duplicated requirements

### How to test your work
Tests should pass 

@dtasev 
`yapf` would like for the `setup.py` list to be in 5 lines instead of 1 per requirement. 
That is:
```python
setup_requires = [
    'attrs==20.3.0',
    'dash==1.20.0',
    'dash_html_components==1.1.3',
    'dash_core_components==1.16.0',
    'docker==5.0.0',
    'Django==3.2',
    'django_extensions==3.1.2',
    'django_plotly_dash==1.6.3',
    'django-user-agents==0.4.0',
    'filelock==3.0.12',
    'fire==0.4.0',
    'gitpython==3.1.14',
    'nexusformat==0.6.1',
    'numpy==1.19.2',
    'pandas==1.1.5',
    'plotly==4.14.3',
    'pytz==2021.1',
    'PyMySQL==1.0.2',
    'pysftp==0.2.9',
    'python-icat==0.18.0',
    'requests==2.25.1',
    'service_identity==18.1.0',
    'stomp.py==6.1.0',
    'suds-py3==1.4.4.1',
    'PyYAML==5.4.1'
]
```

To this:
```python
setup_requires = [
    'attrs==20.3.0', 'dash==1.20.0', 'dash_html_components==1.1.3', 'dash_core_components==1.16.0', 'docker==5.0.0',
    'Django==3.2', 'django_extensions==3.1.2', 'django_plotly_dash==1.6.3', 'django-user-agents==0.4.0',
    'filelock==3.0.12', 'fire==0.4.0', 'gitpython==3.1.14', 'nexusformat==0.6.1', 'numpy==1.19.2', 'pandas==1.1.5',
    'plotly==4.14.3', 'pytz==2021.1', 'PyMySQL==1.0.2', 'pysftp==0.2.9', 'python-icat==0.18.0', 'requests==2.25.1',
    'service_identity==18.1.0', 'stomp.py==6.1.0', 'suds-py3==1.4.4.1', 'PyYAML==5.4.1'
]

```

I think this is confusing and think we should exclude `setup.py` from `yapf ` as it is so small anyway. Thoughts?

