### PR TITLE
Add initial compose AR-316

### DIFF
--- a/systemtests/reduction_sys_test/docker-compose.yml
+++ b/systemtests/reduction_sys_test/docker-compose.yml
@@ -1,0 +1,9 @@
+services:
+  activemq:
+    image: rmohr/activemq:5.15.9
+    ports:
+    - 6163:6163
+    - 8161:8161
+
+  queueprocessors:
+    image: autoreduction/qp

--- a/systemtests/reduction_sys_test/test_reduce_scripts.py
+++ b/systemtests/reduction_sys_test/test_reduce_scripts.py
@@ -1,0 +1,3 @@
+"""
+This module is for testing the current reduction scripts and will notify on failure
+"""

--- a/systemtests/reduction_sys_test/test_reduce_scripts.py
+++ b/systemtests/reduction_sys_test/test_reduce_scripts.py
@@ -1,3 +1,85 @@
 """
 This module is for testing the current reduction scripts and will notify on failure
 """
+import time
+from unittest import TestCase
+
+import requests
+
+from model.database import access as db
+from queue_processors.queue_processor.settings import SCRIPT_TIMEOUT
+from scripts.manual_operations import manual_submission
+
+RUNS = [
+    ("ARMI", 12345),
+    ("TEST_INSTRUMENT", 143423)
+]
+
+class TestReduceScripts(TestCase):
+
+    failures = []
+    message = ""
+
+    def tearDown(self) -> None:
+        if self._is_test_failure():
+            self._build_alert_message()
+            self._alert_on_fail()
+
+    def _is_test_failure(self):
+        if hasattr(self, '_outcome'):
+            result = self.defaultTestResult()
+            self._feedErrorsToResult(result, self._outcome.errors)
+            return len(result.failures) > 0 or len(result.errors) > 0
+        return False
+
+    def _build_alert_message(self):
+        for fail in self.failures:
+            self.message += f"\n - Reduction run {fail[1]} failed on instrument: {fail[0]} due to: {fail[2]}  "
+        self.message += ""
+
+    def _alert_on_fail(self):
+        data = {
+            "@context": "https://schema.org/extensions",
+            "@type": "MessageCard",
+            "themeColor": "0072C6",
+            "title": "System Test Failure Alert",
+            "text": f"Reductions failed on instruments:  \n{self.message}",
+            "potentialAction": []
+        }
+        requests.post(os.environ.get("SYSTEST_WEBHOOK_URL"), json=data)
+
+    def _is_run_complete(self):
+        run = self._find_run_in_database()
+        return run.status == db.get_status("e") or run.status == db.get_status("c")
+
+    def _find_run_in_database(self):
+        instrument = db.get_instrument(self.instrument)
+        return instrument.reduction_runs.filter(run_number=self.run_number)
+
+    def test_reduction(self):
+        for run_pair in RUNS:
+            with self.subTest():
+                self.instrument = run_pair[0]
+                self.run_number = run_pair[1]
+                self.reason = ""
+
+                try:
+                    manual_submission.main(self.instrument, self.run_number)
+                except:  # pylint:disable=bare-except
+                    self.reason = "Failed to submit reduction run, ActiveMQ or ICAT may be unreachable"
+                    self.fail(self.reason)
+                start_time = time.time()
+                while not self._is_run_complete():
+                    time.sleep(1)
+                    if time.time() - start_time > SCRIPT_TIMEOUT:
+                        self.reason = "Reduction failed to complete within the timeout period"
+                        self.fail(self.reason)
+
+                run = self._find_run_in_database()
+
+                self.reason = "Reduction run failed with error status"
+                self.assertEqual(run.status,  db.get_status("c"), self.reason)
+            if self._is_test_failure():
+                TestReduceScripts.failures.append((self.instrument, self.run_number, self.reason))
+
+


### PR DESCRIPTION
### Summary of work
What exists:
- Manual submission call
- Check the submission completed with a completed status
- Alert to teams as shown

![image](https://user-images.githubusercontent.com/44777678/116685333-1104e500-a9aa-11eb-9a8a-b3b00c409bde.png)

What needs to be done:
 - [ ] Mount CEPH
 - [ ] Set credentials to compose containers
 - [ ] Change `queue_processor` settings to output to a different location
 - [ ] Update `RUNS` to real instruments with known successful run numbers
 - [ ] Verify if a wait between `manual_submission` call and database polling needs to be added
 - [ ] Verify I correctly added the webhook url to the environment of the vm 
 - [ ] Exclude this test from CI

It would also be nice to use `parametized` instead of `subTest` but I couldnt get the `tearDown` to run locally with it.

Once this is done we should in theory have everything such that we can schedule a cron job to spin up the environment and run this test at a certain interval.

@dtasev  I hope this was a useful start, sorry I couldnt get more done in time! 
