### PR TITLE
Add slight margin below back button

### DIFF
--- a/WebApp/autoreduce_webapp/static/css/base.css
+++ b/WebApp/autoreduce_webapp/static/css/base.css
@@ -210,6 +210,10 @@ search#run_search {
     word-wrap: break-word;
 }
 
+a#cancel {
+    margin-bottom: 12px;
+}
+
 /****************
  7. Variables
 ****************/


### PR DESCRIPTION
### Summary of work
Added slight margin below run summary back button.

Before:
![image](https://user-images.githubusercontent.com/5902731/114582374-6e91f580-9c78-11eb-8131-2d1f6480773c.png)

After:
![image](https://user-images.githubusercontent.com/5902731/114583087-258e7100-9c79-11eb-8c03-fa736bbbc813.png)

### How to test your work
* Test the run summary page to see the margin