### PR TITLE
Fixes how the most relevant batch run is found

### DIFF
--- a/autoreduce_qp/autoreduce_django/fixtures/run_with_multiple_variables.json
+++ b/autoreduce_qp/autoreduce_django/fixtures/run_with_multiple_variables.json
@@ -20,7 +20,7 @@
         "model": "reduction_viewer.reductionrun",
         "pk": 1,
         "fields": {
-            "status_id": 2,
+            "status_id": 5,
             "run_version": 0,
             "run_description": "This is the test run_description",
             "last_updated": "2020-10-19 17:35:04+00:00",


### PR DESCRIPTION
### Summary of work
Fixes how the most relevant batch run is found, in order to have the correct version number. It now matches all run numbers. If any run number is mismatching then this is a new batch run.

### How to test your work
1. Run all the things, the order is not important: `Run queue listener`, `Run webapp`, `Run REST API`. All 3 must be running as submitting a runs uses all 3
2. Go to http://127.0.0.1:8000/tokens/ and generate a new token for the `(super)` user
3. Go to INTER and click Submit Batch Run button
4. Submit run for 63125-63130, change some of the description/params just to test that they get changed
	- You'll need to create reduce.py/reduce_vars.py first! Full instructions here https://github.com/ISISScientificComputing/autoreduce/wiki/Start-here-(getting-the-code---installation)#are-you-going-to-be-submitting-runs--reruns, but here's them adapted for INTER

```
mkdir -p ~/.autoreduce/dev/data-archive/NDXINTER/user/scripts/autoreduction
echo 'standard_vars = {"variable1":"value1"}' > ~/.autoreduce/dev/data-archive/NDXINTER/user/scripts/autoreduction/reduce_vars.py
echo 'def main(input_file, output_dir): print("Hello")' > ~/.autoreduce/dev/data-archive/NDXINTER/user/scripts/autoreduction/reduce.py
```
5. Follow the link to find the filtered run. If not showing up check the queue processor terminal for errors