### PR TITLE
Queue processor now respects an instrument's is_active flag

### DIFF
--- a/autoreduce_qp/queue_processor/handle_message.py
+++ b/autoreduce_qp/queue_processor/handle_message.py
@@ -160,7 +160,8 @@ class HandleMessage:
         except RuntimeError as validation_err:
             return f"Validation error from handler: {validation_err}"
 
-        # if
+        if not instrument.is_active:
+            return f"Run {message.run_number} has been skipped because the instrument {instrument.name} is inactive"
 
         if instrument.is_paused:
             return f"Run {message.run_number} has been skipped because the instrument {instrument.name} is paused"

--- a/autoreduce_qp/queue_processor/handle_message.py
+++ b/autoreduce_qp/queue_processor/handle_message.py
@@ -6,54 +6,53 @@
 # SPDX - License - Identifier: GPL-3.0-or-later
 # ############################################################################
 """
-This modules handles an incoming message from the queue processor
-and takes appropriate action(s) based on the message contents.
+This modules handles an incoming message from the queue processor and takes
+appropriate action(s) based on the message contents.
 
-For example, this may include shuffling the message to another queue,
-update relevant DB fields or logging out the status.
+For example, this may include shuffling the message to another queue, update
+relevant DB fields or logging out the status.
 """
 import logging
 from typing import Optional
+
 from django.db import transaction
 from django.utils import timezone
 
 from autoreduce_db.reduction_viewer.models import DataLocation, ReductionLocation, Status
 from autoreduce_utils.message.message import Message
-
-from autoreduce_qp.model.database import records
 from autoreduce_qp.model.database import access as db_access
+from autoreduce_qp.model.database import records
 from autoreduce_qp.queue_processor.instrument_variable_utils import InstrumentVariablesUtils
-from autoreduce_qp.queue_processor.variable_utils import VariableUtils
 from autoreduce_qp.queue_processor.reduction.process_manager import ReductionProcessManager
 from autoreduce_qp.queue_processor.reduction.service import ReductionScript
+from autoreduce_qp.queue_processor.variable_utils import VariableUtils
 
 
 class HandleMessage:
     """
-    Handles messages from the queue client and forwards through various
-    stages depending on the message contents.
+    Handles messages from the queue client and forwards through various stages
+    depending on the message contents.
     """
     def __init__(self):
         self.instrument_variable = InstrumentVariablesUtils()
-
         self._logger = logging.getLogger(__package__)
 
     def data_ready(self, message: Message):
         """
-        Called when destination queue was data_ready.
-        Updates the reduction run in the database.
+        Called when destination queue was data_ready. Updates the reduction run
+        in the database.
 
-        When we DO NO PROCESSING:
-        - If rb number isn't an integer, or isn't a 7 digit integer
-        - If instrument is paused
-        - If there is no reduce.py
+        NO processing occurs when:
+        • rb number isn't a 7 digit integer.
+        • instrument is paused.
+        • there is no reduce.py.
         """
         self._logger.info("Data ready for processing run %s on %s", message.run_number, message.instrument)
 
         try:
             reduction_run, message, instrument = self.create_run_records(message)
         except Exception as err:
-            # failed to even create the reduction run object - can't reacover from this
+            # Failed to create the reduction run object - unrecoverable
             self._logger.error("Encountered error in transaction to create ReductionRun and related records, error: %s",
                                str(err))
             raise
@@ -66,7 +65,10 @@ class HandleMessage:
             raise
 
     def _handle_error(self, reduction_run, message, err):
-        # couldn't save the state in the database properly - mark the run as errored
+        """
+        Couldn't save the state in the database properly - mark the run as
+        errored.
+        """
         err_msg = "Encountered error when saving run variables"
         message.message = err_msg
         self._logger.error("%s\n%s", err_msg, str(err))
@@ -75,9 +77,11 @@ class HandleMessage:
 
     def create_run_records(self, message: Message):
         """
-        Creates or gets the necessary records to construct a ReductionRun.
+        Create or get the necessary records to construct a ReductionRun.
+
+        This must be done before looking up the run version to make sure the
+        experiment record exists!
         """
-        # This must be done before looking up the run version to make sure the experiment record exists!
         rb_number = self.normalise_rb_number(message.rb_number)
         experiment = db_access.get_experiment(rb_number)
         run_version = db_access.find_highest_run_version(experiment, run_number=str(message.run_number))
@@ -88,9 +92,7 @@ class HandleMessage:
     @staticmethod
     @transaction.atomic
     def do_create_reduction_record(message: Message, experiment, instrument):
-        """
-        Creates the reduction record
-        """
+        """Create the reduction record."""
         script = ReductionScript(instrument.name)
         script_text = script.text()
 
@@ -103,9 +105,10 @@ class HandleMessage:
                                                             status=Status.get_queued())
         reduction_run.save()
 
-        # Create a new data location entry which has a foreign key linking it to the current
-        # reduction run. The file path itself will point to a datafile
-        # (e.g. "/isis/inst$/NDXWISH/Instrument/data/cycle_17_1/WISH00038774.nxs")
+        # Create a new data location entry which has a foreign key linking it to
+        # the current reduction run. The file path itself will point to a
+        # datafile. E.g:
+        # "/isis/inst$/NDXWISH/Instrument/data/cycle_17_1/WISH00038774.nxs")
         data_location = DataLocation(file_path=message.data, reduction_run_id=reduction_run.pk)
         data_location.save()
 
@@ -113,10 +116,10 @@ class HandleMessage:
 
     def create_run_variables(self, reduction_run, message: Message, instrument):
         """
-        Creates the RunVariables for this ReductionRun
+        Create the RunVariables that are described in the run's reduce_vars.py.
         """
-        # Create all of the variables for the run that are described in it's reduce_vars.py
         self._logger.info('Creating variables for run')
+
         variables = self.instrument_variable.create_run_variables(reduction_run, message.reduction_arguments)
         if not variables:
             self._logger.warning("No instrument variables found on %s for run %s", instrument.name, message.run_number)
@@ -124,14 +127,15 @@ class HandleMessage:
         self._logger.info('Getting script and arguments')
         message.reduction_script = reduction_run.script
         message.reduction_arguments = self.get_script_arguments(variables)
+
         return message
 
     def send_message_onwards(self, reduction_run, message: Message, instrument):
         """
-        Sends the message onwards, either for processing, if validation is OK and instrument isn't paused
-        or skips it if either of those is true.
+        Sends the message onwards, either for processing, if validation is OK
+        and instrument isn't paused or skips it if either of those is true.
         """
-        # activate instrument if script was found
+        # Activate instrument if script was found
         skip_reason = self.find_reason_to_skip_run(reduction_run, message, instrument)
         if skip_reason is not None:
             message.message = skip_reason
@@ -145,16 +149,17 @@ class HandleMessage:
     @staticmethod
     def find_reason_to_skip_run(reduction_run, message: Message, instrument) -> Optional[str]:
         """
-        Determines whether the processing should be skippped.
-
-        The run will be skipped if the message validation fails or if the instrument is paused
+        Determines whether the processing should be skippped. The run will be
+        skipped if the message validation fails or if the instrument is paused.
         """
         if reduction_run.script == "":
             return "Script text for current instrument is empty"
         try:
             message.validate("/queue/DataReady")
         except RuntimeError as validation_err:
-            return f"Validation error from handler: {str(validation_err)}"
+            return f"Validation error from handler: {validation_err}"
+
+        # if
 
         if instrument.is_paused:
             return f"Run {message.run_number} has been skipped because the instrument {instrument.name} is paused"
@@ -163,8 +168,8 @@ class HandleMessage:
 
     def do_reduction(self, reduction_run, message: Message):
         """
-        Handovers to the ReductionProcessManager to actually run the reduction process.
-        Handles the outcome from the run.
+        Handovers to the ReductionProcessManager to actually run the reduction
+        process. Handles the outcome from the run.
         """
         reduction_process_manager = ReductionProcessManager(message)
         self.reduction_started(reduction_run, message)
@@ -176,20 +181,21 @@ class HandleMessage:
 
     def activate_db_inst(self, instrument):
         """
-        Gets the DB instrument record from the database, if one is not
-        found it instead creates and saves the record to the DB, then
-        returns it.
+        Gets the DB instrument record from the database, if one is not found it
+        instead creates and saves the record to the DB, then returns it.
         """
         # Activate the instrument if it is currently set to inactive
         if not instrument.is_active:
             self._logger.info("Activating %s", instrument.name)
             instrument.is_active = 1
             instrument.save()
+
         return instrument
 
     def reduction_started(self, reduction_run, message: Message):
         """
-        Called when the run is ready to start. Updates the run as started/processing in the database.
+        Called when the run is ready to start. Updates the run as started /
+        processing in the database.
         """
         self._logger.info("Run %s has started reduction", message.run_number)
         reduction_run.status = Status.get_processing()
@@ -199,23 +205,23 @@ class HandleMessage:
     @transaction.atomic
     def reduction_complete(self, reduction_run, message: Message):
         """
-        Called when the run has completed. Updates the run as complete in the database.
+        Called when the run has completed. Updates the run as complete in the
+        database.
         """
         self._logger.info("Run %s has completed reduction", message.run_number)
-
         self._common_reduction_run_update(reduction_run, Status.get_completed(), message)
-
         reduction_run.software = db_access.get_software("Mantid", message.software)
 
         if message.reduction_data is not None:
             reduction_location = ReductionLocation(file_path=message.reduction_data, reduction_run=reduction_run)
             reduction_location.save()
+
         reduction_run.save()
 
     def reduction_skipped(self, reduction_run, message: Message):
         """
-        Called when there was a reason to skip the run.
-        Updates the run to Skipped status in database. Will NOT attempt re-run
+        Called when there was a reason to skip the run. Updates the run to
+        Skipped status in database. Will NOT attempt re-run.
         """
         if message.message is not None:
             self._logger.info("Run %s has been skipped - %s", message.run_number, message.message)
@@ -227,7 +233,8 @@ class HandleMessage:
 
     def reduction_error(self, reduction_run, message: Message):
         """
-        Called when the run encountered an error. Updates the run as complete in the database.
+        Called when the run encountered an error. Updates the run as complete in
+        the database.
         """
         if message.message:
             self._logger.info("Run %s has encountered an error - %s", message.run_number, message.message)
@@ -248,8 +255,8 @@ class HandleMessage:
     @staticmethod
     def get_script_arguments(run_variables):
         """
-        Converts the RunVariables that have been created into Python kwargs which can
-        be passed as the script parameters at runtime.
+        Converts the RunVariables that have been created into Python kwargs
+        which can be passed as the script parameters at runtime.
         """
         standard_vars, advanced_vars = {}, {}
         for run_variable in run_variables:
@@ -267,7 +274,8 @@ class HandleMessage:
     @staticmethod
     def normalise_rb_number(rb_number) -> int:
         """
-        Enfornce the RB number to always be an int. If an invalid integer value is passed it returns 0 instead.
+        Enfornce the RB number to always be an int. If an invalid integer value
+        is passed it returns 0 instead.
         """
         try:
             return int(rb_number)

--- a/autoreduce_qp/queue_processor/handle_message.py
+++ b/autoreduce_qp/queue_processor/handle_message.py
@@ -30,7 +30,7 @@ from autoreduce_qp.queue_processor.variable_utils import VariableUtils
 
 class HandleMessage:
     """
-    Handles messages from the queue client and forwards through various stages
+    Handle messages from the queue client and forward through the various stages
     depending on the message contents.
     """
     def __init__(self):
@@ -39,10 +39,10 @@ class HandleMessage:
 
     def data_ready(self, message: Message):
         """
-        Called when destination queue was data_ready. Updates the reduction run
-        in the database.
+        Update the reduction run in the database. This is called when
+        destination queue was data_ready.
 
-        NO processing occurs when:
+        No processing occurs when:
         • rb number isn't a 7 digit integer.
         • instrument is paused.
         • there is no reduce.py.
@@ -132,8 +132,9 @@ class HandleMessage:
 
     def send_message_onwards(self, reduction_run, message: Message, instrument):
         """
-        Sends the message onwards, either for processing, if validation is OK
-        and instrument isn't paused or skips it if either of those is true.
+        Send the message onwards, either for processing, if validation is OK
+        and instrument isn't paused, otherwiese skips if either of those is
+        true.
         """
         # Activate instrument if script was found
         skip_reason = self.find_reason_to_skip_run(reduction_run, message, instrument)
@@ -149,7 +150,7 @@ class HandleMessage:
     @staticmethod
     def find_reason_to_skip_run(reduction_run, message: Message, instrument) -> Optional[str]:
         """
-        Determines whether the processing should be skippped. The run will be
+        Determine whether the processing should be skippped. The run will be
         skipped if the message validation fails or if the instrument is paused.
         """
         if reduction_run.script == "":
@@ -168,8 +169,8 @@ class HandleMessage:
 
     def do_reduction(self, reduction_run, message: Message):
         """
-        Handovers to the ReductionProcessManager to actually run the reduction
-        process. Handles the outcome from the run.
+        Handover to the ReductionProcessManager to actually run the reduction
+        process and handle the outcome from the run.
         """
         reduction_process_manager = ReductionProcessManager(message)
         self.reduction_started(reduction_run, message)
@@ -181,8 +182,8 @@ class HandleMessage:
 
     def activate_db_inst(self, instrument):
         """
-        Gets the DB instrument record from the database, if one is not found it
-        instead creates and saves the record to the DB, then returns it.
+        Get the DB instrument record from the database, if one is not found,
+        create and save the record to the DB, then return it.
         """
         # Activate the instrument if it is currently set to inactive
         if not instrument.is_active:
@@ -194,7 +195,7 @@ class HandleMessage:
 
     def reduction_started(self, reduction_run, message: Message):
         """
-        Called when the run is ready to start. Updates the run as started /
+        Called when the run is ready to start. Update the run as started /
         processing in the database.
         """
         self._logger.info("Run %s has started reduction", message.run_number)
@@ -205,8 +206,8 @@ class HandleMessage:
     @transaction.atomic
     def reduction_complete(self, reduction_run, message: Message):
         """
-        Called when the run has completed. Updates the run as complete in the
-        database.
+        Update the run as complete in the database. This is called when the run
+        has completed.
         """
         self._logger.info("Run %s has completed reduction", message.run_number)
         self._common_reduction_run_update(reduction_run, Status.get_completed(), message)
@@ -220,8 +221,8 @@ class HandleMessage:
 
     def reduction_skipped(self, reduction_run, message: Message):
         """
-        Called when there was a reason to skip the run. Updates the run to
-        Skipped status in database. Will NOT attempt re-run.
+        Update the run status to 'Skipped' in the database. This is called when
+        there was a reason to skip the run. Will NOT attempt re-run.
         """
         if message.message is not None:
             self._logger.info("Run %s has been skipped - %s", message.run_number, message.message)
@@ -233,8 +234,8 @@ class HandleMessage:
 
     def reduction_error(self, reduction_run, message: Message):
         """
-        Called when the run encountered an error. Updates the run as complete in
-        the database.
+        Update the run as complete in the database. This is called when the run
+        encounters an error.
         """
         if message.message:
             self._logger.info("Run %s has encountered an error - %s", message.run_number, message.message)
@@ -255,8 +256,8 @@ class HandleMessage:
     @staticmethod
     def get_script_arguments(run_variables):
         """
-        Converts the RunVariables that have been created into Python kwargs
-        which can be passed as the script parameters at runtime.
+        Convert the RunVariables that have been created into kwargs which can be
+        passed as the script parameters at runtime.
         """
         standard_vars, advanced_vars = {}, {}
         for run_variable in run_variables:
@@ -274,8 +275,8 @@ class HandleMessage:
     @staticmethod
     def normalise_rb_number(rb_number) -> int:
         """
-        Enfornce the RB number to always be an int. If an invalid integer value
-        is passed it returns 0 instead.
+        Enforce the RB number to always be an int. If an invalid integer value
+        is passed, return 0.
         """
         try:
             return int(rb_number)

--- a/autoreduce_qp/queue_processor/tests/test_handle_message.py
+++ b/autoreduce_qp/queue_processor/tests/test_handle_message.py
@@ -5,10 +5,8 @@
 # Copyright &copy; 2020 ISIS Rutherford Appleton Laboratory UKRI
 # SPDX - License - Identifier: GPL-3.0-or-later
 # ############################################################################
-"""
-Tests message handling for the queue processor
-"""
-
+"""Tests message handling for the queue processor."""
+# pylint:disable=no-member,unsupported-membership-test
 import random
 from functools import partial
 from unittest import main, mock
@@ -46,7 +44,6 @@ variable_help = {
 """
 
 
-# pylint:disable=no-member
 class FakeMessage:
     started_by = 0
     run_number = 1234567
@@ -55,9 +52,7 @@ class FakeMessage:
 
 
 class TestHandleMessage(TestCase):
-    """
-    Directly tests the message handling classes
-    """
+    """Directly test the message handling classes."""
     fixtures = ["status_fixture"]
 
     def setUp(self):
@@ -92,9 +87,7 @@ class TestHandleMessage(TestCase):
         ["reduction_skipped", 's'],
     ])
     def test_reduction_with_message(self, function_to_call, expected_status):
-        """
-        Tests a reduction error where the message contains an error message
-        """
+        """Test a reduction error where the message contains an error message."""
         self.msg.message = "I am a message"
         getattr(self.handler, function_to_call)(self.reduction_run, self.msg)
 
@@ -111,7 +104,8 @@ class TestHandleMessage(TestCase):
     ])
     def test_reduction_without_message(self, function_to_call, expected_status):
         """
-        Tests a reduction error where the message does not contain an error message
+        Tests a reduction error where the message does not contain an error
+        message.
         """
         getattr(self.handler, function_to_call)(self.reduction_run, self.msg)
 
@@ -121,7 +115,7 @@ class TestHandleMessage(TestCase):
         assert self.mocked_logger.info.call_args[0][1] == self.msg.run_number
 
     def test_reduction_started(self):
-        "Tests starting a reduction"
+        """Tests starting a reduction."""
         assert self.reduction_run.started is None
         assert self.reduction_run.finished is None
 
@@ -134,7 +128,7 @@ class TestHandleMessage(TestCase):
         self.mocked_logger.info.assert_called_once()
 
     def test_reduction_complete(self):
-        "Tests completing a reduction"
+        """Test completing a reduction."""
         self.msg.reduction_data = None
         assert self.reduction_run.finished is None
         self.handler.reduction_complete(self.reduction_run, self.msg)
@@ -148,8 +142,10 @@ class TestHandleMessage(TestCase):
         assert self.reduction_run.reduction_location.count() == 0
 
     def test_reduction_complete_with_reduction_data(self):
-        "Tests completing a reduction that has an output location at reduction_data"
-
+        """
+        Test completing a reduction that has an output location at
+        reduction_data.
+        """
         assert self.reduction_run.finished is None
         self.handler.reduction_complete(self.reduction_run, self.msg)
         self.mocked_logger.info.assert_called_once()
@@ -162,7 +158,7 @@ class TestHandleMessage(TestCase):
 
     @patch("autoreduce_qp.queue_processor.handle_message.ReductionProcessManager")
     def test_do_reduction_success(self, rpm):
-        "Tests do_reduction success path"
+        """Test the success path of do_reduction."""
         rpm.return_value.run = self.do_post_started_assertions
 
         self.handler.do_reduction(self.reduction_run, self.msg)
@@ -173,7 +169,10 @@ class TestHandleMessage(TestCase):
 
     @patch("autoreduce_qp.queue_processor.handle_message.ReductionProcessManager")
     def test_do_reduction_success_special_characters_in_script(self, rpm):
-        "Tests do_reduction success path"
+        """
+        Test the success path of do_reduction with special characters in the
+        script.
+        """
         rpm.return_value.run = self.do_post_started_assertions
         test_special_chars_script = 'print("✈", "’")'
         self.reduction_run.script = test_special_chars_script
@@ -186,7 +185,7 @@ class TestHandleMessage(TestCase):
         assert self.reduction_run.script == test_special_chars_script
 
     def do_post_started_assertions(self, expected_info_calls=1):
-        "Helper to capture common assertions between tests"
+        "Helper method to capture common assertions between tests."
         assert self.reduction_run.status == Status.get_processing()
         assert self.reduction_run.started is not None
         assert self.reduction_run.finished is None
@@ -198,7 +197,7 @@ class TestHandleMessage(TestCase):
     # a bit of a nasty patch, but everything underneath should be unit tested separately
     @patch("autoreduce_qp.queue_processor.handle_message.ReductionProcessManager")
     def test_do_reduction_fail(self, rpm):
-        "Tests do_reduction failure path"
+        "Tests do_reduction failure path."
         self.msg.message = "Something failed"
 
         rpm.return_value.run = self.do_post_started_assertions
@@ -237,23 +236,30 @@ class TestHandleMessage(TestCase):
 
     def test_find_reason_to_skip_run_instrument_paused(self):
         """
-        Test find_reason_to_skip_run correctly captures that the instrument is paused
+        Test find_reason_to_skip_run correctly captures that the instrument is
+        paused.
         """
         self.instrument.is_paused = True
-
         assert "is paused" in self.handler.find_reason_to_skip_run(self.reduction_run, self.msg, self.instrument)
+
+    def test_find_reason_to_skip_run_instrument_inactive(self):
+        """
+        Test that find_reason_to_skip_run returns an error string when an
+        instrument's is_active flag is False.
+        """
+        self.instrument.is_active = False
+        assert "is inactive" in self.handler.find_reason_to_skip_run(self.reduction_run, self.msg, self.instrument)
 
     def test_find_reason_to_skip_run_doesnt_skip_when_all_is_ok(self):
         """
-        Test find_reason_to_skip_run returns None when all the validation passes
+        Test find_reason_to_skip_run returns None when all the validation
+        passes.
         """
         assert self.handler.find_reason_to_skip_run(self.reduction_run, self.msg, self.instrument) is None
 
     @patch("autoreduce_qp.queue_processor.handle_message.ReductionProcessManager")
     def test_send_message_onwards_ok(self, rpm):
-        """
-        Test that a run where all is OK is reduced
-        """
+        """Test that a run where all is OK is reduced."""
         rpm.return_value.run = partial(self.do_post_started_assertions)
 
         self.handler.send_message_onwards(self.reduction_run, self.msg, self.instrument)
@@ -263,9 +269,7 @@ class TestHandleMessage(TestCase):
 
     @patch("autoreduce_qp.queue_processor.handle_message.ReductionProcessManager")
     def test_send_message_onwards_skip_run(self, rpm):
-        """
-        Test that a run that fails validation is skipped
-        """
+        """Test that a run that fails validation is skipped."""
         self.msg.rb_number = 123
 
         self.handler.send_message_onwards(self.reduction_run, self.msg, self.instrument)
@@ -277,7 +281,7 @@ class TestHandleMessage(TestCase):
 
     @patch("autoreduce_qp.queue_processor.handle_message.ReductionScript")
     def test_create_run_records_multiple_versions(self, reduction_script: Mock):
-        "Test creating multiple version of the same run"
+        """Test creating multiple version of the same run."""
         self.instrument.is_active = False
 
         self.msg.description = "Testing multiple versions"
@@ -304,7 +308,7 @@ class TestHandleMessage(TestCase):
             obj.delete()
 
     def test_create_run_variables_no_variables_creates_nothing(self):
-        "Test running a reduction run with an empty reduce_vars.py"
+        "Test running a reduction run with an empty reduce_vars.py."
         expected_args = {'standard_vars': {}, 'advanced_vars': {}}
 
         self.handler.instrument_variable.create_run_variables = mock.Mock(return_value=[])
@@ -317,7 +321,7 @@ class TestHandleMessage(TestCase):
 
     @patch('autoreduce_qp.queue_processor.reduction.service.ReductionScript.load', return_value=FakeModule())
     def test_create_run_variables(self, import_module: Mock):
-        "Test the creation of RunVariables for the ReductionRun"
+        """Test the creation of RunVariables for the ReductionRun."""
         expected_args = {'standard_vars': FakeModule().standard_vars, 'advanced_vars': FakeModule().advanced_vars}
         message = self.handler.create_run_variables(self.reduction_run, self.msg, self.instrument)
         assert self.mocked_logger.info.call_count == 2
@@ -325,7 +329,7 @@ class TestHandleMessage(TestCase):
         import_module.assert_called_once()
 
     def test_data_ready_other_exception_raised_ends_processing(self):
-        "Test an exception being raised inside data_ready handler"
+        """Test an exception being raised inside data_ready handler."""
         self.handler.create_run_records = Mock(side_effect=RuntimeError)
         with self.assertRaises(RuntimeError):
             self.handler.data_ready(self.msg)
@@ -333,7 +337,10 @@ class TestHandleMessage(TestCase):
         self.mocked_logger.error.assert_called_once()
 
     def test_data_ready_variable_integrity_error_marks_reduction_error(self):
-        "Test that an integrity error inside data_ready marks the reduction as errored"
+        """
+        Test that an integrity error inside data_ready marks the reduction as
+        errored.
+        """
         self.handler.create_run_records = Mock(return_value=(self.reduction_run, self.msg, self.instrument))
         self.handler.create_run_variables = Mock(side_effect=IntegrityError)
         with self.assertRaises(IntegrityError):
@@ -356,7 +363,7 @@ class TestHandleMessage(TestCase):
     @patch('autoreduce_qp.queue_processor.reduction.service.ReductionScript.load', return_value=FakeModule())
     @patch("autoreduce_qp.queue_processor.handle_message.ReductionProcessManager")
     def test_data_ready_sends_onwards_completed(self, rpm, load: Mock):
-        "Test data_ready success path sends the message onwards for reduction"
+        """Test data_ready success path sends the message onwards for reduction."""
         rpm.return_value.run = partial(self.do_post_started_assertions, 4)
         self.handler.create_run_records = Mock(return_value=(self.reduction_run, self.msg, self.instrument))
         self.handler.data_ready(self.msg)
@@ -365,10 +372,13 @@ class TestHandleMessage(TestCase):
         assert self.reduction_run.status == Status.get_completed()
         load.assert_called_once()
 
-    @patch('autoreduce_qp.queue_processor.reduction.service.ReductionScript.load', return_value=FakeModule())
+    @patch("autoreduce_qp.queue_processor.reduction.service.ReductionScript.load", return_value=FakeModule())
     @patch("autoreduce_qp.queue_processor.handle_message.ReductionProcessManager")
     def test_data_ready_sends_onwards_error(self, rpm, load: Mock):
-        "Test data_ready error path sends the message onwards to be marked as errored"
+        """
+        Test data_ready error path sends the message onwards to be marked as
+        errored.
+        """
         self.msg.message = "I am error"
         rpm.return_value.run = partial(self.do_post_started_assertions, 4)
         self.handler.create_run_records = Mock(return_value=(self.reduction_run, self.msg, self.instrument))
@@ -380,29 +390,17 @@ class TestHandleMessage(TestCase):
         load.assert_called_once()
 
     def test_create_run_records_invalid_rb_number(self):
-        """
-        Test creating a run record when the rb number is invalid.
-        """
+        """Test creating a run record when the rb number is invalid."""
         with DefaultDataArchive(self.instrument_name):
             self.msg.rb_number = "INVALID RB NUMBER CALIBRATION RUN PERHAPS"
             reduction_run, _, _ = self.handler.create_run_records(self.msg)
             assert reduction_run.experiment.reference_number == 0
 
     def test_create_run_records_valid_rb_number(self):
-        """
-        Test creating a run record when the rb number is invalid.
-        """
+        """Test creating a run record when the rb number is invalid."""
         with DefaultDataArchive(self.instrument_name):
             reduction_run, _, _ = self.handler.create_run_records(self.msg)
             assert reduction_run.experiment.reference_number == self.msg.rb_number
-
-    def test_find_reason_to_skip_run_instrument_inactive(self):
-        """
-        Test find_reason_to_skip_run returns an error string when is_active is
-        False.
-        """
-        self.instrument.is_active = False
-        assert "is inactive" in self.handler.find_reason_to_skip_run(self.reduction_run, self.msg, self.instrument)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
### Summary of work
Add an if block to the `find_reason_to_skip_run()` function that returns an error string if the instrument is active.

### How to test your work
Pytest `autoreduce_qp/queue_processor/tests/test_handle_message.py` and see if all tests pass.

Fixes AR-1447