### PR TITLE
Add yapf pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,6 @@
+repos:
+  - repo: https://github.com/pre-commit/mirrors-yapf
+    rev: v0.31.0  # Keep this version up to date with requirements.txt
+    hooks:
+      - id: yapf
+        args: ['--in-place', '--parallel', '--recursive']

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,4 +11,5 @@ pytest-django==4.2.0
 pytest-xdist==2.2.1
 selenium==3.141.0
 vulture==2.3
-yapf==0.31.0
+yapf==0.31.0  # Keep this version up to date with .pre-commit-config.yaml
+pre-commit==2.12.1


### PR DESCRIPTION
### Summary of work
- Added yapf pre-commit hook

### How to test your work
- Add some incorrectly formatted Python code.
- Stage the file. And try to commit it.
- It should fail to commit and also fix the file.
- Stage the file again. And commit without the hook failing.
- To manually run the hook without committing run `pre-commit run`

### Additional comments
* There's also the opportunity to add [other hooks](https://pre-commit.com/hooks.html).
* `pylint` might be useful to run after yapf but I couldn't get it to work. I tried below (and variations on it) but it always seems to hang or not find the right python modules:
```yml
  - repo: https://github.com/PyCQA/pylint
    rev: v2.8.2
    hooks:
      - id: pylint
        entry: env PYTHONPATH=autoreduce_qp pylint
        additional_dependencies: [pylint-django]
        args: ['--load-plugins=pylint_django autoreduce_qp']
```