### PR TITLE
Read in file as non-binary UTF-8 | AR-1420

### DIFF
--- a/autoreduce_qp/queue_processor/reduction/service.py
+++ b/autoreduce_qp/queue_processor/reduction/service.py
@@ -17,8 +17,6 @@ from importlib.util import spec_from_file_location, module_from_spec
 from pathlib import Path
 from tempfile import TemporaryDirectory
 
-import chardet
-
 from .exceptions import DatafileError, ReductionScriptError
 from .timeout import TimeOut
 from .utilities import channels_redirected
@@ -167,14 +165,10 @@ class ReductionScript:
         """Returns the text of the script file. Does not load it as a module"""
         # Read raw bytes and determine encoding
         try:
-            with io.open(self.script_path, 'rb') as file_raw:
-                encoding = chardet.detect(file_raw.read(32))["encoding"]
+            with io.open(self.script_path, 'r') as open_file:
+                return open_file.read()
         except IOError:
             return ""
-
-        # Read the file in decoded; io is used for the encoding kwarg
-        with io.open(self.script_path, 'r', encoding=encoding) as file_decoded:
-            return file_decoded.read()
 
     def replace_variables(self, reduction_arguments):
         """

--- a/autoreduce_qp/queue_processor/reduction/tests/test_service.py
+++ b/autoreduce_qp/queue_processor/reduction/tests/test_service.py
@@ -305,6 +305,10 @@ class TestReductionService(unittest.TestCase):
         with self._test_module(test_string) as red_script:
             assert red_script.text() == test_string
 
+        test_special_chars = 'print("✈", "’")'
+        with self._test_module(test_special_chars) as red_script:
+            assert red_script.text() == test_special_chars
+
     def test_reduction_script_replace_variables_before_load(self):
         """
         Test that replace variables raises if called before the module is loaded

--- a/autoreduce_qp/queue_processor/reduction/tests/test_service.py
+++ b/autoreduce_qp/queue_processor/reduction/tests/test_service.py
@@ -268,6 +268,7 @@ class TestReductionService(unittest.TestCase):
         red_script.script_path = Path(os.path.join(os.path.dirname(__file__), "module_to_import.py"))
         module = red_script.load()
 
+        assert red_script.exists()
         assert getattr(module, "TEST_DICTIONARY") == TEST_DICTIONARY
         assert red_script.module is not None
 

--- a/autoreduce_qp/queue_processor/tests/test_handle_message.py
+++ b/autoreduce_qp/queue_processor/tests/test_handle_message.py
@@ -171,6 +171,20 @@ class TestHandleMessage(TestCase):
         assert self.reduction_run.finished is not None
         assert self.reduction_run.reduction_location.first().file_path == "/path/1"
 
+    @patch("autoreduce_qp.queue_processor.handle_message.ReductionProcessManager")
+    def test_do_reduction_success_special_characters_in_script(self, rpm):
+        "Tests do_reduction success path"
+        rpm.return_value.run = self.do_post_started_assertions
+        test_special_chars_script = 'print("✈", "’")'
+        self.reduction_run.script = test_special_chars_script
+
+        self.handler.do_reduction(self.reduction_run, self.msg)
+        assert self.reduction_run.status == Status.get_completed()
+        assert self.reduction_run.started is not None
+        assert self.reduction_run.finished is not None
+        assert self.reduction_run.reduction_location.first().file_path == "/path/1"
+        assert self.reduction_run.script == test_special_chars_script
+
     def do_post_started_assertions(self, expected_info_calls=1):
         "Helper to capture common assertions between tests"
         assert self.reduction_run.status == Status.get_processing()

--- a/setup.py
+++ b/setup.py
@@ -13,8 +13,8 @@ setup(name="autoreduce_qp",
       author="ISIS Autoreduction Team",
       url="https://github.com/ISISScientificComputing/autoreduce/",
       install_requires=[
-          "autoreduce_utils==0.1.3", "autoreduce_db==0.1.4", "autoreduce_scripts==22.0.0.dev1", "chardet==3.0.4",
-          "Django==3.2.2", "fire==0.4.0", "plotly==4.14.3", "stomp.py==6.1.0"
+          "autoreduce_utils==0.1.3", "autoreduce_db==0.1.4", "autoreduce_scripts==22.0.0.dev1", "Django==3.2.2",
+          "fire==0.4.0", "plotly==4.14.3", "stomp.py==6.1.0"
       ],
       packages=find_packages(),
       entry_points={"console_scripts": ["autoreduce-qp-start = autoreduce_qp.queue_processor.queue_listener:main"]},


### PR DESCRIPTION
### Summary of work
Removes using `chardet` to try and find the encoding as the implementation was broken - it just checked one character `chardet.detect(file_raw.read(32))["encoding"]`. For this to work properly, that specific character had to be non-ASCII.

This may be leftover from Python 2.7

It seems that there is no need for this anymore. Just doing `open` and reading in the file works, and can handle any UTF-8 characters.

Adds some tests with emojis to ensure utf-8 compatibility.

### How to test your work
Tests should pass. Code review

### Additional comments
<!---Anything else: e.g. was the estimate reasonable for this issue?---> 
