### PR TITLE
Keep real types in the database objects' values AR-1283 AR-1329

### DIFF
--- a/WebApp/autoreduce_webapp/autoreduce_webapp/fixtures/run_with_multiple_variables.json
+++ b/WebApp/autoreduce_webapp/autoreduce_webapp/fixtures/run_with_multiple_variables.json
@@ -1,0 +1,240 @@
+[{
+        "model": "reduction_viewer.reductionrun",
+        "pk": 1,
+        "fields": {
+            "run_number": 99999,
+            "status_id": 2,
+            "run_version": 0,
+            "run_description": "This is the test run_description",
+            "last_updated": "2020-10-19 17:35:04+00:00",
+            "created": "2020-10-19 17:30:04+00:00",
+            "reduction_log": "test_log",
+            "admin_log": "log",
+            "hidden_in_failviewer": 0,
+            "experiment_id": 1,
+            "instrument_id": 1,
+            "started_by": -1,
+            "reduction_host": "test-host-123"
+        }
+    },
+    {
+        "pk": 1,
+        "model": "reduction_viewer.software",
+        "fields": {
+            "name": "FakeSoftware",
+            "version": "6"
+        }
+    },
+    {
+        "pk": 1,
+        "model": "reduction_viewer.datalocation",
+        "fields": {
+            "file_path": "/tmp",
+            "reduction_run_id": 1
+        }
+    },
+    {
+        "model": "reduction_viewer.experiment",
+        "pk": 1,
+        "fields": {
+            "reference_number": 1234567
+        }
+    },
+    {
+        "model": "reduction_viewer.instrument",
+        "pk": 1,
+        "fields": {
+            "name": "TestInstrument",
+            "is_active": true,
+            "is_paused": false
+        }
+    },
+    {
+        "model": "instrument.variable",
+        "pk": 1,
+        "fields": {
+            "name": "variable_str",
+            "value": "value1",
+            "type": "text",
+            "is_advanced": false,
+            "help_text": ""
+        }
+    },
+    {
+        "model": "instrument.variable",
+        "pk": 2,
+        "fields": {
+            "name": "variable_int",
+            "value": 123,
+            "type": "number",
+            "is_advanced": false,
+            "help_text": ""
+        }
+    },
+    {
+        "model": "instrument.variable",
+        "pk": 3,
+        "fields": {
+            "name": "variable_float",
+            "value": 123.321,
+            "type": "number",
+            "is_advanced": false,
+            "help_text": ""
+        }
+    },
+    {
+        "model": "instrument.variable",
+        "pk": 4,
+        "fields": {
+            "name": "variable_listint",
+            "value": [
+                1,
+                2,
+                3
+            ],
+            "type": "list_number",
+            "is_advanced": false,
+            "help_text": ""
+        }
+    },
+    {
+        "model": "instrument.variable",
+        "pk": 5,
+        "fields": {
+            "name": "variable_liststr",
+            "value": [
+                "a",
+                "b",
+                "c"
+            ],
+            "type": "list_text",
+            "is_advanced": false,
+            "help_text": ""
+        }
+    },
+    {
+        "model": "instrument.variable",
+        "pk": 6,
+        "fields": {
+            "name": "variable_none",
+            "value": "",
+            "type": "text",
+            "is_advanced": false,
+            "help_text": ""
+        }
+    },
+    {
+        "model": "instrument.instrumentvariable",
+        "pk": 1,
+        "fields": {
+            "variable_ptr_id": 1,
+            "instrument_id": 1,
+            "experiment_reference": null,
+            "start_run": 99999,
+            "tracks_script": true
+        }
+    },
+    {
+        "model": "instrument.runvariable",
+        "pk": 1,
+        "fields": {
+            "variable_id": 1,
+            "reduction_run_id": 1
+        }
+    },
+    {
+        "model": "instrument.instrumentvariable",
+        "pk": 2,
+        "fields": {
+            "variable_ptr_id": 2,
+            "instrument_id": 1,
+            "experiment_reference": null,
+            "start_run": 99999,
+            "tracks_script": true
+        }
+    },
+    {
+        "model": "instrument.runvariable",
+        "pk": 2,
+        "fields": {
+            "variable_id": 2,
+            "reduction_run_id": 1
+        }
+    },
+    {
+        "model": "instrument.instrumentvariable",
+        "pk": 3,
+        "fields": {
+            "variable_ptr_id": 3,
+            "instrument_id": 1,
+            "experiment_reference": null,
+            "start_run": 99999,
+            "tracks_script": true
+        }
+    },
+    {
+        "model": "instrument.runvariable",
+        "pk": 3,
+        "fields": {
+            "variable_id": 3,
+            "reduction_run_id": 1
+        }
+    },
+    {
+        "model": "instrument.instrumentvariable",
+        "pk": 4,
+        "fields": {
+            "variable_ptr_id": 4,
+            "instrument_id": 1,
+            "experiment_reference": null,
+            "start_run": 99999,
+            "tracks_script": true
+        }
+    },
+    {
+        "model": "instrument.runvariable",
+        "pk": 4,
+        "fields": {
+            "variable_id": 4,
+            "reduction_run_id": 1
+        }
+    },
+    {
+        "model": "instrument.instrumentvariable",
+        "pk": 5,
+        "fields": {
+            "variable_ptr_id": 5,
+            "instrument_id": 1,
+            "experiment_reference": null,
+            "start_run": 99999,
+            "tracks_script": true
+        }
+    },
+    {
+        "model": "instrument.runvariable",
+        "pk": 5,
+        "fields": {
+            "variable_id": 5,
+            "reduction_run_id": 1
+        }
+    },
+    {
+        "model": "instrument.instrumentvariable",
+        "pk": 6,
+        "fields": {
+            "variable_ptr_id": 6,
+            "instrument_id": 1,
+            "experiment_reference": null,
+            "start_run": 99999,
+            "tracks_script": true
+        }
+    },
+    {
+        "model": "instrument.runvariable",
+        "pk": 6,
+        "fields": {
+            "variable_id": 6,
+            "reduction_run_id": 1
+        }
+    }
+]

--- a/WebApp/autoreduce_webapp/autoreduce_webapp/fixtures/run_with_multiple_variables.json
+++ b/WebApp/autoreduce_webapp/autoreduce_webapp/fixtures/run_with_multiple_variables.json
@@ -14,7 +14,8 @@
             "experiment_id": 1,
             "instrument_id": 1,
             "started_by": -1,
-            "reduction_host": "test-host-123"
+            "reduction_host": "test-host-123",
+            "software_id": 1
         }
     },
     {
@@ -117,6 +118,17 @@
         "pk": 6,
         "fields": {
             "name": "variable_none",
+            "value": "None",
+            "type": "text",
+            "is_advanced": false,
+            "help_text": ""
+        }
+    },
+    {
+        "model": "instrument.variable",
+        "pk": 7,
+        "fields": {
+            "name": "variable_empty",
             "value": "",
             "type": "text",
             "is_advanced": false,
@@ -234,6 +246,25 @@
         "pk": 6,
         "fields": {
             "variable_id": 6,
+            "reduction_run_id": 1
+        }
+    },
+    {
+        "model": "instrument.instrumentvariable",
+        "pk": 7,
+        "fields": {
+            "variable_ptr_id": 7,
+            "instrument_id": 1,
+            "experiment_reference": null,
+            "start_run": 99999,
+            "tracks_script": true
+        }
+    },
+    {
+        "model": "instrument.runvariable",
+        "pk": 7,
+        "fields": {
+            "variable_id": 7,
             "reduction_run_id": 1
         }
     }

--- a/WebApp/autoreduce_webapp/instrument/models.py
+++ b/WebApp/autoreduce_webapp/instrument/models.py
@@ -16,7 +16,7 @@ class Variable(models.Model):
     Generic model class that should be treated as abstract
     """
     name = models.CharField(max_length=50, blank=False)
-    value = models.CharField(max_length=300, blank=False)
+    value = models.CharField(max_length=300, blank=True)
     type = models.CharField(max_length=50, blank=False)
     is_advanced = models.BooleanField(default=False)
     help_text = models.TextField(blank=True, null=True, default='')

--- a/WebApp/autoreduce_webapp/selenium_tests/pages/component_mixins/rerun_form_mixin.py
+++ b/WebApp/autoreduce_webapp/selenium_tests/pages/component_mixins/rerun_form_mixin.py
@@ -51,3 +51,141 @@ class RerunFormMixin:
         Selenium requires that we clear the field first!
         """
         self._set_field(self.variable1_field, value)
+
+    @property
+    def variable_str_field(self) -> WebElement:
+        """
+        Finds and returns the variabl1 input field
+        """
+        return self.driver.find_element_by_id("var-standard-variable_str")
+
+    @property
+    def variable_str_field_val(self) -> WebElement:
+        """
+        Finds and returns the variabl1 input field
+        """
+        return self.driver.find_element_by_id("var-standard-variable_str").get_attribute("value")
+
+    @variable_str_field.setter
+    def variable_str_field(self, value) -> None:
+        """
+        Clears the field and sends the keys to the input field.
+
+        Selenium requires that we clear the field first!
+        """
+        self._set_field(self.variable_str_field, value)
+
+    @property
+    def variable_int_field(self) -> WebElement:
+        """
+        Finds and returns the variabl1 input field
+        """
+        return self.driver.find_element_by_id("var-standard-variable_int")
+
+    @property
+    def variable_int_field_val(self) -> WebElement:
+        """
+        Finds and returns the variabl1 input field
+        """
+        return self.driver.find_element_by_id("var-standard-variable_int").get_attribute("value")
+
+    @variable_int_field.setter
+    def variable_int_field(self, value) -> None:
+        """
+        Clears the field and sends the keys to the input field.
+
+        Selenium requires that we clear the field first!
+        """
+        self._set_field(self.variable_int_field, value)
+
+    @property
+    def variable_float_field(self) -> WebElement:
+        """
+        Finds and returns the variabl1 input field
+        """
+        return self.driver.find_element_by_id("var-standard-variable_float")
+
+    @property
+    def variable_float_field_val(self) -> WebElement:
+        """
+        Finds and returns the variabl1 input field
+        """
+        return self.driver.find_element_by_id("var-standard-variable_float").get_attribute("value")
+
+    @variable_float_field.setter
+    def variable_float_field(self, value) -> None:
+        """
+        Clears the field and sends the keys to the input field.
+
+        Selenium requires that we clear the field first!
+        """
+        self._set_field(self.variable_float_field, value)
+
+    @property
+    def variable_listint_field(self) -> WebElement:
+        """
+        Finds and returns the variabl1 input field
+        """
+        return self.driver.find_element_by_id("var-standard-variable_listint")
+
+    @property
+    def variable_listint_field_val(self) -> WebElement:
+        """
+        Finds and returns the variabl1 input field
+        """
+        return self.driver.find_element_by_id("var-standard-variable_listint").get_attribute("value")
+
+    @variable_listint_field.setter
+    def variable_listint_field(self, value) -> None:
+        """
+        Clears the field and sends the keys to the input field.
+
+        Selenium requires that we clear the field first!
+        """
+        self._set_field(self.variable_listint_field, value)
+
+    @property
+    def variable_liststr_field(self) -> WebElement:
+        """
+        Finds and returns the variabl1 input field
+        """
+        return self.driver.find_element_by_id("var-standard-variable_liststr")
+
+    @property
+    def variable_liststr_field_val(self) -> WebElement:
+        """
+        Finds and returns the variabl1 input field
+        """
+        return self.driver.find_element_by_id("var-standard-variable_liststr").get_attribute("value")
+
+    @variable_liststr_field.setter
+    def variable_liststr_field(self, value) -> None:
+        """
+        Clears the field and sends the keys to the input field.
+
+        Selenium requires that we clear the field first!
+        """
+        self._set_field(self.variable_liststr_field, value)
+
+    @property
+    def variable_none_field(self) -> WebElement:
+        """
+        Finds and returns the variabl1 input field
+        """
+        return self.driver.find_element_by_id("var-standard-variable_none")
+
+    @property
+    def variable_none_field_val(self) -> WebElement:
+        """
+        Finds and returns the variabl1 input field
+        """
+        return self.driver.find_element_by_id("var-standard-variable_none").get_attribute("value")
+
+    @variable_none_field.setter
+    def variable_none_field(self, value) -> None:
+        """
+        Clears the field and sends the keys to the input field.
+
+        Selenium requires that we clear the field first!
+        """
+        self._set_field(self.variable_none_field, value)

--- a/WebApp/autoreduce_webapp/selenium_tests/pages/component_mixins/rerun_form_mixin.py
+++ b/WebApp/autoreduce_webapp/selenium_tests/pages/component_mixins/rerun_form_mixin.py
@@ -189,3 +189,26 @@ class RerunFormMixin:
         Selenium requires that we clear the field first!
         """
         self._set_field(self.variable_none_field, value)
+
+    @property
+    def variable_empty_field(self) -> WebElement:
+        """
+        Finds and returns the variabl1 input field
+        """
+        return self.driver.find_element_by_id("var-standard-variable_empty")
+
+    @property
+    def variable_empty_field_val(self) -> WebElement:
+        """
+        Finds and returns the variabl1 input field
+        """
+        return self.driver.find_element_by_id("var-standard-variable_empty").get_attribute("value")
+
+    @variable_empty_field.setter
+    def variable_empty_field(self, value) -> None:
+        """
+        Clears the field and sends the keys to the input field.
+
+        Selenium requires that we clear the field first!
+        """
+        self._set_field(self.variable_empty_field, value)

--- a/WebApp/autoreduce_webapp/selenium_tests/tests/test_rerun_jobs_integration_multivars.py
+++ b/WebApp/autoreduce_webapp/selenium_tests/tests/test_rerun_jobs_integration_multivars.py
@@ -1,0 +1,125 @@
+# ############################################################################### #
+# Autoreduction Repository : https://github.com/ISISScientificComputing/autoreduce
+#
+# Copyright &copy; 2021 ISIS Rutherford Appleton Laboratory UKRI
+# SPDX - License - Identifier: GPL-3.0-or-later
+# ############################################################################### #
+
+from django.urls import reverse
+from selenium_tests.pages.rerun_jobs_page import RerunJobsPage
+from selenium_tests.tests.base_tests import (BaseTestCase, FooterTestMixin, NavbarTestMixin, AccessibilityTestMixin)
+from selenium_tests.utils import submit_and_wait_for_result
+
+from WebApp.autoreduce_webapp.selenium_tests.utils import setup_external_services
+
+SCRIPT = """
+import sys
+import os
+
+sys.path.append(os.path.dirname(__file__))
+
+import reduce_vars as web_var
+
+def main(input_file, output_dir):
+    with open("/tmp/testfile", 'w+') as file:
+        file.write("\\n".join([str(var) for var in web_var.standard_vars.items()]))
+"""
+
+
+class TestRerunJobsPageIntegrationMultiVar(NavbarTestMixin, BaseTestCase, FooterTestMixin, AccessibilityTestMixin):
+    fixtures = BaseTestCase.fixtures + ["run_with_multiple_variables"]
+
+    accessibility_test_ignore_rules = {
+        # https://github.com/ISISScientificComputing/autoreduce/issues/1267
+        "duplicate-id-aria": "input",
+    }
+
+    @classmethod
+    def setUpClass(cls):
+        """Starts external services and sets instrument for all test cases"""
+        super().setUpClass()
+        cls.instrument_name = "TestInstrument"
+        cls.data_archive, cls.database_client, cls.queue_client, cls.listener = setup_external_services(
+            cls.instrument_name, 21, 21)
+        cls.data_archive.add_reduction_script(cls.instrument_name, SCRIPT)
+        cls.data_archive.add_reduce_vars_script(
+            cls.instrument_name, """standard_vars={"variable_str":"test_variable_value_123",
+                                                "variable_int":123, "variable_float":123.321,
+                                                "variable_listint":[1,2,3], "variable_liststr":["a","b","c"],
+                                                "variable_none":None}""")
+        cls.instrument_name = "TestInstrument"
+        cls.rb_number = 1234567
+        cls.run_number = 99999
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        """Stops external services."""
+        cls.queue_client.disconnect()
+        cls.database_client.disconnect()
+        cls.data_archive.delete()
+        super().tearDownClass()
+
+    def setUp(self) -> None:
+        """Sets up RerunJobsPage before each test case"""
+        super().setUp()
+        self.page = RerunJobsPage(self.driver, self.instrument_name)
+        self.page.launch()
+
+    def test_variables_appear_as_expected(self):
+        """
+        Test: Just opening the submit page and clicking rerun
+        """
+        assert self.page.variable_str_field_val == "value1"
+        assert self.page.variable_int_field_val == "123"
+        assert self.page.variable_float_field_val == "123.321"
+        assert self.page.variable_listint_field_val == "[1, 2, 3]"
+        assert self.page.variable_liststr_field_val == "['a', 'b', 'c']"
+        assert self.page.variable_none_field_val == "None"
+
+    def test_submit_rerun_same_variables(self):
+        """
+        Test: Just opening the submit page and clicking rerun
+        """
+        result = submit_and_wait_for_result(self)
+        assert len(result) == 2
+
+        assert result[0].run_version == 0
+        assert result[1].run_version == 1
+
+        for run0_var, run1_var in zip(result[0].run_variables.all(), result[1].run_variables.all()):
+            assert run0_var.variable == run1_var.variable
+
+    def test_submit_rerun_changed_variable_arbitrary_value(self):
+        """
+        Test: Open submit page, change a variable, submit the run
+        """
+        new_str_value = "the new value in the field"
+        self.page.variable_str_field = new_str_value
+        new_int = "42"
+        self.page.variable_int_field = new_int
+        new_float = "144.33"
+        self.page.variable_float_field = new_float
+        new_listint = "[111, 222]"
+        self.page.variable_listint_field = new_listint
+        new_liststr = "['string1', 'string2']"
+        self.page.variable_liststr_field = new_liststr
+
+        result = submit_and_wait_for_result(self)
+        assert len(result) == 2
+
+        assert result[0].run_version == 0
+        assert result[1].run_version == 1
+
+        for run0_var, run1_var in zip(result[0].run_variables.all(), result[1].run_variables.all()):
+            # the value of the variable has been overwritten because it's the same run number
+            assert run0_var.variable == run1_var.variable
+
+        run_vars = result[1].run_variables.all()
+        assert run_vars[0].variable.value == new_str_value
+        assert run_vars[1].variable.value == new_int
+        assert run_vars[2].variable.value == new_float
+        assert run_vars[3].variable.value == new_listint
+        assert run_vars[4].variable.value == new_liststr
+        assert run_vars[5].variable.value == ""
+
+    # TODO: verify the saved out file's values against the expected - currently BROKEN!

--- a/WebApp/autoreduce_webapp/selenium_tests/tests/test_rerun_jobs_integration_multivars.py
+++ b/WebApp/autoreduce_webapp/selenium_tests/tests/test_rerun_jobs_integration_multivars.py
@@ -14,7 +14,7 @@ from selenium_tests.utils import submit_and_wait_for_result
 
 from WebApp.autoreduce_webapp.selenium_tests.utils import setup_external_services
 
-TEMP_OUT_FILE = tempfile.TemporaryFile()
+TEMP_OUT_FILE = tempfile.NamedTemporaryFile()
 SCRIPT = f"""
 import sys
 import os
@@ -29,7 +29,7 @@ def main(input_file, output_dir):
 """
 
 
-class TestRerunJobsPageIntegrationMultiVar(NavbarTestMixin, BaseTestCase, FooterTestMixin, AccessibilityTestMixin):
+class TestRerunJobsPageIntegrationMultiVar(BaseTestCase, NavbarTestMixin, FooterTestMixin, AccessibilityTestMixin):
     fixtures = BaseTestCase.fixtures + ["run_with_multiple_variables"]
 
     accessibility_test_ignore_rules = {

--- a/WebApp/autoreduce_webapp/selenium_tests/tests/test_rerun_jobs_integration_multivars.py
+++ b/WebApp/autoreduce_webapp/selenium_tests/tests/test_rerun_jobs_integration_multivars.py
@@ -7,7 +7,6 @@
 
 import tempfile
 
-from django.urls import reverse
 from selenium_tests.pages.rerun_jobs_page import RerunJobsPage
 from selenium_tests.tests.base_tests import (BaseTestCase, FooterTestMixin, NavbarTestMixin, AccessibilityTestMixin)
 from selenium_tests.utils import submit_and_wait_for_result

--- a/WebApp/autoreduce_webapp/templates/run_summary.html
+++ b/WebApp/autoreduce_webapp/templates/run_summary.html
@@ -290,7 +290,7 @@
     <link rel="stylesheet" href="{% static 'css/vendor/bootstrap-tour.min.css' %}">
 {% endblock %}
 {% block scripts %}
-    <script src="{% static "javascript/run_summary.js" %}"></script>
+    <script src="{% static 'javascript/run_summary.js' %}"></script>
     <script src="{% static 'javascript/vendor/prettify.js' %}"></script>
     <script src="{% static 'javascript/run_variables.js' %}"></script>
     <script src="{% static 'javascript/vendor/bootstrap-tour.min.js' %}"></script>

--- a/model/database/access.py
+++ b/model/database/access.py
@@ -92,6 +92,10 @@ def get_software(name, version):
     :return: (Software) The Software object from the database
     """
     database = start_database()
+    if not version:
+        # Hard-code a version if not provided unitl
+        # https://autoreduce.atlassian.net/browse/AR-1230 is addressed
+        version = "6"
     return database.data_model.Software.objects.get_or_create(name=name, version=version)[0]
 
 

--- a/queue_processors/queue_processor/instrument_variable_utils.py
+++ b/queue_processors/queue_processor/instrument_variable_utils.py
@@ -154,7 +154,6 @@ class InstrumentVariablesUtils:
         for name, value, is_advanced in all_vars:
             script_help_text = InstrumentVariablesUtils.get_help_text(
                 'standard_vars' if not is_advanced else 'advanced_vars', name, reduction_arguments)
-            new_value = str(value).replace('[', '').replace(']', '')
             new_type = VariableUtils.get_type_string(value)
 
             # Try to find a suitable variable to re-use from the ones that already exist
@@ -164,7 +163,7 @@ class InstrumentVariablesUtils:
             if variable is None:
                 var_kwargs = {
                     'name': name,
-                    'value': new_value,
+                    'value': value,
                     'type': new_type,
                     'help_text': script_help_text,
                     'is_advanced': is_advanced,
@@ -181,7 +180,7 @@ class InstrumentVariablesUtils:
                     variable.tracks_script = not from_webapp
                 variable.save()
             else:
-                InstrumentVariablesUtils.update_if_necessary(variable, experiment_reference, run_number, new_value,
+                InstrumentVariablesUtils.update_if_necessary(variable, experiment_reference, run_number, value,
                                                              new_type, script_help_text, from_webapp)
             variables.append(variable)
         return variables

--- a/queue_processors/queue_processor/reduction/runner.py
+++ b/queue_processors/queue_processor/reduction/runner.py
@@ -95,7 +95,7 @@ class ReductionRunner:
 
         reduction_log_stream = io.StringIO()
         try:
-            reduce(reduction_dir, temp_dir, datafile, reduction_script, reduction_log_stream)
+            reduce(reduction_dir, temp_dir, datafile, reduction_script, self.reduction_arguments, reduction_log_stream)
             self.message.reduction_log = reduction_log_stream.getvalue()
             self.message.reduction_data = str(reduction_dir.path)
         except ReductionScriptError as err:

--- a/queue_processors/queue_processor/reduction/service.py
+++ b/queue_processors/queue_processor/reduction/service.py
@@ -187,22 +187,25 @@ class ReductionScript:
             Merge self.reduction_arguments[dictName] into reduce_script.web_var[dictName],
             overwriting any key that exists in both with the value from sourceDict.
             """
-            def merge_dict_to_name(dictionary_name, source_dict):
+            def merge_dict_to_name(source_dict):
                 """ Merge the two dictionaries. """
                 old_dict = {}
-                if hasattr(self.module.web_var, dictionary_name):
-                    old_dict = getattr(self.module.web_var, dictionary_name)
+                if hasattr(self.module.web_var, dict_name):
+                    old_dict = getattr(self.module.web_var, dict_name)
                 else:
                     pass
                 old_dict.update(source_dict)
-                setattr(self.module.web_var, dictionary_name, old_dict)
+                setattr(self.module.web_var, dict_name, old_dict)
 
             def ascii_encode(var):
                 """ ASCII encode var. """
                 return var.encode('ascii', 'ignore') if type(var).__name__ == "unicode" else var
 
             encoded_dict = {k: ascii_encode(v) for k, v in reduction_arguments[dict_name].items()}
-            merge_dict_to_name(dict_name, encoded_dict)
+            merge_dict_to_name(encoded_dict)
+
+        if not self.module:
+            raise RuntimeError("The script has not been loaded yet")
 
         if not hasattr(self.module, "web_var"):
             self.module.web_var = types.ModuleType("reduce_vars")

--- a/queue_processors/queue_processor/tests/test_instrument_variable_utils.py
+++ b/queue_processors/queue_processor/tests/test_instrument_variable_utils.py
@@ -358,7 +358,7 @@ class TestInstrumentVariableUtils(unittest.TestCase):
 
         var = new_variables_again[0].variable
         assert var.name == "standard_var1"
-        assert var.value == "123"
+        assert var.value == 123
         assert var.type == "number"
         assert var.help_text == "CHANGED HELP FOR VARIABLE"
 

--- a/queue_processors/queue_processor/variable_utils.py
+++ b/queue_processors/queue_processor/variable_utils.py
@@ -9,7 +9,7 @@ Class to deal with reduction run variables
 """
 import re
 import logging
-from typing import Dict
+from typing import Dict, List
 
 from model.database import access
 from queue_processors.queue_processor.reduction.service import ReductionScript
@@ -53,6 +53,13 @@ class VariableUtils:
             return "text"
 
     @staticmethod
+    def _prepare_list(input_list: str) -> List[str]:
+        if not isinstance(input_list, list):
+            return input_list.replace("[", "").replace("]", "").split(",")
+        else:
+            return input_list
+
+    @staticmethod
     def convert_variable_to_type(value, var_type):
         """
         Convert the given value a type matching that of var_type.
@@ -73,7 +80,7 @@ class VariableUtils:
                 return float(value)
             return int(re.sub("[^0-9]+", "", str(value)))
         if var_type == "list_text":
-            var_list = str(value).split(',')
+            var_list = VariableUtils._prepare_list(value)
             list_text = []
             for list_val in var_list:
                 item = list_val.strip().strip("'")
@@ -81,7 +88,7 @@ class VariableUtils:
                     list_text.append(item)
             return list_text
         if var_type == "list_number":
-            var_list = value.split(',')
+            var_list = VariableUtils._prepare_list(value)
             list_number = []
             for list_val in var_list:
                 if list_val:


### PR DESCRIPTION
### Summary of work
Stops the queue processor from converting everything to string before saving in the DB - this means the original types are now kept. Adds tests for the different supported variable types to check that they are properly shown on the web app and stored in the DB as expected

**Adds back replacement of the reduction arguments** - currently only the values in reduce_vars are used and are never replaced. The fix will be deployed in production after this PR is merged. Adds test for this so it doesn't happen again.

### How to test your work
Tests should pass

### Additional comments
<!---Anything else: e.g. was the estimate reasonable for this issue?---> 

Fixes AR-1283