### PR TITLE
753 time discrepancy on runs ar 753

### DIFF
--- a/autoreduce_qp/autoreduce_django/settings.py
+++ b/autoreduce_qp/autoreduce_django/settings.py
@@ -53,7 +53,7 @@ AUTH_PASSWORD_VALIDATORS = []
 
 LANGUAGE_CODE = 'en-us'
 
-TIME_ZONE = 'UTC'
+TIME_ZONE = 'Europe/London'
 
 USE_I18N = True
 

--- a/autoreduce_qp/queue_processor/handle_message.py
+++ b/autoreduce_qp/queue_processor/handle_message.py
@@ -43,9 +43,9 @@ class HandleMessage:
         destination queue was data_ready.
 
         No processing occurs when:
-        - rb number isn't a 7 digit integer.
-        - instrument is paused.
-        - there is no reduce.py.
+        - RB number isn't a 7 digit integer.
+        - Instrument is paused.
+        - There is no reduce.py.
         """
         self._logger.info("Data ready for processing run %s on %s", message.run_number, message.instrument)
 
@@ -107,8 +107,8 @@ class HandleMessage:
 
         # Create a new data location entry which has a foreign key linking it to
         # the current reduction run. The file path itself will point to a
-        # datafile. E.g:
-        # "/isis/inst$/NDXWISH/Instrument/data/cycle_17_1/WISH00038774.nxs")
+        # datafile e.g.
+        # "/isis/inst$/NDXWISH/Instrument/data/cycle_17_1/WISH00038774.nxs"
         data_location = DataLocation(file_path=message.data, reduction_run_id=reduction_run.pk)
         data_location.save()
 


### PR DESCRIPTION
### Summary of work
Use the 'Europe/London' time zone for the queue processor instead of 'UTC' so that run dates during British Summer Time are properly displayed.

### How to test your work
1. Run the web app.
2. Navigate to http://127.0.0.1:8000/runs/LARMOR/
3. Click the most recent run.
4. The run start time should be 1:39pm instead of 12:39pm.

Fixes AR-753