### PR TITLE
Update stomp to 7

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(name="autoreduce_qp",
       url="https://github.com/ISISScientificComputing/autoreduce/",
       install_requires=[
           "autoreduce_utils==22.0.0.dev3", "autoreduce_db==22.0.0.dev5", "Django==3.2.4", "fire==0.4.0",
-          "plotly==4.14.3", "stomp.py==6.1.0"
+          "plotly==4.14.3", "stomp.py==7.0.0"
       ],
       packages=find_packages(),
       entry_points={"console_scripts": ["autoreduce-qp-start = autoreduce_qp.queue_processor.queue_listener:main"]},


### PR DESCRIPTION
### Summary of work
Updates stomp.py to 7 as it seems that 6.0.0 and 6.1.0 have been yanked from pip https://pypi.org/project/stomp.py/7.0.0/#history

### How to test your work
Builds should pass

### Additional comments
<!---Anything else: e.g. was the estimate reasonable for this issue?---> 

**Before merging ensure the release notes have been updated**
